### PR TITLE
refactor: simplify environment variables to use only GraphQL endpoint

### DIFF
--- a/quotevote-frontend/.env.local
+++ b/quotevote-frontend/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_GRAPHQL_ENDPOINT=http://localhost:4000/graphql

--- a/quotevote-frontend/.gitignore
+++ b/quotevote-frontend/.gitignore
@@ -31,7 +31,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
 
 # vercel
 .vercel

--- a/quotevote-frontend/README.md
+++ b/quotevote-frontend/README.md
@@ -58,13 +58,14 @@ The application will be available at [http://localhost:3000](http://localhost:30
 
 ### Environment Variables
 
-Create a `.env.local` file in the root directory with the following variables:
+Create a `.env.local` file in the root directory with the following variable:
 
 ```env
-# Client-side variables (must be prefixed with NEXT_PUBLIC_)
-NEXT_PUBLIC_API_URL=http://localhost:4000
-NEXT_PUBLIC_GRAPHQL_URL=http://localhost:4000
+# GraphQL endpoint URL (must be prefixed with NEXT_PUBLIC_)
+NEXT_PUBLIC_GRAPHQL_ENDPOINT=http://localhost:4000/graphql
 ```
+
+The server URL is automatically derived from the GraphQL endpoint by removing the `/graphql` suffix.
 
 ## 🎯 Path Aliases
 

--- a/quotevote-frontend/src/config/env.ts
+++ b/quotevote-frontend/src/config/env.ts
@@ -64,9 +64,17 @@ export const env = {
   
   /**
    * Base server URL
-   * Required environment variable: NEXT_PUBLIC_SERVER_URL
+   * Derived from GraphQL endpoint or from NEXT_PUBLIC_SERVER_URL
    */
   get serverUrl(): string {
+    // If GraphQL endpoint is set, derive server URL from it
+    const graphqlEndpoint = getOptionalEnvVar('NEXT_PUBLIC_GRAPHQL_ENDPOINT');
+    if (graphqlEndpoint) {
+      // Remove /graphql suffix if present
+      return graphqlEndpoint.replace(/\/graphql\/?$/, '');
+    }
+    
+    // Fallback to explicit server URL
     return getEnvVar('NEXT_PUBLIC_SERVER_URL');
   },
   


### PR DESCRIPTION
## Summary
- Remove redundant NEXT_PUBLIC_API_URL and NEXT_PUBLIC_GRAPHQL_URL variables
- Update env.ts to derive serverUrl from GraphQL endpoint automatically
- Simplify .env.local to only require NEXT_PUBLIC_GRAPHQL_ENDPOINT
- Update README.md documentation to reflect simplified setup

This reduces configuration complexity by requiring only the GraphQL endpoint URL, from which the server URL is automatically derived.