### PR TITLE
feat: migrate Quotes components to Next.js with shadcn/ui

### DIFF
--- a/quotevote-frontend/src/app/test/quotes/page.tsx
+++ b/quotevote-frontend/src/app/test/quotes/page.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { LatestQuotes } from '@/components/Quotes'
+
+export default function QuotesTestPage() {
+  return (
+    <div className="container mx-auto p-8">
+      <div className="max-w-4xl mx-auto space-y-8">
+        <div className="space-y-4">
+          <h1 className="text-3xl font-bold">Quotes Component Test</h1>
+          <p className="text-muted-foreground">
+            Test the LatestQuotes component with different formats and states.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <h2 className="text-2xl font-semibold">Test Instructions</h2>
+          <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
+            <li>Verify quotes are fetched and displayed correctly</li>
+            <li>Check that new quotes appear at the top (polling every 3 seconds)</li>
+            <li>Verify username and quote text are displayed properly</li>
+            <li>Test with different limit values</li>
+            <li>Check layout, spacing, and styling</li>
+            <li>Verify component handles empty state gracefully</li>
+            <li>Test responsive design on different screen sizes</li>
+          </ol>
+        </div>
+
+        <div className="space-y-8">
+          <div className="space-y-4">
+            <h3 className="text-xl font-semibold">Default Limit (5 quotes)</h3>
+            <LatestQuotes />
+          </div>
+
+          <div className="space-y-4">
+            <h3 className="text-xl font-semibold">Custom Limit (10 quotes)</h3>
+            <LatestQuotes limit={10} />
+          </div>
+
+          <div className="space-y-4">
+            <h3 className="text-xl font-semibold">Small Limit (3 quotes)</h3>
+            <LatestQuotes limit={3} />
+          </div>
+        </div>
+
+        <div className="space-y-4 p-4 border rounded-lg bg-muted/50">
+          <h3 className="text-xl font-semibold">Component Features</h3>
+          <ul className="list-disc list-inside space-y-2 text-sm text-muted-foreground">
+            <li>Real-time quote updates via GraphQL polling (3s interval)</li>
+            <li>Automatic deduplication of quotes</li>
+            <li>shadcn/ui Card component for consistent styling</li>
+            <li>Tailwind CSS for responsive layout</li>
+            <li>TypeScript type safety</li>
+            <li>Configurable quote limit</li>
+            <li>Clean, readable quote display format</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/quotevote-frontend/src/components/Quotes/LatestQuotes.tsx
+++ b/quotevote-frontend/src/components/Quotes/LatestQuotes.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect, useState, startTransition } from 'react'
+import { useQuery } from '@apollo/client/react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { GET_LATEST_QUOTES } from '@/graphql/queries'
+import type { LatestQuotesProps, Quote } from '@/types/components'
+
+export function LatestQuotes({ limit = 5 }: LatestQuotesProps) {
+  const [quotes, setQuotes] = useState<Quote[]>([])
+  const { data } = useQuery(GET_LATEST_QUOTES, {
+    variables: { limit },
+    pollInterval: 3000,
+    fetchPolicy: 'network-only',
+  })
+
+  useEffect(() => {
+    if (data && (data as { latestQuotes?: Quote[] }).latestQuotes) {
+      const latestQuotes = (data as { latestQuotes: Quote[] }).latestQuotes
+      startTransition(() => {
+        setQuotes((prev) => {
+          const existingIds = prev.map((q) => q._id)
+          const fresh = latestQuotes.filter(
+            (q: Quote) => !existingIds.includes(q._id)
+          )
+          return [...fresh, ...prev]
+        })
+      })
+    }
+  }, [data])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Latest Quotes</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-4">
+          {quotes.map((q) => (
+            <li key={q._id} className="block">
+              <p className="text-sm">
+                <strong>{q.user?.username}</strong>: {q.quote}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/quotevote-frontend/src/components/Quotes/index.ts
+++ b/quotevote-frontend/src/components/Quotes/index.ts
@@ -1,0 +1,2 @@
+export { LatestQuotes } from './LatestQuotes'
+

--- a/quotevote-frontend/src/graphql/queries.ts
+++ b/quotevote-frontend/src/graphql/queries.ts
@@ -79,3 +79,21 @@ export const GROUPS_QUERY = gql`
     }
   }
 `
+
+/**
+ * Get latest quotes query
+ */
+export const GET_LATEST_QUOTES = gql`
+  query latestQuotes($limit: Int!) {
+    latestQuotes(limit: $limit) {
+      _id
+      quote
+      created
+      user {
+        _id
+        username
+        contributorBadge
+      }
+    }
+  }
+`

--- a/quotevote-frontend/src/types/components.ts
+++ b/quotevote-frontend/src/types/components.ts
@@ -696,3 +696,25 @@ export interface SubmitPostFormValues {
   group: Group | { title: string } | string;
 }
 
+// Quotes Component Types
+export interface QuoteUser {
+  _id: string;
+  username: string;
+  contributorBadge?: string;
+}
+
+export interface Quote {
+  _id: string;
+  quote: string;
+  created: string;
+  user?: QuoteUser;
+}
+
+export interface LatestQuotesProps {
+  /**
+   * Maximum number of quotes to fetch
+   * @default 5
+   */
+  limit?: number;
+}
+

--- a/quotevote-frontend/tsconfig.json
+++ b/quotevote-frontend/tsconfig.json
@@ -80,6 +80,12 @@
       "@/components/SubmitPost/*": [
         "./src/components/SubmitPost/*"
       ],
+      "@/components/Quotes": [
+        "./src/components/Quotes"
+      ],
+      "@/components/Quotes/*": [
+        "./src/components/Quotes/*"
+      ],
       "@/components/*": [
         "./src/app/components/*"
       ],


### PR DESCRIPTION
## Migrate Quotes components from client to quotevote-frontend

- Migrate LatestQuotes component from client/src/components/Quotes/
- Convert JSX to TypeScript (LatestQuotes.jsx → LatestQuotes.tsx)
- Replace Material-UI components with shadcn/ui (Paper → Card, Typography → native HTML)
- Apply Tailwind CSS styling consistent with v2 design system
- Add GET_LATEST_QUOTES GraphQL query to src/graphql/queries.ts
- Add TypeScript types (Quote, QuoteUser, LatestQuotesProps) to src/types/components.ts
- Create test page at app/test/quotes/page.tsx with multiple display scenarios
- Add path mappings for @/components/Quotes in tsconfig.json
- Fix React Compiler lint error by wrapping state updates in startTransition
- Maintain real-time quote updates with 3-second polling interval
- Preserve quote accumulation logic (deduplication and prepending new quotes)

All quote components now use shadcn/ui and Tailwind, with complete TypeScript
typing and no Material-UI dependencies. Component passes TypeScript compilation,
linting, and Next.js build verification.

Closes #38 