### PR TITLE
feat: refactor PostChatComponents

### DIFF
--- a/quotevote-frontend/src/app/test-postchat/page.tsx
+++ b/quotevote-frontend/src/app/test-postchat/page.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { AuthModalProvider } from '@/context/AuthModalContext'
+import PostChatMessage from '@/components/PostChat/PostChatMessage'
+import PostChatSend from '@/components/PostChat/PostChatSend'
+
+// Mock data for testing the UI
+const mockMessage = {
+  _id: 'test-msg-1',
+  userId: 'other-user-123',
+  text: 'This is a test message from another user. It can be quite long to test how the bubble handles wrapping and such.',
+  created: new Date().toISOString(),
+  user: {
+    name: 'Test User',
+    username: 'testuser',
+    avatar: undefined,
+  },
+}
+
+const mockOwnMessage = {
+  _id: 'test-msg-2',
+  userId: '', // Will be replaced with current user ID
+  text: 'This is my own message!',
+  created: new Date(Date.now() - 60000).toISOString(),
+  user: {
+    name: 'Me',
+    username: 'me',
+    avatar: undefined,
+  },
+}
+
+export default function TestPostChatPage() {
+  return (
+    <AuthModalProvider>
+    <div className="min-h-screen bg-gray-100 p-8">
+      <h1 className="mb-6 text-2xl font-bold">PostChat Component Test</h1>
+      
+      <div className="mx-auto max-w-2xl rounded-lg bg-gray-200 p-4">
+        <h2 className="mb-4 text-lg font-semibold">Messages</h2>
+        
+        {/* Test messages */}
+        <div className="space-y-2">
+          <PostChatMessage message={mockMessage} />
+          <PostChatMessage message={mockOwnMessage} />
+          <PostChatMessage message={{...mockMessage, _id: 'test-3', text: 'Short msg'}} />
+        </div>
+
+        {/* Send input */}
+        <div className="mt-4 rounded bg-white">
+          <PostChatSend 
+            messageRoomId="test-room-123"
+            title="Test Post"
+            postId="test-post-123"
+          />
+        </div>
+      </div>
+
+      <p className="mt-4 text-sm text-gray-500">
+        Note: Mutations won&apos;t work without the backend running. This is for visual testing only.
+      </p>
+    </div>
+    </AuthModalProvider>
+  )
+}

--- a/quotevote-frontend/src/components/PostChat/PostChatMessage.tsx
+++ b/quotevote-frontend/src/components/PostChat/PostChatMessage.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useQuery, useMutation } from '@apollo/client/react'
+import { Trash2 } from 'lucide-react'
+
+import Avatar from '@/components/Avatar'
+import PostChatReactions from './PostChatReactions'
+import { useAppStore } from '@/store'
+import { GET_MESSAGE_REACTIONS } from '@/graphql/queries'
+import { DELETE_MESSAGE } from '@/graphql/mutations'
+import { cn } from '@/lib/utils'
+import type { PostChatMessageProps, MessageReaction } from '@/types/postChat'
+
+interface MessageReactionsData {
+  messageReactions: MessageReaction[]
+}
+
+interface DeleteMessageData {
+  deleteMessage: {
+    _id: string
+  }
+}
+
+export default function PostChatMessage({ message }: PostChatMessageProps) {
+  const { username, name } = message.user
+  const router = useRouter()
+
+  const user = useAppStore((state) => state.user.data)
+  const setSnackbar = useAppStore((state) => state.setSnackbar)
+
+  const userId = user._id || user.id
+  const isDefaultDirection = message.userId !== userId
+  const isOwner = userId === message.userId || user.admin
+
+  const { loading, data } = useQuery<MessageReactionsData>(GET_MESSAGE_REACTIONS, {
+    variables: { messageId: message._id },
+  })
+
+  const messageReactions = (!loading && data?.messageReactions) || []
+
+  const [deleteMessage] = useMutation<DeleteMessageData>(DELETE_MESSAGE, {
+    update(cache, { data: mutationData }) {
+      if (!mutationData?.deleteMessage) return
+      cache.modify({
+        fields: {
+          messages(existing: readonly { __ref: string }[] = [], { readField }) {
+            return existing.filter(
+              (messageRef) => readField('_id', messageRef) !== mutationData.deleteMessage._id
+            )
+          },
+        },
+      })
+    },
+  })
+
+  const handleDelete = async () => {
+    try {
+      await deleteMessage({ variables: { messageId: message._id } })
+      setSnackbar({
+        open: true,
+        message: 'Message deleted successfully',
+        type: 'success',
+      })
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Unknown error'
+      setSnackbar({
+        open: true,
+        message: `Delete Error: ${errorMessage}`,
+        type: 'danger',
+      })
+    }
+  }
+
+  const handleRedirectToProfile = () => {
+    router.push(`/Profile/${username}`)
+  }
+
+  const senderName = name || username || 'Unknown'
+  const avatarSrc = typeof message.user.avatar === 'string' ? message.user.avatar : undefined
+
+  return (
+    <div
+      className={cn(
+        'mb-3 flex w-full items-start gap-3 px-2',
+        isDefaultDirection ? 'flex-row' : 'flex-row-reverse'
+      )}
+    >
+      {/* Avatar */}
+      <div className="shrink-0">
+        <Avatar
+          src={avatarSrc}
+          alt={senderName}
+          size={50}
+          fallback={senderName[0]?.toUpperCase() || '?'}
+          onClick={handleRedirectToProfile}
+          className="cursor-pointer"
+        />
+      </div>
+
+      {/* Message Bubble */}
+      <div className="group relative max-w-[75%] min-w-[120px]">
+        <div
+          className={cn(
+            'relative rounded-md px-3.5 py-3.5 pb-1 text-base leading-relaxed shadow-sm',
+            // Speech bubble arrow
+            "before:absolute before:top-0 before:border-10 before:border-transparent before:content-['']",
+            isDefaultDirection
+              ? 'bg-white text-gray-700 before:-left-2.5 before:border-t-white'
+              : 'bg-emerald-500 text-white before:-right-2.5 before:border-t-emerald-500'
+          )}
+        >
+          <p className="whitespace-pre-wrap wrap-break-word tracking-wide">{message.text}</p>
+          <PostChatReactions
+            created={message.created}
+            messageId={message._id}
+            reactions={messageReactions}
+            isDefaultDirection={isDefaultDirection}
+            userName={name}
+            username={username}
+          />
+        </div>
+
+        {/* Delete Button */}
+        {isOwner && (
+          <button
+            type="button"
+            onClick={handleDelete}
+            className={cn(
+              'absolute -top-2 z-10 flex h-7 w-7 items-center justify-center',
+              'rounded-full bg-white shadow-md',
+              'text-red-500 opacity-0 transition-opacity group-hover:opacity-100',
+              'hover:bg-red-50 hover:text-red-600',
+              isDefaultDirection ? '-right-2' : '-left-2'
+            )}
+            aria-label="Delete message"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/quotevote-frontend/src/components/PostChat/PostChatReactions.tsx
+++ b/quotevote-frontend/src/components/PostChat/PostChatReactions.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useMutation } from '@apollo/client/react'
+import { Smile } from 'lucide-react'
+import data from '@emoji-mart/data'
+import Picker from '@emoji-mart/react'
+import _ from 'lodash'
+
+import { Button } from '@/components/ui/button'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { useAppStore } from '@/store'
+import { ADD_MESSAGE_REACTION, UPDATE_MESSAGE_REACTION } from '@/graphql/mutations'
+import { GET_MESSAGE_REACTIONS } from '@/graphql/queries'
+import { parseCommentDate } from '@/lib/utils/momentUtils'
+import useGuestGuard from '@/hooks/useGuestGuard'
+import { cn } from '@/lib/utils'
+import type { PostChatReactionsProps, MessageReaction } from '@/types/postChat'
+
+interface EmojiSelectData {
+  native: string
+}
+
+export default function PostChatReactions({
+  created,
+  messageId,
+  reactions = [],
+  isDefaultDirection,
+  userName,
+  username,
+}: PostChatReactionsProps) {
+  const userId = useAppStore((state) => state.user.data._id || state.user.data.id) as string
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const parsedTime = parseCommentDate(new Date(created))
+  const ensureAuth = useGuestGuard()
+
+  const [addReaction] = useMutation(ADD_MESSAGE_REACTION, {
+    onError: (err: unknown) => {
+      console.error(err)
+    },
+    refetchQueries: [
+      {
+        query: GET_MESSAGE_REACTIONS,
+        variables: { messageId },
+      },
+    ],
+  })
+
+  const [updateReaction] = useMutation(UPDATE_MESSAGE_REACTION, {
+    onError: (err: unknown) => {
+      console.error(err)
+    },
+    refetchQueries: [
+      {
+        query: GET_MESSAGE_REACTIONS,
+        variables: { messageId },
+      },
+    ],
+  })
+
+  const userReaction = _.find(reactions, { userId }) as MessageReaction | undefined
+  const groupedReactions = _.groupBy(reactions, 'emoji')
+
+  const handleEmojiSelect = async (emoji: EmojiSelectData) => {
+    if (!ensureAuth()) return
+    const newEmoji = emoji.native
+    const reaction = {
+      userId,
+      messageId,
+      emoji: newEmoji,
+    }
+
+    if (userReaction) {
+      await updateReaction({
+        variables: { _id: userReaction._id, emoji: reaction.emoji },
+      })
+    } else {
+      await addReaction({
+        variables: { reaction },
+      })
+    }
+
+    setOpen(false)
+  }
+
+  const handleRedirectToProfile = () => {
+    router.push(`/Profile/${username}`)
+  }
+
+  return (
+    <div className="mt-2 flex items-center justify-between">
+      {/* User name and time */}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleRedirectToProfile}
+          className={cn(
+            'text-base font-normal hover:underline',
+            isDefaultDirection ? 'text-gray-500' : 'text-white'
+          )}
+        >
+          {userName}
+        </button>
+        <span
+          className={cn(
+            'text-sm',
+            isDefaultDirection ? 'text-gray-500' : 'text-white/80'
+          )}
+          suppressHydrationWarning
+        >
+          {parsedTime}
+        </span>
+      </div>
+
+      {/* Reactions */}
+      <div className="flex items-center gap-1">
+        {/* Emoji reaction bubbles */}
+        <div className="flex gap-1">
+          {Object.keys(groupedReactions).map((emoji) => (
+            <div
+              key={emoji}
+              className={cn(
+                'flex items-center gap-1 rounded-lg px-1.5 py-0.5 text-sm',
+                isDefaultDirection ? 'bg-gray-100' : 'bg-emerald-400'
+              )}
+            >
+              <span>{emoji}</span>
+              <span className={isDefaultDirection ? 'text-gray-600' : 'text-white'}>
+                {groupedReactions[emoji].length}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Emoji picker */}
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                'h-8 w-8',
+                isDefaultDirection
+                  ? 'text-gray-500 hover:text-gray-700'
+                  : 'text-white hover:text-white/80'
+              )}
+              onClick={(e) => {
+                if (!ensureAuth()) {
+                  e.preventDefault()
+                }
+              }}
+            >
+              <Smile className="h-5 w-5" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto border-none p-0" align="end">
+            <Picker
+              data={data}
+              onEmojiSelect={handleEmojiSelect}
+              theme="light"
+              previewPosition="none"
+              skinTonePosition="none"
+            />
+          </PopoverContent>
+        </Popover>
+      </div>
+    </div>
+  )
+}

--- a/quotevote-frontend/src/components/PostChat/PostChatSend.tsx
+++ b/quotevote-frontend/src/components/PostChat/PostChatSend.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { useMutation } from '@apollo/client/react'
+import { Send } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { useAppStore } from '@/store'
+import { SEND_MESSAGE } from '@/graphql/mutations'
+import { GET_ROOM_MESSAGES } from '@/graphql/queries'
+import useGuestGuard from '@/hooks/useGuestGuard'
+import { cn } from '@/lib/utils'
+import type { PostChatSendProps } from '@/types/postChat'
+
+interface MessagesData {
+  messages: Array<{
+    _id: string
+    messageRoomId: string
+    userId: string
+    userName: string
+    title: string
+    text: string
+    type: string
+    created: string
+  }>
+}
+
+interface CreateMessageData {
+  createMessage: {
+    __typename?: string
+    _id: string
+    messageRoomId: string
+    userId: string
+    userName: string
+    title: string
+    text: string
+    type: string
+    created: string
+    user: {
+      __typename?: string
+      _id: string
+      name: string
+      username: string
+      avatar: string
+    }
+  }
+}
+
+export default function PostChatSend({ messageRoomId, title, postId }: PostChatSendProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [text, setText] = useState('')
+
+  const user = useAppStore((state) => state.user.data)
+  const setChatSubmitting = useAppStore((state) => state.setChatSubmitting)
+  const ensureAuth = useGuestGuard()
+
+  const type = 'POST'
+
+  const [createMessage] = useMutation<CreateMessageData>(SEND_MESSAGE, {
+    onError: () => {
+      setChatSubmitting(false)
+    },
+    onCompleted: () => {
+      setChatSubmitting(false)
+    },
+    refetchQueries: messageRoomId
+      ? [
+          {
+            query: GET_ROOM_MESSAGES,
+            variables: { messageRoomId },
+          },
+        ]
+      : [],
+  })
+
+  const handleSubmit = async () => {
+    if (!ensureAuth()) return
+    if (!text.trim()) return
+
+    setChatSubmitting(true)
+
+    const message = {
+      title,
+      type,
+      messageRoomId: messageRoomId || null,
+      componentId: postId || null,
+      text: text.trim(),
+    }
+
+    const dateSubmitted = new Date()
+
+    await createMessage({
+      variables: { message },
+      optimisticResponse: {
+        createMessage: {
+          __typename: 'Message' as const,
+          _id: dateSubmitted.toISOString(),
+          messageRoomId: messageRoomId || '',
+          userName: (user.name as string) || '',
+          userId: ((user._id || user.id) as string) || '',
+          title: title || '',
+          text: text.trim(),
+          type,
+          created: dateSubmitted.toISOString(),
+          user: {
+            __typename: 'User' as const,
+            _id: ((user._id || user.id) as string) || '',
+            name: (user.name as string) || '',
+            username: (user.username as string) || '',
+            avatar: typeof user.avatar === 'string' ? user.avatar : '',
+          },
+        },
+      },
+      update: (cache, { data: mutationData }) => {
+        if (!messageRoomId || !mutationData?.createMessage) return
+
+        const existingData = cache.readQuery<MessagesData>({
+          query: GET_ROOM_MESSAGES,
+          variables: { messageRoomId },
+        })
+
+        if (existingData) {
+          cache.writeQuery({
+            query: GET_ROOM_MESSAGES,
+            variables: { messageRoomId },
+            data: {
+              ...existingData,
+              messages: [...existingData.messages, mutationData.createMessage],
+            },
+          })
+        }
+      },
+    })
+
+    setText('')
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3 p-2.5 sm:p-3">
+      {/* Chat label - hidden on mobile */}
+      <span className="hidden text-sm font-semibold text-gray-500 sm:block sm:w-16">Chat</span>
+
+      {/* Input area */}
+      <div className="flex flex-1 items-end gap-2">
+        <Textarea
+          ref={textareaRef}
+          placeholder="type a message..."
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className={cn(
+            'min-h-[45px] max-h-[75px] flex-1 resize-none rounded-md',
+            'border border-border bg-muted/50',
+            'px-3 py-2 text-sm',
+            'placeholder:text-muted-foreground/70',
+            'focus:bg-background focus:ring-2 focus:ring-primary/20',
+            !text.trim() && 'min-h-[65px]'
+          )}
+          rows={1}
+        />
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleSubmit}
+          className="h-10 w-10 text-primary hover:bg-primary/10"
+          aria-label="Send message"
+        >
+          <Send className="h-5 w-5" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/quotevote-frontend/src/graphql/mutations.ts
+++ b/quotevote-frontend/src/graphql/mutations.ts
@@ -426,3 +426,30 @@ export const DELETE_MESSAGE = gql`
     }
   }
 `
+
+/**
+ * Add message reaction mutation
+ * Used by PostChatReactions component
+ */
+export const ADD_MESSAGE_REACTION = gql`
+  mutation addMessageReaction($reaction: ReactionInput!) {
+    addMessageReaction(reaction: $reaction) {
+      userId
+      messageId
+      emoji
+    }
+  }
+`
+
+/**
+ * Update message reaction mutation
+ * Used by PostChatReactions component
+ */
+export const UPDATE_MESSAGE_REACTION = gql`
+  mutation updateReaction($_id: String!, $emoji: String!) {
+    updateReaction(_id: $_id, emoji: $emoji) {
+      _id
+      emoji
+    }
+  }
+`

--- a/quotevote-frontend/src/graphql/queries.ts
+++ b/quotevote-frontend/src/graphql/queries.ts
@@ -620,3 +620,18 @@ export const SEARCH_USERNAMES = gql`
     }
   }
 `
+
+/**
+ * Get message reactions query
+ * Used by PostChatReactions component
+ */
+export const GET_MESSAGE_REACTIONS = gql`
+  query messageReactions($messageId: String!) {
+    messageReactions(messageId: $messageId) {
+      _id
+      emoji
+      messageId
+      userId
+    }
+  }
+`

--- a/quotevote-frontend/src/types/postChat.ts
+++ b/quotevote-frontend/src/types/postChat.ts
@@ -1,0 +1,93 @@
+/**
+ * PostChat-related TypeScript types
+ * Used for post chat messages, reactions, and related components
+ */
+
+/**
+ * User information attached to a post chat message
+ */
+export interface PostChatUser {
+  /** Display name */
+  name: string
+  /** Username handle */
+  username: string
+  /** Avatar URL */
+  avatar?: string
+}
+
+/**
+ * Post chat message structure
+ */
+export interface PostChatMessageData {
+  /** Unique message identifier */
+  _id: string
+  /** Author user identifier */
+  userId: string
+  /** Text content of the message */
+  text: string
+  /** ISO timestamp of creation */
+  created: string
+  /** User details */
+  user: PostChatUser
+}
+
+/**
+ * Message reaction structure
+ */
+export interface MessageReaction {
+  /** Unique reaction identifier */
+  _id: string
+  /** Emoji character */
+  emoji: string
+  /** Message this reaction belongs to */
+  messageId: string
+  /** User who made this reaction */
+  userId: string
+}
+
+/**
+ * Props for PostChatMessage component
+ */
+export interface PostChatMessageProps {
+  /** The message data to display */
+  message: PostChatMessageData
+}
+
+/**
+ * Props for PostChatReactions component
+ */
+export interface PostChatReactionsProps {
+  /** ISO timestamp when message was created */
+  created: string
+  /** Message identifier for reactions */
+  messageId: string
+  /** Array of reactions on the message */
+  reactions?: MessageReaction[]
+  /** Whether message is from another user (affects styling) */
+  isDefaultDirection: boolean
+  /** Display name of message author */
+  userName: string
+  /** Username handle of message author */
+  username: string
+}
+
+/**
+ * Props for PostChatSend component
+ */
+export interface PostChatSendProps {
+  /** Room ID for the message (null if room doesn't exist yet) */
+  messageRoomId?: string | null
+  /** Title for the message/room */
+  title?: string
+  /** Post ID for creating room if needed */
+  postId?: string
+}
+
+/**
+ * Input for creating a new message reaction
+ */
+export interface ReactionInput {
+  userId: string
+  messageId: string
+  emoji: string
+}

--- a/quotevote-frontend/tsconfig.json
+++ b/quotevote-frontend/tsconfig.json
@@ -92,6 +92,12 @@
       "@/components/Quotes/*": [
         "./src/components/Quotes/*"
       ],
+      "@/components/PostChat/*": [
+        "./src/components/PostChat/*"
+      ],
+      "@/components/Chat/*": [
+        "./src/components/Chat/*"
+      ],
       "@/components/*": [
         "./src/app/components/*"
       ],


### PR DESCRIPTION
### **Summary**
Migrates the PostChat components from the legacy React 17/Material-UI codebase to the Next.js 16 architecture following project migration guidelines.  Closes: https://github.com/QuoteVote/quotevote-next/issues/45

Components migrated:

- PostChatMessage - Displays individual chat messages with speech bubbles
- PostChatReactions - Emoji reactions with picker for messages
- PostChatSend - Message input/send form

**Changes**

New Files

- src/components/PostChat/PostChatMessage.tsx
- src/components/PostChat/PostChatReactions.tsx
- src/components/PostChat/PostChatSend.tsx
- src/types/postChat.ts - TypeScript type definitions
- src/app/test-postchat/page.tsx - Temporary test page (to be removed)

<img width="741" height="609" alt="Screenshot 2025-12-14 at 12 45 26 AM" src="https://github.com/user-attachments/assets/b87da536-4e7c-4127-8f7b-db7275e7c88e" />
