### PR TITLE
Docs/read me file add zeplin

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ quotevote-next/
 
 ## 🎨 Design Resources
 
-- **[UI Design Inspiration (Figma)](https://www.figma.com/design/b4zMmypvTj7R9HgcWUwGHM/Quote.Vote-User-Interface-Design)** - Design inspiration and UI patterns
-- **[UI Design Specifications (Zeplin)](https://zpl.io/VDlzXPg)** - Detailed design specifications and measurements
+- **[UI Design Inspiration (Figma)](https://www.figma.com/design/b4zMmypvTj7R9HgcWUwGHM/Quote.Vote-User-Interface-Design)**
+- **[UI Design Specifications (Zeplin)](https://zpl.io/VDlzXPg)**
 
 ## 📋 Prerequisites
 

--- a/quotevote-frontend/README.md
+++ b/quotevote-frontend/README.md
@@ -16,6 +16,11 @@ A modern, type-safe frontend application built with Next.js 16, React 19, and Ty
 - **Form Handling**: [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/)
 - **Package Manager**: [pnpm](https://pnpm.io/)
 
+## 🎨 Design Resources
+
+- **[Quote.Vote UI Design (Figma)](https://www.figma.com/design/b4zMmypvTj7R9HgcWUwGHM/Quote.Vote-User-Interface-Design)**
+- **[UI Design Specifications (Zeplin)](https://zpl.io/VDlzXPg)**
+
 ## 📋 Prerequisites
 
 - **Node.js**: 20.x or higher
@@ -185,8 +190,8 @@ pnpm format:check
 
 The UI design is a work in progress and serves as a source of inspiration for the implementation:
 
-- **[Quote.Vote UI Design (Figma)](https://www.figma.com/design/b4zMmypvTj7R9HgcWUwGHM/Quote.Vote-User-Interface-Design)** - Design inspiration and UI patterns (work in progress)
-- **[UI Design Specifications (Zeplin)](https://zpl.io/VDlzXPg)** - Detailed design specifications and measurements
+- **[Quote.Vote UI Design (Figma)](https://www.figma.com/design/b4zMmypvTj7R9HgcWUwGHM/Quote.Vote-User-Interface-Design)**
+- **[UI Design Specifications (Zeplin)](https://zpl.io/VDlzXPg)**
 
 **Note**: The Figma design is not fully completed. Use it as a reference and inspiration for:
 - Color schemes and theming direction


### PR DESCRIPTION
## Add Zeplin Design Resources and Improve Design Section Visibility
### Summary
Adds Zeplin design specifications link and moves the Design Resources section higher in the READMEs for better visibility.
### Changes
- Added Zeplin link (https://zpl.io/VDlzXPg) to design resources in:
    - Root README (quotevote-next/README.md)
    - Frontend README (quotevote-frontend/README.md)
- Moved Design Resources section to the top (right after Tech Stack) in:
- Root README — moved from near the bottom to after Tech Stack
- Frontend README — added new section after Tech Stack
## Benefits
- Developers can find design resources faster
- Both Figma and Zeplin links are easily accessible
- Consistent placement across READMEs
### Files Changed
- quotevote-next/README.md
- quotevote-next/quotevote-frontend/README.md
