### PR TITLE
fix: resolve circular references in Tailwind v4 @theme configuration

### DIFF
--- a/quotevote-frontend/src/app/globals.css
+++ b/quotevote-frontend/src/app/globals.css
@@ -43,39 +43,45 @@
   --foreground: var(--color-text-primary);
 }
 
-/* Tailwind v4 requires @theme inline to expose CSS variables as Tailwind utilities */
+/* Tailwind v4 @theme inline block exposes CSS variables as Tailwind utilities */
+/* Colors defined here reference the :root variables above */
 @theme inline {
   /* Background Colors */
-  --color-background: var(--color-background);
-  --color-foreground: var(--color-text-primary);
-  --color-white: var(--color-white);
-  --color-background-off-white: var(--color-background-off-white);
+  --color-background: #EEF4F9;
+  --color-foreground: #000000;
+  --color-white: #ffffff;
+  --color-background-off-white: #FAFAFA;
   
   /* Primary Brand Colors */
-  --color-primary: var(--color-primary);
-  --color-primary-contrast: var(--color-primary-contrast);
-  --color-secondary: var(--color-secondary);
-  --color-secondary-contrast: var(--color-secondary-contrast);
+  --color-primary: #52b274;
+  --color-primary-contrast: #ffffff;
+  --color-secondary: #E91E63;
+  --color-secondary-contrast: #ffffff;
   
   /* Text Colors */
-  --color-text-primary: var(--color-text-primary);
-  --color-text-secondary: var(--color-text-secondary);
-  --color-text-muted: var(--color-text-muted);
-  --color-text-light: var(--color-text-light);
+  --color-text-primary: #000000;
+  --color-text-secondary: #424556;
+  --color-text-muted: #454545;
+  --color-text-light: #999999;
   
   /* Activity Colors */
-  --color-quoted: var(--color-quoted);
-  --color-commented: var(--color-commented);
-  --color-upvote: var(--color-upvote);
-  --color-downvote: var(--color-downvote);
-  --color-hearted: var(--color-hearted);
-  --color-trending: var(--color-trending);
+  --color-quoted: #E36DFA;
+  --color-commented: #FDD835;
+  --color-upvote: #52b274;
+  --color-downvote: #FF6060;
+  --color-hearted: #F16C99;
+  --color-trending: #00BCD4;
   
   /* Status Colors */
-  --color-success: var(--color-success);
-  --color-warning: var(--color-warning);
-  --color-danger: var(--color-danger);
-  --color-info: var(--color-info);
+  --color-success: #55B559;
+  --color-warning: #FF9E0F;
+  --color-danger: #F55145;
+  --color-info: #00CAE3;
+  
+  /* Additional Colors */
+  --color-gray-inactive: #D8D8D8;
+  --color-gray-light: #E5E5E5;
+  --color-black-card: #2D2A2A;
   
   /* Fonts */
   --font-sans: var(--font-geist-sans);


### PR DESCRIPTION
- Replace self-referencing CSS variables in @theme inline block with actual color values
- Fixes Tailwind v4 theme configuration to properly expose colors as utilities
- Maintains color consistency between :root variables and @theme definitions
- Verified build completes successfully with updated configuration

Closes #3 