### PR TITLE
feat: migrate LoadingSpinner component to Next.js/TypeScript

### DIFF
--- a/quotevote-frontend/src/__tests__/components/LoadingSpinner.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/LoadingSpinner.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * LoadingSpinner Component Tests
+ * 
+ * Tests that verify:
+ * - Component renders correctly with default props
+ * - Component renders correctly with custom props
+ * - Component applies correct styling
+ * - Component is accessible
+ * - Component handles edge cases
+ */
+
+import { render, screen } from '../utils/test-utils'
+import { LoadingSpinner } from '@/components/LoadingSpinner'
+
+describe('LoadingSpinner Component', () => {
+  describe('Rendering', () => {
+    it('renders without crashing with default props', () => {
+      const { container } = render(<LoadingSpinner />)
+
+      expect(container).toBeInTheDocument()
+      const spinner = container.querySelector('[role="status"]')
+      expect(spinner).toBeInTheDocument()
+    })
+
+    it('renders with custom size', () => {
+      const { container } = render(<LoadingSpinner size={100} />)
+
+      const spinner = container.querySelector('[role="status"]') as HTMLElement
+      expect(spinner).toBeInTheDocument()
+      expect(spinner).toHaveStyle({ width: '100px', height: '100px' })
+    })
+
+    it('renders with custom marginTop', () => {
+      const { container } = render(<LoadingSpinner marginTop="50px" />)
+
+      const wrapper = container.firstChild as HTMLElement
+      expect(wrapper).toBeInTheDocument()
+      expect(wrapper).toHaveStyle({ marginTop: '50px' })
+    })
+
+    it('renders with both custom size and marginTop', () => {
+      const { container } = render(
+        <LoadingSpinner size={120} marginTop="30px" />
+      )
+
+      const wrapper = container.firstChild as HTMLElement
+      const spinner = container.querySelector('[role="status"]') as HTMLElement
+
+      expect(wrapper).toHaveStyle({ marginTop: '30px' })
+      expect(spinner).toHaveStyle({ width: '120px', height: '120px' })
+    })
+  })
+
+  describe('Styling', () => {
+    it('applies correct container classes', () => {
+      const { container } = render(<LoadingSpinner />)
+
+      const wrapper = container.firstChild as HTMLElement
+      expect(wrapper).toHaveClass('flex', 'items-center', 'justify-center', 'w-full')
+    })
+
+    it('applies correct spinner classes', () => {
+      const { container } = render(<LoadingSpinner />)
+
+      const spinner = container.querySelector('[role="status"]') as HTMLElement
+      expect(spinner).toHaveClass('animate-spin', 'rounded-full', 'border-4', 'border-solid')
+    })
+
+    it('applies default size of 80px', () => {
+      const { container } = render(<LoadingSpinner />)
+
+      const spinner = container.querySelector('[role="status"]') as HTMLElement
+      expect(spinner).toHaveStyle({ width: '80px', height: '80px' })
+    })
+
+    it('applies default marginTop of 15px', () => {
+      const { container } = render(<LoadingSpinner />)
+
+      const wrapper = container.firstChild as HTMLElement
+      expect(wrapper).toHaveStyle({ marginTop: '15px' })
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has role="status" for screen readers', () => {
+      const { container } = render(<LoadingSpinner />)
+
+      const spinner = container.querySelector('[role="status"]')
+      expect(spinner).toBeInTheDocument()
+    })
+
+    it('has aria-label for screen readers', () => {
+      const { container } = render(<LoadingSpinner />)
+
+      const spinner = container.querySelector('[role="status"]')
+      expect(spinner).toHaveAttribute('aria-label', 'Loading')
+    })
+
+    it('has sr-only text for screen readers', () => {
+      render(<LoadingSpinner />)
+
+      const srText = screen.getByText('Loading...')
+      expect(srText).toBeInTheDocument()
+      expect(srText).toHaveClass('sr-only')
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('handles size of 0', () => {
+      const { container } = render(<LoadingSpinner size={0} />)
+
+      const spinner = container.querySelector('[role="status"]') as HTMLElement
+      expect(spinner).toHaveStyle({ width: '0px', height: '0px' })
+    })
+
+    it('handles very large size', () => {
+      const { container } = render(<LoadingSpinner size={500} />)
+
+      const spinner = container.querySelector('[role="status"]') as HTMLElement
+      expect(spinner).toHaveStyle({ width: '500px', height: '500px' })
+    })
+
+    it('handles empty marginTop string', () => {
+      const { container } = render(<LoadingSpinner marginTop="" />)
+
+      const wrapper = container.firstChild as HTMLElement
+      expect(wrapper).toHaveStyle({ marginTop: '' })
+    })
+
+    it('handles zero marginTop', () => {
+      const { container } = render(<LoadingSpinner marginTop="0" />)
+
+      const wrapper = container.firstChild as HTMLElement
+      expect(wrapper).toHaveStyle({ marginTop: '0' })
+    })
+  })
+
+  describe('Component Structure', () => {
+    it('has correct DOM structure', () => {
+      const { container } = render(<LoadingSpinner />)
+
+      const wrapper = container.firstChild as HTMLElement
+      const spinner = wrapper.querySelector('[role="status"]')
+      const srText = wrapper.querySelector('.sr-only')
+
+      expect(wrapper).toBeInTheDocument()
+      expect(spinner).toBeInTheDocument()
+      expect(srText).toBeInTheDocument()
+    })
+
+    it('does not throw hydration warnings', () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      render(<LoadingSpinner />)
+
+      expect(consoleError).not.toHaveBeenCalledWith(
+        expect.stringContaining('hydration'),
+        expect.anything()
+      )
+
+      consoleError.mockRestore()
+    })
+  })
+})
+

--- a/quotevote-frontend/src/components/LoadingSpinner.tsx
+++ b/quotevote-frontend/src/components/LoadingSpinner.tsx
@@ -1,0 +1,36 @@
+import type { LoadingSpinnerProps } from '@/types/components'
+import { cn } from '@/lib/utils'
+
+/**
+ * LoadingSpinner Component
+ * 
+ * A centered loading spinner with customizable size and margin.
+ * Uses Tailwind CSS for styling with a custom animated spinner.
+ * 
+ * @param size - Size of the spinner in pixels (default: 80)
+ * @param marginTop - Top margin for the spinner container (default: '15px')
+ */
+export function LoadingSpinner({ size = 80, marginTop = '15px' }: LoadingSpinnerProps) {
+  return (
+    <div 
+      className="flex items-center justify-center w-full"
+      style={{ marginTop }}
+    >
+      <div
+        className={cn(
+          'animate-spin rounded-full border-4 border-solid',
+          'border-[var(--color-primary)] border-t-transparent'
+        )}
+        style={{
+          width: `${size}px`,
+          height: `${size}px`,
+        }}
+        role="status"
+        aria-label="Loading"
+      >
+        <span className="sr-only">Loading...</span>
+      </div>
+    </div>
+  )
+}
+

--- a/quotevote-frontend/src/types/components.ts
+++ b/quotevote-frontend/src/types/components.ts
@@ -1,0 +1,21 @@
+/**
+ * TypeScript interfaces for React components
+ * These types define the structure of component props
+ */
+
+/**
+ * Props for the LoadingSpinner component
+ */
+export interface LoadingSpinnerProps {
+  /**
+   * Size of the spinner in pixels
+   * @default 80
+   */
+  size?: number;
+  /**
+   * Top margin for the spinner container
+   * @default '15px'
+   */
+  marginTop?: string;
+}
+

--- a/quotevote-frontend/tsconfig.json
+++ b/quotevote-frontend/tsconfig.json
@@ -34,6 +34,7 @@
       "@/*": ["./src/*"],
       "@/components/ui/*": ["./src/components/ui/*"],
       "@/components/ErrorBoundary": ["./src/components/ErrorBoundary"],
+      "@/components/LoadingSpinner": ["./src/components/LoadingSpinner"],
       "@/components/*": ["./src/app/components/*"],
       "@/hooks/*": ["./src/hooks/*"],
       "@/store/*": ["./src/store/*"],


### PR DESCRIPTION
## Description
Migrate LoadingSpinner component from React 17/Vite to Next.js 16/TypeScript, replacing Material-UI CircularProgress with a custom Tailwind CSS animated spinner.

## Issue Reference
Closes #17

## Changes Made
- Created `LoadingSpinner.tsx` component with TypeScript
- Replaced MUI CircularProgress with Tailwind CSS animated spinner
- Added `LoadingSpinnerProps` interface to `src/types/components.ts`
- Added comprehensive test suite (17 tests) in `src/__tests__/components/`
- Updated `tsconfig.json` with path alias for LoadingSpinner

## Testing
- [x] Unit tests added/updated (17 new tests)
- [x] All existing tests pass (104 total)
- [x] Manual testing completed
- [x] TypeScript compilation passes
- [x] Linting passes

## Type Safety
- [x] No `any` types used
- [x] All types properly defined in `src/types/components.ts`
- [x] TypeScript compiles without errors

## Migration Details
- **From**: MUI CircularProgress (React 17)
- **To**: Custom Tailwind CSS spinner (Next.js 16/React 19)
- **Location**: `src/components/LoadingSpinner.tsx`
- **Types**: `src/types/components.ts`
- **Tests**: `src/__tests__/components/LoadingSpinner.test.tsx`

## Accessibility
- Added `role="status"` and `aria-label="Loading"`
- Included screen reader text with `sr-only` class