### PR TITLE
feat: migrate post GraphQL operations to Next.js frontend

### DIFF
--- a/quotevote-frontend/package.json
+++ b/quotevote-frontend/package.json
@@ -36,6 +36,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "graphql": "^16.12.0",
+    "graphql-ws": "^6.0.6",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
     "lucide-react": "^0.554.0",

--- a/quotevote-frontend/pnpm-lock.yaml
+++ b/quotevote-frontend/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: ^4.0.9
-        version: 4.0.9(graphql@16.12.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2)
+        version: 4.0.9(graphql-ws@6.0.6(graphql@16.12.0)(ws@8.18.3))(graphql@16.12.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2)
       '@emoji-mart/data':
         specifier: ^1.2.1
         version: 1.2.1
@@ -65,6 +65,9 @@ importers:
       graphql:
         specifier: ^16.12.0
         version: 16.12.0
+      graphql-ws:
+        specifier: ^6.0.6
+        version: 6.0.6(graphql@16.12.0)(ws@8.18.3)
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
@@ -2374,6 +2377,25 @@ packages:
     peerDependencies:
       graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
+  graphql-ws@6.0.6:
+    resolution: {integrity: sha512-zgfER9s+ftkGKUZgc0xbx8T7/HMO4AV5/YuYiFc+AtgcO5T0v8AxYYNQ+ltzuzDZgNkYJaFspm5MMYLjQzrkmw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@fastify/websocket': ^10 || ^11
+      crossws: ~0.3
+      graphql: ^15.10.1 || ^16
+      uWebSockets.js: ^20
+      ws: ^8
+    peerDependenciesMeta:
+      '@fastify/websocket':
+        optional: true
+      crossws:
+        optional: true
+      uWebSockets.js:
+        optional: true
+      ws:
+        optional: true
+
   graphql@16.12.0:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
@@ -3883,7 +3905,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@apollo/client@4.0.9(graphql@16.12.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2)':
+  '@apollo/client@4.0.9(graphql-ws@6.0.6(graphql@16.12.0)(ws@8.18.3))(graphql@16.12.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
       '@wry/caches': 1.0.1
@@ -3895,6 +3917,7 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
     optionalDependencies:
+      graphql-ws: 6.0.6(graphql@16.12.0)(ws@8.18.3)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -6303,6 +6326,12 @@ snapshots:
     dependencies:
       graphql: 16.12.0
       tslib: 2.8.1
+
+  graphql-ws@6.0.6(graphql@16.12.0)(ws@8.18.3):
+    dependencies:
+      graphql: 16.12.0
+    optionalDependencies:
+      ws: 8.18.3
 
   graphql@16.12.0: {}
 

--- a/quotevote-frontend/src/__tests__/graphql/apollo-subscriptions.test.ts
+++ b/quotevote-frontend/src/__tests__/graphql/apollo-subscriptions.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Apollo Client WebSocket Subscriptions Tests
+ * 
+ * Tests that verify:
+ * - Apollo Client is configured with WebSocket support
+ * - Split link correctly routes subscriptions to WebSocket
+ * - Subscriptions can be initialized (structure validation)
+ * - WebSocket link is only created on client side
+ */
+
+import { getApolloClient } from '@/lib/apollo/apollo-client'
+import { getMainDefinition } from '@apollo/client/utilities'
+import { NEW_NOTIFICATION_SUBSCRIPTION, NEW_MESSAGE_SUBSCRIPTION } from '@/graphql/subscriptions'
+
+describe('Apollo Client WebSocket Subscriptions', () => {
+  describe('Client Configuration', () => {
+    it('creates Apollo Client with subscription support', () => {
+      const client = getApolloClient()
+      
+      expect(client).toBeDefined()
+      expect(client.link).toBeDefined()
+    })
+
+    it('handles client-side WebSocket link creation', () => {
+      // On client side (window is defined in test environment)
+      const client = getApolloClient()
+      
+      // Client should be created successfully
+      expect(client).toBeDefined()
+      // The link should be configured (may be split link or HTTP link)
+      expect(client.link).toBeDefined()
+    })
+
+    it('handles server-side without WebSocket link', () => {
+      // Save original window
+      const originalWindow = global.window
+      
+      // Simulate server-side (no window)
+      // @ts-expect-error - Testing SSR mode
+      delete global.window
+      
+      // Should not throw when creating client on server
+      expect(() => {
+        getApolloClient()
+      }).not.toThrow()
+      
+      // Restore window
+      global.window = originalWindow
+    })
+  })
+
+  describe('Subscription Query Detection', () => {
+    it('correctly identifies subscription operations', () => {
+      const notificationDef = getMainDefinition(NEW_NOTIFICATION_SUBSCRIPTION)
+      const messageDef = getMainDefinition(NEW_MESSAGE_SUBSCRIPTION)
+      
+      expect(notificationDef.kind).toBe('OperationDefinition')
+      if ('operation' in notificationDef) {
+        expect(notificationDef.operation).toBe('subscription')
+      }
+      
+      expect(messageDef.kind).toBe('OperationDefinition')
+      if ('operation' in messageDef) {
+        expect(messageDef.operation).toBe('subscription')
+      }
+    })
+
+    it('subscriptions have correct structure', () => {
+      const notificationDef = getMainDefinition(NEW_NOTIFICATION_SUBSCRIPTION)
+      const messageDef = getMainDefinition(NEW_MESSAGE_SUBSCRIPTION)
+      
+      expect(notificationDef).toBeDefined()
+      expect(messageDef).toBeDefined()
+      
+      // Both should be operation definitions
+      expect(notificationDef.kind).toBe('OperationDefinition')
+      expect(messageDef.kind).toBe('OperationDefinition')
+    })
+  })
+
+  describe('Subscription Definitions', () => {
+    describe('NEW_NOTIFICATION_SUBSCRIPTION', () => {
+      it('is properly defined as a subscription', () => {
+        expect(NEW_NOTIFICATION_SUBSCRIPTION).toBeDefined()
+        expect(NEW_NOTIFICATION_SUBSCRIPTION.definitions).toBeDefined()
+        expect(NEW_NOTIFICATION_SUBSCRIPTION.definitions.length).toBeGreaterThan(0)
+      })
+
+      it('has correct subscription structure', () => {
+        const subscriptionString = NEW_NOTIFICATION_SUBSCRIPTION.loc?.source.body || ''
+        expect(subscriptionString).toContain('subscription notification')
+        expect(subscriptionString).toContain('$userId: String!')
+      })
+
+      it('includes required notification fields', () => {
+        const subscriptionString = NEW_NOTIFICATION_SUBSCRIPTION.loc?.source.body || ''
+        expect(subscriptionString).toContain('_id')
+        expect(subscriptionString).toContain('userId')
+        expect(subscriptionString).toContain('notificationType')
+        expect(subscriptionString).toContain('post')
+      })
+    })
+
+    describe('NEW_MESSAGE_SUBSCRIPTION', () => {
+      it('is properly defined as a subscription', () => {
+        expect(NEW_MESSAGE_SUBSCRIPTION).toBeDefined()
+        expect(NEW_MESSAGE_SUBSCRIPTION.definitions).toBeDefined()
+        expect(NEW_MESSAGE_SUBSCRIPTION.definitions.length).toBeGreaterThan(0)
+      })
+
+      it('has correct subscription structure', () => {
+        const subscriptionString = NEW_MESSAGE_SUBSCRIPTION.loc?.source.body || ''
+        expect(subscriptionString).toContain('subscription newMessage')
+        expect(subscriptionString).toContain('$messageRoomId: String!')
+      })
+
+      it('includes required message fields', () => {
+        const subscriptionString = NEW_MESSAGE_SUBSCRIPTION.loc?.source.body || ''
+        expect(subscriptionString).toContain('_id')
+        expect(subscriptionString).toContain('messageRoomId')
+        expect(subscriptionString).toContain('userId')
+        expect(subscriptionString).toContain('text')
+      })
+    })
+  })
+
+  describe('Subscription Compatibility', () => {
+    it('subscriptions can be used with useSubscription hook structure', () => {
+      // Verify subscriptions have the correct structure for useSubscription
+      const notificationDef = getMainDefinition(NEW_NOTIFICATION_SUBSCRIPTION)
+      const messageDef = getMainDefinition(NEW_MESSAGE_SUBSCRIPTION)
+      
+      // Both should be operation definitions
+      expect(notificationDef.kind).toBe('OperationDefinition')
+      expect(messageDef.kind).toBe('OperationDefinition')
+      
+      // Both should be subscriptions
+      if ('operation' in notificationDef) {
+        expect(notificationDef.operation).toBe('subscription')
+      }
+      if ('operation' in messageDef) {
+        expect(messageDef.operation).toBe('subscription')
+      }
+    })
+
+    it('subscriptions have required variables defined', () => {
+      const notificationDef = getMainDefinition(NEW_NOTIFICATION_SUBSCRIPTION)
+      const messageDef = getMainDefinition(NEW_MESSAGE_SUBSCRIPTION)
+      
+      // Check that variable definitions exist
+      if ('variableDefinitions' in notificationDef && notificationDef.variableDefinitions) {
+        expect(notificationDef.variableDefinitions.length).toBeGreaterThan(0)
+      }
+      
+      if ('variableDefinitions' in messageDef && messageDef.variableDefinitions) {
+        expect(messageDef.variableDefinitions.length).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe('WebSocket Link Configuration', () => {
+    it('client link supports split routing', () => {
+      const client = getApolloClient()
+      
+      // The link should exist and be configured
+      expect(client.link).toBeDefined()
+      
+      // On client side, the link should support split routing
+      // (This is verified by the fact that getMainDefinition works correctly)
+      const testSubscription = NEW_NOTIFICATION_SUBSCRIPTION
+      const definition = getMainDefinition(testSubscription)
+      
+      expect(definition.kind).toBe('OperationDefinition')
+      if ('operation' in definition) {
+        expect(definition.operation).toBe('subscription')
+      }
+    })
+  })
+})
+

--- a/quotevote-frontend/src/__tests__/graphql/posts.test.ts
+++ b/quotevote-frontend/src/__tests__/graphql/posts.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Post GraphQL Operations Tests
+ * 
+ * Tests that verify:
+ * - Post-related queries are properly defined and can be used
+ * - Post-related mutations are properly defined and can be used
+ * - Post-related subscriptions are properly defined
+ * - GraphQL operations use correct syntax and structure
+ */
+
+import { gql } from '@apollo/client'
+import {
+  GET_POST,
+  GET_TOP_POSTS,
+  GET_PAGINATED_POSTS,
+  GET_FRIENDS_POSTS,
+  GET_FEATURED_POSTS,
+  GET_LATEST_QUOTES,
+} from '@/graphql/queries'
+import {
+  SUBMIT_POST,
+  APPROVE_POST,
+  REJECT_POST,
+  DELETE_POST,
+  UPDATE_POST_BOOKMARK,
+  TOGGLE_VOTING,
+  UPDATE_FEATURED_SLOT,
+  REPORT_POST,
+  VOTE,
+  DELETE_VOTE,
+  ADD_QUOTE,
+  DELETE_QUOTE,
+} from '@/graphql/mutations'
+import {
+  NEW_NOTIFICATION_SUBSCRIPTION,
+  NEW_MESSAGE_SUBSCRIPTION,
+} from '@/graphql/subscriptions'
+
+describe('Post GraphQL Queries', () => {
+  describe('GET_POST', () => {
+    it('is defined and is a valid GraphQL query', () => {
+      expect(GET_POST).toBeDefined()
+      expect(GET_POST.definitions).toBeDefined()
+      expect(GET_POST.definitions.length).toBeGreaterThan(0)
+    })
+
+    it('has correct query structure', () => {
+      const queryString = GET_POST.loc?.source.body || ''
+      expect(queryString).toContain('query post')
+      expect(queryString).toContain('$postId: String!')
+      expect(queryString).toContain('post(postId: $postId)')
+    })
+
+    it('includes required post fields', () => {
+      const queryString = GET_POST.loc?.source.body || ''
+      expect(queryString).toContain('_id')
+      expect(queryString).toContain('title')
+      expect(queryString).toContain('text')
+      expect(queryString).toContain('creator')
+      expect(queryString).toContain('comments')
+      expect(queryString).toContain('votes')
+      expect(queryString).toContain('quotes')
+    })
+  })
+
+  describe('GET_TOP_POSTS', () => {
+    it('is defined and is a valid GraphQL query', () => {
+      expect(GET_TOP_POSTS).toBeDefined()
+      expect(GET_TOP_POSTS.definitions).toBeDefined()
+    })
+
+    it('has correct query structure with pagination', () => {
+      const queryString = GET_TOP_POSTS.loc?.source.body || ''
+      expect(queryString).toContain('query topPosts')
+      expect(queryString).toContain('$limit: Int!')
+      expect(queryString).toContain('$offset: Int!')
+      expect(queryString).toContain('pagination')
+      expect(queryString).toContain('total_count')
+    })
+
+    it('includes post entities with required fields', () => {
+      const queryString = GET_TOP_POSTS.loc?.source.body || ''
+      expect(queryString).toContain('entities')
+      expect(queryString).toContain('creator')
+      expect(queryString).toContain('upvotes')
+      expect(queryString).toContain('downvotes')
+    })
+  })
+
+  describe('GET_PAGINATED_POSTS', () => {
+    it('is defined and is a valid GraphQL query', () => {
+      expect(GET_PAGINATED_POSTS).toBeDefined()
+      expect(GET_PAGINATED_POSTS.definitions).toBeDefined()
+    })
+
+    it('has pagination support', () => {
+      const queryString = GET_PAGINATED_POSTS.loc?.source.body || ''
+      expect(queryString).toContain('pagination')
+      expect(queryString).toContain('limit')
+      expect(queryString).toContain('offset')
+    })
+  })
+
+  describe('GET_FRIENDS_POSTS', () => {
+    it('is defined and is a valid GraphQL query', () => {
+      expect(GET_FRIENDS_POSTS).toBeDefined()
+      expect(GET_FRIENDS_POSTS.definitions).toBeDefined()
+    })
+
+    it('includes friendsOnly parameter', () => {
+      const queryString = GET_FRIENDS_POSTS.loc?.source.body || ''
+      expect(queryString).toContain('$friendsOnly: Boolean')
+    })
+  })
+
+  describe('GET_FEATURED_POSTS', () => {
+    it('is defined and is a valid GraphQL query', () => {
+      expect(GET_FEATURED_POSTS).toBeDefined()
+      expect(GET_FEATURED_POSTS.definitions).toBeDefined()
+    })
+
+    it('has featured posts query structure', () => {
+      const queryString = GET_FEATURED_POSTS.loc?.source.body || ''
+      expect(queryString).toContain('query featuredPosts')
+      expect(queryString).toContain('featuredPosts(')
+    })
+  })
+
+  describe('GET_LATEST_QUOTES', () => {
+    it('is defined and is a valid GraphQL query', () => {
+      expect(GET_LATEST_QUOTES).toBeDefined()
+      expect(GET_LATEST_QUOTES.definitions).toBeDefined()
+    })
+
+    it('has correct query structure', () => {
+      const queryString = GET_LATEST_QUOTES.loc?.source.body || ''
+      expect(queryString).toContain('query latestQuotes')
+      expect(queryString).toContain('$limit: Int!')
+      expect(queryString).toContain('user')
+    })
+  })
+})
+
+describe('Post GraphQL Mutations', () => {
+  describe('SUBMIT_POST', () => {
+    it('is defined and is a valid GraphQL mutation', () => {
+      expect(SUBMIT_POST).toBeDefined()
+      expect(SUBMIT_POST.definitions).toBeDefined()
+    })
+
+    it('has correct mutation structure', () => {
+      const mutationString = SUBMIT_POST.loc?.source.body || ''
+      expect(mutationString).toContain('mutation addPost')
+      expect(mutationString).toContain('$post: PostInput!')
+      expect(mutationString).toContain('addPost(post: $post)')
+    })
+
+    it('returns post _id and url', () => {
+      const mutationString = SUBMIT_POST.loc?.source.body || ''
+      expect(mutationString).toContain('_id')
+      expect(mutationString).toContain('url')
+    })
+  })
+
+  describe('APPROVE_POST', () => {
+    it('is defined and is a valid GraphQL mutation', () => {
+      expect(APPROVE_POST).toBeDefined()
+      expect(APPROVE_POST.definitions).toBeDefined()
+    })
+
+    it('has correct mutation parameters', () => {
+      const mutationString = APPROVE_POST.loc?.source.body || ''
+      expect(mutationString).toContain('$postId: String!')
+      expect(mutationString).toContain('$userId: String!')
+      expect(mutationString).toContain('$remove: Boolean')
+    })
+  })
+
+  describe('REJECT_POST', () => {
+    it('is defined and is a valid GraphQL mutation', () => {
+      expect(REJECT_POST).toBeDefined()
+      expect(REJECT_POST.definitions).toBeDefined()
+    })
+
+    it('has correct mutation structure', () => {
+      const mutationString = REJECT_POST.loc?.source.body || ''
+      expect(mutationString).toContain('mutation rejectPost')
+    })
+  })
+
+  describe('DELETE_POST', () => {
+    it('is defined and is a valid GraphQL mutation', () => {
+      expect(DELETE_POST).toBeDefined()
+      expect(DELETE_POST.definitions).toBeDefined()
+    })
+
+    it('has correct mutation structure', () => {
+      const mutationString = DELETE_POST.loc?.source.body || ''
+      expect(mutationString).toContain('mutation deletePost')
+      expect(mutationString).toContain('$postId: String!')
+    })
+  })
+
+  describe('UPDATE_POST_BOOKMARK', () => {
+    it('is defined and is a valid GraphQL mutation', () => {
+      expect(UPDATE_POST_BOOKMARK).toBeDefined()
+      expect(UPDATE_POST_BOOKMARK.definitions).toBeDefined()
+    })
+
+    it('returns bookmarkedBy field', () => {
+      const mutationString = UPDATE_POST_BOOKMARK.loc?.source.body || ''
+      expect(mutationString).toContain('bookmarkedBy')
+    })
+  })
+
+  describe('TOGGLE_VOTING', () => {
+    it('is defined and is a valid GraphQL mutation', () => {
+      expect(TOGGLE_VOTING).toBeDefined()
+      expect(TOGGLE_VOTING.definitions).toBeDefined()
+    })
+
+    it('returns enable_voting field', () => {
+      const mutationString = TOGGLE_VOTING.loc?.source.body || ''
+      expect(mutationString).toContain('enable_voting')
+    })
+  })
+
+  describe('UPDATE_FEATURED_SLOT', () => {
+    it('is defined and is a valid GraphQL mutation', () => {
+      expect(UPDATE_FEATURED_SLOT).toBeDefined()
+      expect(UPDATE_FEATURED_SLOT.definitions).toBeDefined()
+    })
+
+    it('has featuredSlot parameter', () => {
+      const mutationString = UPDATE_FEATURED_SLOT.loc?.source.body || ''
+      expect(mutationString).toContain('$featuredSlot: Int')
+    })
+  })
+
+  describe('REPORT_POST', () => {
+    it('is defined and is a valid GraphQL mutation', () => {
+      expect(REPORT_POST).toBeDefined()
+      expect(REPORT_POST.definitions).toBeDefined()
+    })
+
+    it('returns reportedBy field', () => {
+      const mutationString = REPORT_POST.loc?.source.body || ''
+      expect(mutationString).toContain('reportedBy')
+    })
+  })
+
+  describe('VOTE', () => {
+    it('is defined and is a valid GraphQL mutation', () => {
+      expect(VOTE).toBeDefined()
+      expect(VOTE.definitions).toBeDefined()
+    })
+
+    it('has correct mutation structure', () => {
+      const mutationString = VOTE.loc?.source.body || ''
+      expect(mutationString).toContain('mutation addVote')
+      expect(mutationString).toContain('$vote: VoteInput!')
+    })
+  })
+
+  describe('DELETE_VOTE', () => {
+    it('is defined and is a valid GraphQL mutation', () => {
+      expect(DELETE_VOTE).toBeDefined()
+      expect(DELETE_VOTE.definitions).toBeDefined()
+    })
+
+    it('has correct mutation structure', () => {
+      const mutationString = DELETE_VOTE.loc?.source.body || ''
+      expect(mutationString).toContain('mutation deleteVote')
+      expect(mutationString).toContain('$voteId: String!')
+    })
+  })
+
+  describe('ADD_QUOTE', () => {
+    it('is defined and is a valid GraphQL mutation', () => {
+      expect(ADD_QUOTE).toBeDefined()
+      expect(ADD_QUOTE.definitions).toBeDefined()
+    })
+
+    it('has correct mutation structure', () => {
+      const mutationString = ADD_QUOTE.loc?.source.body || ''
+      expect(mutationString).toContain('mutation addQuote')
+      expect(mutationString).toContain('$quote: QuoteInput!')
+    })
+  })
+
+  describe('DELETE_QUOTE', () => {
+    it('is defined and is a valid GraphQL mutation', () => {
+      expect(DELETE_QUOTE).toBeDefined()
+      expect(DELETE_QUOTE.definitions).toBeDefined()
+    })
+
+    it('has correct mutation structure', () => {
+      const mutationString = DELETE_QUOTE.loc?.source.body || ''
+      expect(mutationString).toContain('mutation deleteQuote')
+      expect(mutationString).toContain('$quoteId: String!')
+    })
+  })
+})
+
+describe('Post GraphQL Subscriptions', () => {
+  describe('NEW_NOTIFICATION_SUBSCRIPTION', () => {
+    it('is defined and is a valid GraphQL subscription', () => {
+      expect(NEW_NOTIFICATION_SUBSCRIPTION).toBeDefined()
+      expect(NEW_NOTIFICATION_SUBSCRIPTION.definitions).toBeDefined()
+    })
+
+    it('has correct subscription structure', () => {
+      const subscriptionString = NEW_NOTIFICATION_SUBSCRIPTION.loc?.source.body || ''
+      expect(subscriptionString).toContain('subscription notification')
+      expect(subscriptionString).toContain('$userId: String!')
+    })
+
+    it('includes post field in notification', () => {
+      const subscriptionString = NEW_NOTIFICATION_SUBSCRIPTION.loc?.source.body || ''
+      expect(subscriptionString).toContain('post')
+      expect(subscriptionString).toContain('_id')
+      expect(subscriptionString).toContain('url')
+    })
+  })
+
+  describe('NEW_MESSAGE_SUBSCRIPTION', () => {
+    it('is defined and is a valid GraphQL subscription', () => {
+      expect(NEW_MESSAGE_SUBSCRIPTION).toBeDefined()
+      expect(NEW_MESSAGE_SUBSCRIPTION.definitions).toBeDefined()
+    })
+
+    it('has correct subscription structure', () => {
+      const subscriptionString = NEW_MESSAGE_SUBSCRIPTION.loc?.source.body || ''
+      expect(subscriptionString).toContain('subscription newMessage')
+      expect(subscriptionString).toContain('$messageRoomId: String!')
+    })
+  })
+})
+
+describe('GraphQL Operations Integration', () => {
+  it('all queries use @apollo/client gql', () => {
+    // Verify queries are created with gql from @apollo/client
+    expect(GET_POST.kind).toBe('Document')
+    expect(GET_TOP_POSTS.kind).toBe('Document')
+    expect(GET_PAGINATED_POSTS.kind).toBe('Document')
+    expect(GET_FRIENDS_POSTS.kind).toBe('Document')
+    expect(GET_FEATURED_POSTS.kind).toBe('Document')
+    expect(GET_LATEST_QUOTES.kind).toBe('Document')
+  })
+
+  it('all mutations use @apollo/client gql', () => {
+    // Verify mutations are created with gql from @apollo/client
+    expect(SUBMIT_POST.kind).toBe('Document')
+    expect(APPROVE_POST.kind).toBe('Document')
+    expect(REJECT_POST.kind).toBe('Document')
+    expect(DELETE_POST.kind).toBe('Document')
+    expect(UPDATE_POST_BOOKMARK.kind).toBe('Document')
+    expect(TOGGLE_VOTING.kind).toBe('Document')
+    expect(UPDATE_FEATURED_SLOT.kind).toBe('Document')
+    expect(REPORT_POST.kind).toBe('Document')
+    expect(VOTE.kind).toBe('Document')
+    expect(DELETE_VOTE.kind).toBe('Document')
+    expect(ADD_QUOTE.kind).toBe('Document')
+    expect(DELETE_QUOTE.kind).toBe('Document')
+  })
+
+  it('all subscriptions use @apollo/client gql', () => {
+    // Verify subscriptions are created with gql from @apollo/client
+    expect(NEW_NOTIFICATION_SUBSCRIPTION.kind).toBe('Document')
+    expect(NEW_MESSAGE_SUBSCRIPTION.kind).toBe('Document')
+  })
+
+  it('queries have proper operation names', () => {
+    const getOperationName = (doc: ReturnType<typeof gql>) => {
+      const definition = doc.definitions[0]
+      if (definition && 'name' in definition && definition.name) {
+        return definition.name.value
+      }
+      return null
+    }
+
+    expect(getOperationName(GET_POST)).toBe('post')
+    expect(getOperationName(GET_TOP_POSTS)).toBe('topPosts')
+    expect(getOperationName(GET_PAGINATED_POSTS)).toBe('paginatedPosts')
+    expect(getOperationName(GET_FRIENDS_POSTS)).toBe('friendsPosts')
+    expect(getOperationName(GET_FEATURED_POSTS)).toBe('featuredPosts')
+    expect(getOperationName(GET_LATEST_QUOTES)).toBe('latestQuotes')
+  })
+
+  it('mutations have proper operation names', () => {
+    const getOperationName = (doc: ReturnType<typeof gql>) => {
+      const definition = doc.definitions[0]
+      if (definition && 'name' in definition && definition.name) {
+        return definition.name.value
+      }
+      return null
+    }
+
+    expect(getOperationName(SUBMIT_POST)).toBe('addPost')
+    expect(getOperationName(APPROVE_POST)).toBe('approvePost')
+    expect(getOperationName(REJECT_POST)).toBe('rejectPost')
+    expect(getOperationName(DELETE_POST)).toBe('deletePost')
+    expect(getOperationName(UPDATE_POST_BOOKMARK)).toBe('updatePostBookmark')
+    expect(getOperationName(TOGGLE_VOTING)).toBe('toggleVoting')
+    expect(getOperationName(UPDATE_FEATURED_SLOT)).toBe('updateFeaturedSlot')
+    expect(getOperationName(REPORT_POST)).toBe('reportPost')
+    expect(getOperationName(VOTE)).toBe('addVote')
+    expect(getOperationName(DELETE_VOTE)).toBe('deleteVote')
+    expect(getOperationName(ADD_QUOTE)).toBe('addQuote')
+    expect(getOperationName(DELETE_QUOTE)).toBe('deleteQuote')
+  })
+})
+

--- a/quotevote-frontend/src/graphql/mutations.ts
+++ b/quotevote-frontend/src/graphql/mutations.ts
@@ -221,3 +221,129 @@ export const UPDATE_ACTION_REACTION = gql`
     }
   }
 `
+
+/**
+ * Approve post mutation
+ */
+export const APPROVE_POST = gql`
+  mutation approvePost($postId: String!, $userId: String!, $remove: Boolean) {
+    approvePost(postId: $postId, userId: $userId, remove: $remove) {
+      _id
+    }
+  }
+`
+
+/**
+ * Reject post mutation
+ */
+export const REJECT_POST = gql`
+  mutation rejectPost($postId: String!, $userId: String!, $remove: Boolean) {
+    rejectPost(postId: $postId, userId: $userId, remove: $remove) {
+      _id
+    }
+  }
+`
+
+/**
+ * Delete post mutation
+ */
+export const DELETE_POST = gql`
+  mutation deletePost($postId: String!) {
+    deletePost(postId: $postId) {
+      _id
+    }
+  }
+`
+
+/**
+ * Update post bookmark mutation
+ */
+export const UPDATE_POST_BOOKMARK = gql`
+  mutation updatePostBookmark($postId: String!, $userId: String!) {
+    updatePostBookmark(postId: $postId, userId: $userId) {
+      _id
+      bookmarkedBy
+    }
+  }
+`
+
+/**
+ * Toggle voting on a post mutation
+ */
+export const TOGGLE_VOTING = gql`
+  mutation toggleVoting($postId: String!) {
+    toggleVoting(postId: $postId) {
+      _id
+      enable_voting
+    }
+  }
+`
+
+/**
+ * Update featured slot mutation
+ */
+export const UPDATE_FEATURED_SLOT = gql`
+  mutation updateFeaturedSlot($postId: String!, $featuredSlot: Int) {
+    updateFeaturedSlot(postId: $postId, featuredSlot: $featuredSlot) {
+      _id
+      featuredSlot
+    }
+  }
+`
+
+/**
+ * Report post mutation
+ */
+export const REPORT_POST = gql`
+  mutation reportPost($postId: String!, $userId: String!) {
+    reportPost(postId: $postId, userId: $userId) {
+      _id
+      reportedBy
+    }
+  }
+`
+
+/**
+ * Add vote mutation
+ */
+export const VOTE = gql`
+  mutation addVote($vote: VoteInput!) {
+    addVote(vote: $vote) {
+      postId
+      type
+    }
+  }
+`
+
+/**
+ * Delete vote mutation
+ */
+export const DELETE_VOTE = gql`
+  mutation deleteVote($voteId: String!) {
+    deleteVote(voteId: $voteId) {
+      _id
+    }
+  }
+`
+
+/**
+ * Add quote mutation
+ */
+export const ADD_QUOTE = gql`
+  mutation addQuote($quote: QuoteInput!) {
+    addQuote(quote: $quote) {
+      _id
+    }
+  }
+`
+
+/**
+ * Delete quote mutation
+ */
+export const DELETE_QUOTE = gql`
+  mutation deleteQuote($quoteId: String!) {
+    deleteQuote(quoteId: $quoteId) {
+      _id
+    }
+  }
+`

--- a/quotevote-frontend/src/graphql/queries.ts
+++ b/quotevote-frontend/src/graphql/queries.ts
@@ -93,3 +93,400 @@ export const GET_ACTION_REACTIONS = gql`
     }
   }
 `
+
+/**
+ * Get a single post by ID
+ */
+export const GET_POST = gql`
+  query post($postId: String!) {
+    post(postId: $postId) {
+      _id
+      userId
+      created
+      groupId
+      title
+      text
+      url
+      upvotes
+      downvotes
+      approvedBy
+      rejectedBy
+      reportedBy
+      bookmarkedBy
+      enable_voting
+      creator {
+        _id
+        name
+        avatar
+        username
+        contributorBadge
+      }
+      comments {
+        _id
+        created
+        userId
+        content
+        startWordIndex
+        endWordIndex
+        postId
+        url
+        reaction
+        user {
+          _id
+          username
+          name
+          avatar
+          contributorBadge
+        }
+      }
+      votes {
+        _id
+        startWordIndex
+        endWordIndex
+        created
+        type
+        tags
+        content
+        user {
+          _id
+          username
+          name
+          avatar
+          contributorBadge
+        }
+      }
+      quotes {
+        _id
+        startWordIndex
+        endWordIndex
+        created
+        quote
+        user {
+          _id
+          username
+          name
+          avatar
+          contributorBadge
+        }
+      }
+      messageRoom {
+        _id
+        users
+        postId
+        messageType
+        created
+      }
+    }
+  }
+`
+
+/**
+ * Get top posts query
+ */
+export const GET_TOP_POSTS = gql`
+  query topPosts(
+    $limit: Int!
+    $offset: Int!
+    $searchKey: String!
+    $startDateRange: String
+    $endDateRange: String
+    $friendsOnly: Boolean
+    $interactions: Boolean
+    $userId: String
+    $sortOrder: String
+  ) {
+    posts(
+      limit: $limit
+      offset: $offset
+      searchKey: $searchKey
+      startDateRange: $startDateRange
+      endDateRange: $endDateRange
+      friendsOnly: $friendsOnly
+      interactions: $interactions
+      userId: $userId
+      sortOrder: $sortOrder
+    ) {
+      entities {
+        _id
+        userId
+        groupId
+        title
+        text
+        upvotes
+        downvotes
+        bookmarkedBy
+        created
+        url
+        rejectedBy
+        approvedBy
+        creator {
+          name
+          username
+          avatar
+          _id
+          contributorBadge
+        }
+        votes {
+          _id
+          startWordIndex
+          endWordIndex
+          type
+        }
+        comments {
+          _id
+        }
+        quotes {
+          _id
+        }
+        messageRoom {
+          _id
+          messages {
+            _id
+          }
+        }
+      }
+      pagination {
+        total_count
+        limit
+        offset
+      }
+    }
+  }
+`
+
+/**
+ * Paginated version of GET_TOP_POSTS for page-based pagination
+ */
+export const GET_PAGINATED_POSTS = gql`
+  query paginatedPosts(
+    $limit: Int!
+    $offset: Int!
+    $searchKey: String!
+    $startDateRange: String
+    $endDateRange: String
+    $friendsOnly: Boolean
+    $interactions: Boolean
+    $userId: String
+    $sortOrder: String
+  ) {
+    posts(
+      limit: $limit
+      offset: $offset
+      searchKey: $searchKey
+      startDateRange: $startDateRange
+      endDateRange: $endDateRange
+      friendsOnly: $friendsOnly
+      interactions: $interactions
+      userId: $userId
+      sortOrder: $sortOrder
+    ) {
+      entities {
+        _id
+        userId
+        groupId
+        title
+        text
+        upvotes
+        downvotes
+        bookmarkedBy
+        created
+        url
+        rejectedBy
+        approvedBy
+        creator {
+          name
+          username
+          avatar
+          _id
+          contributorBadge
+        }
+        votes {
+          _id
+          startWordIndex
+          endWordIndex
+          type
+        }
+        comments {
+          _id
+        }
+        quotes {
+          _id
+        }
+        messageRoom {
+          _id
+          messages {
+            _id
+          }
+        }
+      }
+      pagination {
+        total_count
+        limit
+        offset
+      }
+    }
+  }
+`
+
+/**
+ * Get friends posts query
+ */
+export const GET_FRIENDS_POSTS = gql`
+  query friendsPosts(
+    $limit: Int!
+    $offset: Int!
+    $searchKey: String!
+    $startDateRange: String
+    $endDateRange: String
+    $friendsOnly: Boolean
+    $interactions: Boolean
+  ) {
+    posts(
+      limit: $limit
+      offset: $offset
+      searchKey: $searchKey
+      startDateRange: $startDateRange
+      endDateRange: $endDateRange
+      friendsOnly: $friendsOnly
+      interactions: $interactions
+    ) {
+      entities {
+        _id
+        userId
+        title
+        text
+        upvotes
+        downvotes
+        bookmarkedBy
+        created
+        url
+        creator {
+          name
+          username
+          avatar
+          _id
+          contributorBadge
+        }
+        votes {
+          _id
+          startWordIndex
+          endWordIndex
+          type
+        }
+        comments {
+          _id
+        }
+        quotes {
+          _id
+        }
+        messageRoom {
+          _id
+          messages {
+            _id
+          }
+        }
+      }
+      pagination {
+        total_count
+        limit
+        offset
+      }
+    }
+  }
+`
+
+/**
+ * Get featured posts query
+ */
+export const GET_FEATURED_POSTS = gql`
+  query featuredPosts(
+    $limit: Int
+    $offset: Int
+    $searchKey: String
+    $startDateRange: String
+    $endDateRange: String
+    $friendsOnly: Boolean
+    $groupId: String
+    $userId: String
+    $approved: Boolean
+    $deleted: Boolean
+    $interactions: Boolean
+    $sortOrder: String
+  ) {
+    featuredPosts(
+      limit: $limit
+      offset: $offset
+      searchKey: $searchKey
+      startDateRange: $startDateRange
+      endDateRange: $endDateRange
+      friendsOnly: $friendsOnly
+      groupId: $groupId
+      userId: $userId
+      approved: $approved
+      deleted: $deleted
+      interactions: $interactions
+      sortOrder: $sortOrder
+    ) {
+      entities {
+        _id
+        userId
+        groupId
+        title
+        text
+        upvotes
+        downvotes
+        bookmarkedBy
+        created
+        url
+        creator {
+          name
+          username
+          avatar
+          _id
+          contributorBadge
+        }
+        votes {
+          _id
+          startWordIndex
+          endWordIndex
+          type
+        }
+        comments {
+          _id
+        }
+        quotes {
+          _id
+        }
+        messageRoom {
+          _id
+          messages {
+            _id
+          }
+        }
+      }
+      pagination {
+        total_count
+        limit
+        offset
+      }
+    }
+  }
+`
+
+/**
+ * Get latest quotes query
+ */
+export const GET_LATEST_QUOTES = gql`
+  query latestQuotes($limit: Int!) {
+    latestQuotes(limit: $limit) {
+      _id
+      quote
+      created
+      user {
+        _id
+        username
+        contributorBadge
+      }
+    }
+  }
+`

--- a/quotevote-frontend/src/graphql/subscriptions.ts
+++ b/quotevote-frontend/src/graphql/subscriptions.ts
@@ -12,3 +12,47 @@ export const PRESENCE_SUBSCRIPTION = gql`
     }
   }
 `
+
+/**
+ * New notification subscription - subscribes to notifications including post updates
+ */
+export const NEW_NOTIFICATION_SUBSCRIPTION = gql`
+  subscription notification($userId: String!) {
+    notification(userId: $userId) {
+      _id
+      userId
+      userIdBy
+      userBy {
+        name
+        avatar
+      }
+      label
+      status
+      created
+      notificationType
+      post {
+        _id
+        url
+      }
+    }
+  }
+`
+
+/**
+ * New message subscription - subscribes to new messages in a message room
+ */
+export const NEW_MESSAGE_SUBSCRIPTION = gql`
+  subscription newMessage($messageRoomId: String!) {
+    message(messageRoomId: $messageRoomId) {
+      _id
+      messageRoomId
+      userId
+      userName
+      title
+      text
+      created
+      type
+      mutation_type
+    }
+  }
+`

--- a/quotevote-frontend/src/lib/apollo/apollo-client.ts
+++ b/quotevote-frontend/src/lib/apollo/apollo-client.ts
@@ -1,6 +1,13 @@
-import { ApolloClient, InMemoryCache, HttpLink, from, type ApolloClient as ApolloClientType } from '@apollo/client';
+import { ApolloClient, InMemoryCache, HttpLink, from, split, ApolloLink, type ApolloClient as ApolloClientType } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
+import { onError } from '@apollo/client/link/error';
+import { getMainDefinition } from '@apollo/client/utilities';
+import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
+import { createClient } from 'graphql-ws';
+import { map } from 'rxjs';
 import { env } from '@/config/env';
+import { getGraphqlWsServerUrl } from '@/lib/utils/getServerUrl';
+import { serializeObjectIds } from '@/lib/utils/objectIdSerializer';
 
 /**
  * Get the GraphQL endpoint URL from validated environment configuration
@@ -57,6 +64,133 @@ function createAuthLink() {
 }
 
 /**
+ * Create a WebSocket link for GraphQL subscriptions
+ * Only available on the client side (browser)
+ * 
+ * @returns Configured WebSocket link or null if on server
+ */
+function createWsLink(): GraphQLWsLink | null {
+  // WebSocket links only work in the browser
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  // Track retry attempts to prevent infinite loops
+  let retryCount = 0;
+  let retryResetTimeout: NodeJS.Timeout | null = null;
+  const MAX_RETRY_ATTEMPTS = 10; // Maximum retry attempts before giving up
+  const RETRY_RESET_DELAY = 60000; // Reset retry count after 60 seconds
+
+  return new GraphQLWsLink(
+    createClient({
+      url: getGraphqlWsServerUrl(),
+      connectionParams: () => {
+        const token = localStorage.getItem('token');
+        return {
+          authToken: token ? (token.startsWith('Bearer ') ? token : `Bearer ${token}`) : undefined,
+        };
+      },
+      retryAttempts: MAX_RETRY_ATTEMPTS,
+      shouldRetry: (errOrCloseEvent) => {
+        // Don't retry if we've exceeded max attempts
+        if (retryCount >= MAX_RETRY_ATTEMPTS) {
+          // Schedule a reset of retry count after RETRY_RESET_DELAY
+          if (retryResetTimeout) {
+            clearTimeout(retryResetTimeout);
+          }
+          retryResetTimeout = setTimeout(() => {
+            retryCount = 0;
+          }, RETRY_RESET_DELAY);
+          return false;
+        }
+
+        // Clear any existing reset timeout since we're retrying
+        if (retryResetTimeout) {
+          clearTimeout(retryResetTimeout);
+          retryResetTimeout = null;
+        }
+
+        // Check for specific error codes that shouldn't be retried
+        if (errOrCloseEvent && typeof errOrCloseEvent === 'object' && 'code' in errOrCloseEvent) {
+          const code = errOrCloseEvent.code as number;
+          if (code === 1001 || code === 1002) {
+            // 1001: Going Away, 1002: Protocol Error - don't retry
+            return false;
+          }
+
+          // Check if connection was cleanly closed (code 1000)
+          if (code === 1000 && 'wasClean' in errOrCloseEvent && errOrCloseEvent.wasClean) {
+            return false;
+          }
+        }
+
+        retryCount++;
+        return true;
+      },
+      on: {
+        opened: () => {
+          // Reset retry count on successful connection
+          retryCount = 0;
+          if (retryResetTimeout) {
+            clearTimeout(retryResetTimeout);
+            retryResetTimeout = null;
+          }
+        },
+        closed: () => {
+          // Connection closed
+        },
+        error: () => {
+          // Connection error
+        },
+      },
+    })
+  );
+}
+
+/**
+ * Create an error link to handle network and GraphQL errors
+ * 
+ * @returns Configured error link
+ */
+function createErrorLink() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return onError((error: any) => {
+    // Errors are handled silently to prevent console spam
+    // You can add logging here if needed for debugging
+    if (error?.graphQLErrors) {
+      // GraphQL errors handled silently
+    }
+
+    if (error?.networkError) {
+      // Network errors handled silently
+    }
+  });
+}
+
+/**
+ * Create a link to handle ObjectID serialization
+ * 
+ * @returns Configured ObjectID serialization link
+ */
+function createObjectIdSerializationLink() {
+  return new ApolloLink((operation, forward) => {
+    return forward(operation).pipe(
+      map((response) => {
+        if (response.data) {
+          // Recursively serialize ObjectIDs in the response
+          const serialized = serializeObjectIds(response.data);
+          // Ensure we return the correct type
+          if (typeof serialized === 'object' && serialized !== null && !Array.isArray(serialized)) {
+            response.data = serialized as Record<string, unknown>;
+          }
+        }
+        return response;
+      })
+    );
+  });
+}
+
+/**
  * Create and configure Apollo Client instance
  * This is SSR-aware and safe to use in both server and client components
  * 
@@ -65,13 +199,57 @@ function createAuthLink() {
 function createApolloClient(): ApolloClientType {
   const httpLink = createHttpLink();
   const authLink = createAuthLink();
+  const errorLink = createErrorLink();
+  const objectIdSerializationLink = createObjectIdSerializationLink();
+  const wsLink = createWsLink();
+
+  // Create HTTP link chain with error handling, auth, and ObjectID serialization
+  // Note: Type assertion needed due to pnpm dependency resolution creating
+  // separate instances of ApolloLink types from different packages
+  const httpLinkChain = from([
+    errorLink as unknown as ApolloLink,
+    authLink,
+    objectIdSerializationLink,
+    httpLink,
+  ]);
+
+  // Split link: subscriptions go to WebSocket, queries/mutations go to HTTP
+  // On server, only use HTTP link (no WebSocket support)
+  // Note: Type assertion needed due to pnpm dependency resolution creating
+  // separate instances of ApolloLink types from different packages
+  const link = typeof window !== 'undefined' && wsLink
+    ? (split(
+        ({ query }) => {
+          const definition = getMainDefinition(query);
+          return (
+            definition.kind === 'OperationDefinition' &&
+            definition.operation === 'subscription'
+          );
+        },
+        wsLink as unknown as ApolloLink,
+        httpLinkChain
+      ) as ApolloLink)
+    : httpLinkChain;
 
   return new ApolloClient({
-    link: from([authLink, httpLink]),
+    link,
     cache: new InMemoryCache({
       // Configure cache policies as needed
       typePolicies: {
-        // Add type policies here for custom cache behavior
+        Query: {
+          fields: {
+            searchKey: {
+              read() {
+                return '';
+              },
+            },
+            startDateRange: {
+              read() {
+                return '';
+              },
+            },
+          },
+        },
       },
     }),
     // Enable SSR mode for Next.js
@@ -80,6 +258,7 @@ function createApolloClient(): ApolloClientType {
     defaultOptions: {
       watchQuery: {
         errorPolicy: 'all',
+        fetchPolicy: 'cache-and-network',
       },
       query: {
         errorPolicy: 'all',


### PR DESCRIPTION
## Update GraphQL Integration for Posts

### Summary
Migrates all post-related GraphQL operations from the old client to the Next.js frontend. Adds WebSocket subscription support to Apollo Client and ensures compatibility with the App Router.

### Changes
- **Apollo Client**: Added WebSocket subscription support with split link routing
- **Queries**: Added 6 post queries (`GET_POST`, `GET_TOP_POSTS`, `GET_PAGINATED_POSTS`, `GET_FRIENDS_POSTS`, `GET_FEATURED_POSTS`, `GET_LATEST_QUOTES`)
- **Mutations**: Added 12 post mutations (`SUBMIT_POST`, `APPROVE_POST`, `REJECT_POST`, `DELETE_POST`, `UPDATE_POST_BOOKMARK`, `TOGGLE_VOTING`, `UPDATE_FEATURED_SLOT`, `REPORT_POST`, `VOTE`, `DELETE_VOTE`, `ADD_QUOTE`, `DELETE_QUOTE`)
- **Subscriptions**: Added 2 subscriptions (`NEW_NOTIFICATION_SUBSCRIPTION`, `NEW_MESSAGE_SUBSCRIPTION`)
- **TypeScript**: Converted all operations from `graphql-tag` to `@apollo/client` gql
- **Tests**: Added test suite (63 tests passing)

### Technical Details
- Installed `graphql-ws` for WebSocket support
- Configured split link to route subscriptions to WebSocket, queries/mutations to HTTP
- Added error handling and ObjectID serialization links
- Fixed TypeScript compatibility issues with pnpm dependency resolution

### Testing
- All 63 tests passing
- Type-check passing
- No linting errors

### Related
Closes #39  - Update GraphQL Integration for Posts
