### PR TITLE
feat: migrate RequestAccess components from MUI to shadcn/ui

### DIFF
--- a/quotevote-frontend/src/__tests__/components/RequestAccess/RequestAccessForm.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/RequestAccess/RequestAccessForm.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * RequestAccessForm Component Tests
+ * 
+ * Tests for the RequestAccessForm component
+ */
+
+import { render, screen, waitFor } from '../../utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { RequestAccessForm } from '@/components/RequestAccess/RequestAccessForm';
+
+// Mock toast
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+
+// Mock Apollo Client hooks
+const mockQuery = jest.fn();
+const mockMutation = jest.fn();
+const mockClient = {
+  query: mockQuery,
+};
+
+jest.mock('@apollo/client', () => {
+  const actual = jest.requireActual('@apollo/client');
+  return {
+    ...actual,
+    useApolloClient: () => mockClient,
+    useMutation: () => [
+      mockMutation,
+      { loading: false },
+    ],
+  };
+});
+
+describe('RequestAccessForm Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Default query response (no duplicate)
+    mockQuery.mockResolvedValue({
+      data: {
+        checkDuplicateEmail: [],
+      },
+    });
+    
+    // Default mutation response
+    mockMutation.mockResolvedValue({
+      data: {
+        requestUserAccess: {
+          _id: '123',
+          email: 'test@example.com',
+        },
+      },
+    });
+  });
+
+  it('renders the form correctly', () => {
+    render(<RequestAccessForm />);
+
+    expect(screen.getByPlaceholderText(/enter your email address/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /request invite/i })).toBeInTheDocument();
+    expect(screen.getByText(/you need an account to contribute/i)).toBeInTheDocument();
+  });
+
+  it('shows validation error for invalid email', async () => {
+    const user = userEvent.setup();
+    render(<RequestAccessForm />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+    const submitButton = screen.getByRole('button', { name: /request invite/i });
+
+    await user.type(emailInput, 'invalid-email');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/please enter a valid email address/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error for duplicate email', async () => {
+    const user = userEvent.setup();
+    
+    // Mock query to return duplicate email
+    mockQuery.mockResolvedValue({
+      data: {
+        checkDuplicateEmail: [{ _id: '1', email: 'existing@example.com' }],
+      },
+    });
+
+    render(<RequestAccessForm />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+    const submitButton = screen.getByRole('button', { name: /request invite/i });
+
+    await user.type(emailInput, 'existing@example.com');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/this email address has already been used to request an invite/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('submits form successfully with valid email', async () => {
+    const user = userEvent.setup();
+
+    render(<RequestAccessForm />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+    const submitButton = screen.getByRole('button', { name: /request invite/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Request submitted successfully!');
+    });
+  });
+
+  it('calls onSuccess callback when provided', async () => {
+    const user = userEvent.setup();
+    const onSuccess = jest.fn();
+
+    render(<RequestAccessForm onSuccess={onSuccess} />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+    const submitButton = screen.getByRole('button', { name: /request invite/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it('submits on Enter key press', async () => {
+    const user = userEvent.setup();
+
+    render(<RequestAccessForm />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+
+    await user.type(emailInput, 'test@example.com{Enter}');
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Request submitted successfully!');
+    });
+  });
+});
+

--- a/quotevote-frontend/src/app/test/request-access/page.tsx
+++ b/quotevote-frontend/src/app/test/request-access/page.tsx
@@ -1,0 +1,17 @@
+/**
+ * Test page for RequestAccess components
+ * 
+ * This page is used for testing the RequestAccess flow
+ */
+
+import { RequestAccessForm } from '@/components/RequestAccess/RequestAccessForm';
+
+export default function RequestAccessTestPage() {
+  return (
+    <div className="container mx-auto py-8">
+      <h1 className="text-3xl font-bold mb-8">Request Access Test Page</h1>
+      <RequestAccessForm />
+    </div>
+  );
+}
+

--- a/quotevote-frontend/src/components/RequestAccess/BusinessForm/BusinessForm.tsx
+++ b/quotevote-frontend/src/components/RequestAccess/BusinessForm/BusinessForm.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+/**
+ * BusinessForm Component
+ * 
+ * Multi-step form for business plan request access.
+ * Migrated from Material UI to shadcn/ui components.
+ */
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import Image from 'next/image';
+
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { businessFormSchema } from '@/lib/validation/requestAccessSchema';
+import type { BusinessFormProps } from '@/types/components';
+import { PaymentMethod } from '../PaymentMethod/PaymentMethod';
+
+export function BusinessForm({
+  requestInviteSuccessful,
+  handleSubmit: externalHandleSubmit,
+  isContinued: externalIsContinued,
+  onContinue: externalOnContinue,
+  errors: externalErrors,
+  register: externalRegister,
+  setCardDetails: externalSetCardDetails,
+  cardDetails: externalCardDetails,
+  onSubmit: externalOnSubmit,
+  errorMessage: externalErrorMessage,
+  loading: externalLoading,
+}: Partial<BusinessFormProps>) {
+  // Internal form state if not provided externally
+  const [internalIsContinued, setInternalIsContinued] = useState(false);
+  const [internalCardDetails, setInternalCardDetails] = useState({
+    cardNumber: '',
+    expiry: '',
+    cvv: '',
+    cost: '0',
+  });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(businessFormSchema),
+  });
+
+  // Use external props if provided, otherwise use internal state
+  const isContinued = externalIsContinued ?? internalIsContinued;
+  const cardDetails = externalCardDetails ?? internalCardDetails;
+  const setCardDetails = externalSetCardDetails ?? setInternalCardDetails;
+  const onSubmit = externalOnSubmit ?? (async () => {});
+  const errorMessage = externalErrorMessage;
+  const loading = externalLoading ?? false;
+
+  const onContinue = externalOnContinue ?? ((_data: { fullName: string; companyName: string; email: string }) => {
+    setInternalIsContinued(true);
+  });
+
+  const finalHandleSubmit = externalHandleSubmit ?? handleSubmit;
+  const finalRegister = externalRegister ?? register;
+  const finalErrors = externalErrors ?? errors;
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen py-12 px-4 mr-6">
+      <div className="w-full max-w-6xl">
+        <h1 className="text-center text-2xl md:text-4xl font-bold mb-4 md:mb-8">
+          {requestInviteSuccessful ? (
+            <>
+              Thank you for{' '}
+              <span className="text-[#52b274]">joining us</span>
+            </>
+          ) : (
+            <>
+              Get access to your{' '}
+              <span className="text-[#52b274]">Business Plan!</span>
+            </>
+          )}
+        </h1>
+
+        {!requestInviteSuccessful && (
+          <p className="text-center text-lg md:text-xl mb-8">
+            You are one step away from <b>unlimited access</b> to Quote Vote
+          </p>
+        )}
+
+        <div className="mt-8 md:mt-16">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
+            <div className="flex justify-center">
+              <Image
+                alt="Business Illustration"
+                src="/assets/Illustration.png"
+                width={400}
+                height={265}
+                className="w-[400px] h-[265px] object-contain"
+                priority
+              />
+            </div>
+
+            {requestInviteSuccessful ? (
+              <div className="flex justify-center items-center">
+                <p className="text-lg md:text-2xl leading-tight">
+                  <b>You selected the Business Plan</b>, and we are excited to
+                  talk with you.
+                  <br />
+                  <br />
+                  When an account becomes available, an invite will be sent to
+                  the email address you provided.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-6">
+                <Card>
+                  <CardHeader className="flex flex-row items-center gap-4">
+                    <div className="w-[22px] h-7 rounded-md bg-[#52b274] bg-opacity-85 font-roboto text-lg leading-[1.56] text-white px-1.5 py-0.5 flex items-center justify-center">
+                      1
+                    </div>
+                    <h3 className="font-roboto text-lg leading-[1.56]">
+                      Your Personal Info
+                    </h3>
+                  </CardHeader>
+
+                  {!isContinued && (
+                    <form onSubmit={finalHandleSubmit((data: unknown) => {
+                      onContinue(data as { fullName: string; companyName: string; email: string });
+                    })}>
+                      <CardContent className="space-y-4">
+                        <div className="grid grid-cols-2 gap-4">
+                          <div>
+                            <Label htmlFor="fullName">Full Name</Label>
+                            <Input
+                              id="fullName"
+                              {...finalRegister('fullName')}
+                              aria-invalid={!!finalErrors.fullName}
+                            />
+                            {finalErrors.fullName && (
+                              <p className="text-sm text-red-600 mt-1">
+                                {finalErrors.fullName.message}
+                              </p>
+                            )}
+                          </div>
+                          <div>
+                            <Label htmlFor="companyName">Company Name</Label>
+                            <Input
+                              id="companyName"
+                              {...finalRegister('companyName')}
+                              aria-invalid={!!finalErrors.companyName}
+                            />
+                            {finalErrors.companyName && (
+                              <p className="text-sm text-red-600 mt-1">
+                                {finalErrors.companyName.message}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                        <div>
+                          <Label htmlFor="email">Email</Label>
+                          <Input
+                            id="email"
+                            type="email"
+                            {...finalRegister('email')}
+                            aria-invalid={!!finalErrors.email}
+                          />
+                          {finalErrors.email && (
+                            <p className="text-sm text-red-600 mt-1">
+                              {finalErrors.email.message}
+                            </p>
+                          )}
+                        </div>
+                        <Button
+                          type="submit"
+                          className="bg-[#52b274] text-white hover:bg-[#52b274] float-right"
+                        >
+                          Continue
+                        </Button>
+                      </CardContent>
+                    </form>
+                  )}
+                </Card>
+
+                <PaymentMethod
+                  cardDetails={cardDetails}
+                  onSubmit={onSubmit}
+                  isContinued={isContinued}
+                  setCardDetails={setCardDetails}
+                  errorMessage={errorMessage}
+                  loading={loading}
+                  isPersonal={false}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/quotevote-frontend/src/components/RequestAccess/BusinessForm/index.ts
+++ b/quotevote-frontend/src/components/RequestAccess/BusinessForm/index.ts
@@ -1,0 +1,2 @@
+export { BusinessForm } from './BusinessForm';
+

--- a/quotevote-frontend/src/components/RequestAccess/CreditCardInput.tsx
+++ b/quotevote-frontend/src/components/RequestAccess/CreditCardInput.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+/**
+ * CreditCardInput Component
+ * 
+ * Component for credit card input with formatting for card number, expiry, and CVC.
+ * Migrated from Material UI to shadcn/ui components.
+ */
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { CreditCardInputProps } from '@/types/components';
+
+export function CreditCardInput({
+  cardNumberInputProps = {},
+  cardExpiryInputProps = {},
+  cardCVCInputProps = {},
+  containerStyle,
+  inputStyle,
+  customTextLabels,
+  fieldClassName = '',
+}: CreditCardInputProps) {
+  const formatCardNumber = (value: string): string => {
+    // Remove all non-digits
+    const v = value.replace(/\s+/g, '').replace(/[^0-9]/gi, '');
+    // Add spaces every 4 digits
+    const matches = v.match(/\d{4,16}/g);
+    const match = (matches && matches[0]) || '';
+    const parts: string[] = [];
+    for (let i = 0, len = match.length; i < len; i += 4) {
+      parts.push(match.substring(i, i + 4));
+    }
+    if (parts.length) {
+      return parts.join(' ');
+    }
+    return v;
+  };
+
+  const formatExpiry = (value: string): string => {
+    // Remove all non-digits
+    const v = value.replace(/\s+/g, '').replace(/[^0-9]/gi, '');
+    if (v.length >= 2) {
+      return `${v.substring(0, 2)}/${v.substring(2, 4)}`;
+    }
+    return v;
+  };
+
+  const handleCardNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const formatted = formatCardNumber(e.target.value);
+    e.target.value = formatted;
+    if (cardNumberInputProps.onChange) {
+      cardNumberInputProps.onChange(e);
+    }
+  };
+
+  const handleExpiryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const formatted = formatExpiry(e.target.value);
+    e.target.value = formatted;
+    if (cardExpiryInputProps.onChange) {
+      cardExpiryInputProps.onChange(e);
+    }
+  };
+
+  const handleCVCChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // Only allow digits and limit to 4 characters
+    const v = e.target.value.replace(/\D/g, '').substring(0, 4);
+    e.target.value = v;
+    if (cardCVCInputProps.onChange) {
+      cardCVCInputProps.onChange(e);
+    }
+  };
+
+  return (
+    <div className="space-y-4" style={containerStyle}>
+      <div>
+        <Label htmlFor="cardNumber">
+          {customTextLabels?.cardNumberPlaceholder || 'Card Number'}
+        </Label>
+        <Input
+          id="cardNumber"
+          {...cardNumberInputProps}
+          value={cardNumberInputProps.value || ''}
+          onChange={handleCardNumberChange}
+          maxLength={19} // 16 digits + 3 spaces
+          className={fieldClassName}
+          style={inputStyle}
+          placeholder="1234 5678 9012 3456"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <Label htmlFor="expiry">MM/YY</Label>
+          <Input
+            id="expiry"
+            {...cardExpiryInputProps}
+            value={cardExpiryInputProps.value || ''}
+            onChange={handleExpiryChange}
+            maxLength={5} // MM/YY format
+            className={fieldClassName}
+            style={inputStyle}
+            placeholder="MM/YY"
+          />
+        </div>
+        <div>
+          <Label htmlFor="cvc">CVC</Label>
+          <Input
+            id="cvc"
+            {...cardCVCInputProps}
+            value={cardCVCInputProps.value || ''}
+            onChange={handleCVCChange}
+            maxLength={4}
+            className={fieldClassName}
+            style={inputStyle}
+            placeholder="123"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/quotevote-frontend/src/components/RequestAccess/InfoSections.tsx
+++ b/quotevote-frontend/src/components/RequestAccess/InfoSections.tsx
@@ -1,0 +1,377 @@
+'use client';
+
+/**
+ * InfoSections Component
+ * 
+ * Informational sections about the platform mission and values.
+ * Migrated from Material UI to shadcn/ui components.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { ChevronUp } from 'lucide-react';
+import Image from 'next/image';
+
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+
+import { useMobileDetection } from '@/hooks/useResponsive';
+
+const DONATE_URL = 'mailto:admin@quote.vote';
+
+export function InfoSections() {
+  // Section references for scrolling and animations
+  const missionRef = useRef<HTMLDivElement>(null);
+  const missionSectionRef = useRef<HTMLDivElement>(null);
+  const textOnlyRef = useRef<HTMLDivElement>(null);
+  const votesRef = useRef<HTMLDivElement>(null);
+  const inviteRef = useRef<HTMLDivElement>(null);
+  const moderationRef = useRef<HTMLDivElement>(null);
+
+  // State for UI visibility and animations
+  const [showBackToTop, setShowBackToTop] = useState(false);
+  const [missionVisible, setMissionVisible] = useState(false);
+  const [textOnlyVisible, setTextOnlyVisible] = useState(false);
+  const [votesVisible, setVotesVisible] = useState(false);
+  const [inviteVisible, setInviteVisible] = useState(false);
+  const [moderationVisible, setModerationVisible] = useState(false);
+
+  const isMobileDevice = useMobileDetection();
+
+  // Animation for reveal effect
+  const getAnimationStyle = (isVisible: boolean) => ({
+    opacity: isVisible ? 1 : 0,
+    transform: isVisible ? 'translateY(0)' : 'translateY(50px)',
+    transition: 'opacity 0.8s ease-out, transform 0.8s ease-out',
+  });
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.location.hash === '#mission') {
+      missionRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, []);
+
+  useEffect(() => {
+    // Skip during SSR
+    if (typeof window === 'undefined') return;
+
+    // Show back-to-top after scrolling
+    const onScrollForTop = () => setShowBackToTop(window.scrollY > 300);
+    window.addEventListener('scroll', onScrollForTop);
+
+    // Fallback if IntersectionObserver not supported
+    if (!('IntersectionObserver' in window)) {
+      return () => window.removeEventListener('scroll', onScrollForTop);
+    }
+
+    // Observe each section for reveal animation
+    const mapping = new Map<Element, () => void>();
+    const observedItems = [
+      { ref: missionSectionRef, setter: setMissionVisible },
+      { ref: textOnlyRef, setter: setTextOnlyVisible },
+      { ref: votesRef, setter: setVotesVisible },
+      { ref: inviteRef, setter: setInviteVisible },
+      { ref: moderationRef, setter: setModerationVisible },
+    ];
+
+    const ioOptions = {
+      root: null, // viewport
+      rootMargin: '0px 0px -1% 0px', // trigger slightly before element fully enters viewport
+      threshold: 0.03, // ~3% visible to trigger
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const setter = mapping.get(entry.target);
+          if (setter) {
+            setter();
+            observer.unobserve(entry.target);
+          }
+        }
+      });
+    }, ioOptions);
+
+    // Start observing any mounted elements and record mapping
+    observedItems.forEach(({ ref, setter }) => {
+      if (ref.current) {
+        mapping.set(ref.current, () => setter(true));
+        observer.observe(ref.current);
+      }
+    });
+
+    // Cleanup
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('scroll', onScrollForTop);
+    };
+  }, []);
+
+  // Back-to-top behavior
+  const scrollToTop = () => {
+    if (typeof window === 'undefined') return;
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <>
+      {/* Accessibility: skip link (visually hidden) */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:rounded"
+      >
+        Skip to main content
+      </a>
+
+      <main
+        id="main-content"
+        role="main"
+        aria-label="Mission and Information"
+        className="min-h-screen"
+      >
+        <div
+          id="mission"
+          ref={missionRef}
+          className="max-w-[1400px] mx-auto px-4 py-8 md:py-16"
+        >
+          {/* Mission */}
+          <div
+            ref={missionSectionRef}
+            className="py-8 md:py-10 px-4 md:px-24"
+            style={getAnimationStyle(missionVisible)}
+          >
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-8 items-center">
+              <div className="md:col-span-4 flex items-center md:items-start justify-center md:justify-start">
+                <h1 className="text-2xl md:text-[2.3rem] font-normal text-black m-0 md:mr-24 mb-4 md:mb-2 text-center md:text-left">
+                  Mission
+                </h1>
+              </div>
+
+              <div className="md:col-span-8">
+                <blockquote className="italic text-base md:text-lg leading-relaxed my-2 md:my-4 py-4 md:py-5 px-4 md:px-5 border-l-4 border-[#52b274] bg-[#e8f5ed] rounded-r-[10px] text-[#2b5d3d] font-medium">
+                  &quot;Quote.Vote aspires to be a commons; a catalyst for
+                  consensus, not a contest for influence.&quot;
+                </blockquote>
+
+                <p className="text-sm md:text-base mb-3">
+                  Quote.Vote is a platform for genuine, in-depth discussions. It
+                  exists to protect and nurture civic discourse by creating a
+                  digital space where quoting and voting can flourish—without
+                  manipulation, algorithms, or advertising.
+                </p>
+                <p className="text-sm md:text-base mb-3">
+                  In today&apos;s social media environment, quick posts, outrage
+                  cycles, and engagement metrics dominate our attention. This
+                  place offers a structural alternative, one that values writing
+                  as a tool for reflection and conversation as a form of care.
+                </p>
+                <p className="text-sm md:text-base mb-3">
+                  This is not a startup, but rather a public utility for
+                  collective thought. It is designed to slow users down, not
+                  speed them up. It invites people to read carefully, reflect
+                  together, and vote deliberately.
+                </p>
+              </div>
+            </div>
+
+            <Separator className="mt-4 md:mt-6 bg-[#2b5d3d] opacity-20 h-[0.05rem]" />
+          </div>
+
+          {/* Deliberately Text-Only */}
+          <div
+            ref={textOnlyRef}
+            className="py-8 md:py-10 px-4 md:px-24"
+            style={getAnimationStyle(textOnlyVisible)}
+          >
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-8 items-center">
+              <div className="md:col-span-4 flex items-center md:items-start justify-center md:justify-start">
+                <h1 className="text-2xl md:text-[2.3rem] font-normal text-black m-0 md:mr-24 mb-4 md:mb-2 text-center md:text-left">
+                  Deliberately Text-Only
+                </h1>
+              </div>
+
+              <div className="md:col-span-8">
+                <blockquote className="italic text-base md:text-lg leading-relaxed my-2 md:my-4 py-4 md:py-5 px-4 md:px-5 border-l-4 border-[#52b274] bg-[#e8f5ed] rounded-r-[10px] text-[#2b5d3d] font-medium">
+                  &quot;Every aspect of the platform is intentional. Every
+                  constraint is a choice rooted in values.&quot;
+                </blockquote>
+
+                <p className="text-lg md:text-xl font-medium text-[#52b274] mb-3">
+                  No videos. No images. No audio.
+                </p>
+                <p className="text-sm md:text-base mb-3">
+                  Quotes are blocks of text that open public chatrooms called
+                  Quote Rooms—structured conversations anchored in clarity, and
+                  precise feedback.
+                </p>
+              </div>
+            </div>
+
+            <Separator className="mt-4 md:mt-6 bg-[#2b5d3d] opacity-20 h-[0.05rem]" />
+          </div>
+
+          {/* Votes */}
+          <div
+            ref={votesRef}
+            className="py-8 md:py-10 px-4 md:px-24"
+            style={getAnimationStyle(votesVisible)}
+          >
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-8 items-center">
+              <div className="md:col-span-4 flex items-center md:items-start justify-center md:justify-start">
+                <h1 className="text-2xl md:text-[2.3rem] font-normal text-black m-0 md:mr-24 mb-4 md:mb-2 text-center md:text-left">
+                  Votes, Not Likes
+                </h1>
+              </div>
+
+              <div className="md:col-span-8">
+                <p className="text-sm md:text-base mb-3">
+                  At any time, a quote can be put to a vote that an author can
+                  activate after submitting. Visitors choose to approve or
+                  disagree with ideas. No likes. A quote vote can not be undone
+                  after the toggle is clicked.
+                </p>
+              </div>
+            </div>
+
+            <Separator className="mt-4 md:mt-6 bg-[#2b5d3d] opacity-20 h-[0.05rem]" />
+          </div>
+
+          {/* Invite-only */}
+          <div
+            ref={inviteRef}
+            className="py-8 md:py-10 px-4 md:px-24"
+            style={getAnimationStyle(inviteVisible)}
+          >
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-8 items-center">
+              <div className="md:col-span-4 flex items-center md:items-start justify-center md:justify-start">
+                <h1 className="text-2xl md:text-[2.3rem] font-normal text-black m-0 md:mr-24 mb-4 md:mb-2 text-center md:text-left">
+                  Invite-Only Growth
+                </h1>
+              </div>
+
+              <div className="md:col-span-8">
+                <p className="text-sm md:text-base mb-3">
+                  Posting and quoting are gated through a vouching system. Each
+                  contributor takes responsibility for who they invite. The
+                  growth rate is controlled to protect community culture and
+                  avoid the pitfalls of viral scale.
+                </p>
+                <blockquote className="italic text-base md:text-lg leading-relaxed my-2 md:my-4 py-4 md:py-5 px-4 md:px-5 border-l-4 border-[#52b274] bg-[#e8f5ed] rounded-r-[10px] text-[#2b5d3d] font-medium">
+                  &quot;Quoting and voting are available to all, but the power
+                  to publish is earned through trust and intent.&quot;
+                </blockquote>
+              </div>
+            </div>
+
+            <Separator className="mt-4 md:mt-6 bg-[#2b5d3d] opacity-20 h-[0.05rem]" />
+          </div>
+
+          {/* Moderation */}
+          <div
+            ref={moderationRef}
+            className="py-8 md:py-10 px-4 md:px-24"
+            style={getAnimationStyle(moderationVisible)}
+          >
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-8 items-center">
+              <div className="md:col-span-4 flex items-center md:items-start justify-center md:justify-start">
+                <h1 className="text-2xl md:text-[2.3rem] font-normal text-black m-0 md:mr-24 mb-4 md:mb-2 text-center md:text-left">
+                  Civic Moderation by Reputation
+                </h1>
+              </div>
+
+              <div className="md:col-span-8">
+                <p className="text-sm md:text-base mb-3">
+                  Moderation isn&apos;t algorithmic or top-down. It&apos;s shared.
+                  Each use will be a crucial part of the moderation system, and
+                  when invites are shared with others, the referred user&apos;s
+                  behavior will impact reputation weighting. A user&apos;s invite
+                  tree grows to define the type of user they are following code
+                  of conducts and terms of service; downstream behavior reflects
+                  upstream.
+                </p>
+                <p className="text-sm md:text-base mb-3">
+                  Misconduct is a community responsibility. Every user is a
+                  moderator. Officially appointed moderators are compensated by
+                  the non-for profit entity that exchanges their time for
+                  monetary reward. All community members are facilitators tasked
+                  with protecting clarity about what is tolerated and what is
+                  not.
+                </p>
+              </div>
+            </div>
+
+            <Separator className="mt-4 md:mt-6 bg-[#2b5d3d] opacity-20 h-[0.05rem]" />
+          </div>
+        </div>
+
+        {/* Donate Section */}
+        <section className="my-12 mx-4">
+          <div className="flex flex-col items-center justify-center space-y-4 md:space-y-8">
+            <div className="flex items-center justify-center gap-4">
+              <Image
+                src="/assets/donate-emoji-1.svg"
+                alt="Donate Emoji 1"
+                width={60}
+                height={60}
+                className="hidden md:block"
+              />
+              <div className="flex flex-col justify-center items-center text-center max-w-md">
+                <p className="font-medium mb-4 text-base md:text-lg">
+                  Quote.Vote is non-profit, open source, and donation-supported.
+                </p>
+                <p className="font-medium mb-4 text-base md:text-lg">
+                  Our only funding comes from people like you.
+                </p>
+
+                <Button
+                  variant="default"
+                  className="font-medium text-lg"
+                  onClick={() => {
+                    window.location.href = DONATE_URL;
+                  }}
+                  size={isMobileDevice ? 'default' : 'lg'}
+                >
+                  Please Donate
+                </Button>
+              </div>
+              <Image
+                src="/assets/donate-emoji-2.svg"
+                alt="Donate Emoji 2"
+                width={60}
+                height={60}
+                className="hidden md:block"
+              />
+            </div>
+
+            <Image
+              src="/assets/group-image.svg"
+              alt="Group"
+              width={1200}
+              height={400}
+              className="w-full h-auto"
+            />
+          </div>
+        </section>
+      </main>
+
+      {/* Back to Top floating button */}
+      {showBackToTop && (
+        <div
+          className="fixed bottom-5 md:bottom-10 right-5 md:right-10 z-[1000]"
+          style={{
+            opacity: showBackToTop ? 1 : 0,
+            transition: 'opacity 0.3s ease',
+          }}
+        >
+          <Button
+            onClick={scrollToTop}
+            className="w-14 h-14 rounded-full bg-[#52b274] text-white shadow-[0_6px_20px_rgba(82,178,116,0.4)] transition-all duration-300 hover:translate-y-[-2px]"
+            aria-label="Back to top"
+          >
+            <ChevronUp className="w-7 h-7" />
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}
+

--- a/quotevote-frontend/src/components/RequestAccess/PaymentMethod/PaymentMethod.tsx
+++ b/quotevote-frontend/src/components/RequestAccess/PaymentMethod/PaymentMethod.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+/**
+ * PaymentMethod Component
+ * 
+ * Payment form component for credit card input and cost selection.
+ * Migrated from Material UI to shadcn/ui components.
+ */
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { paymentMethodSchema } from '@/lib/validation/requestAccessSchema';
+import type { PaymentMethodProps } from '@/types/components';
+import { CreditCardInput } from '../CreditCardInput';
+
+export function PaymentMethod({
+  isContinued,
+  cardDetails,
+  onSubmit,
+  setCardDetails,
+  isPersonal = true,
+  errorMessage,
+  loading,
+}: PaymentMethodProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+  } = useForm({
+    resolver: zodResolver(paymentMethodSchema),
+    defaultValues: {
+      cardNumber: cardDetails.cardNumber,
+      expiry: cardDetails.expiry,
+      cvv: cardDetails.cvv,
+      cost: cardDetails.cost,
+    },
+  });
+
+  const handleRequestAccess = () => {
+    if (!Object.keys(errors).length) {
+      onSubmit();
+    }
+  };
+
+  if (!isContinued) {
+    return null;
+  }
+
+  return (
+    <form onSubmit={handleSubmit(handleRequestAccess)}>
+      <Card>
+        <CardHeader className="flex flex-row items-center gap-4">
+          <div className="w-[22px] h-7 rounded-md bg-[#52b274] bg-opacity-85 font-roboto text-lg leading-[1.56] text-white px-1.5 py-0.5 flex items-center justify-center">
+            2
+          </div>
+          <h3 className="font-roboto text-lg leading-[1.56]">
+            Would you like to support this app?
+          </h3>
+        </CardHeader>
+
+        <input
+          type="hidden"
+          {...register('cardNumber', { required: !isPersonal })}
+        />
+        <input
+          type="hidden"
+          {...register('expiry', { required: !isPersonal })}
+        />
+        <input
+          type="hidden"
+          {...register('cvv', { required: !isPersonal })}
+        />
+
+        <CardContent className="space-y-4">
+          <p className="font-roboto text-base leading-[1.56] text-[#424556]">
+            Payment will not be charged until invite is sent
+          </p>
+
+          <CreditCardInput
+            cardNumberInputProps={{
+              autoFocus: !isPersonal,
+              value: cardDetails.cardNumber,
+              onChange: (e) => {
+                setValue('cardNumber', e.target.value);
+                setCardDetails({
+                  ...cardDetails,
+                  cardNumber: e.target.value,
+                });
+              },
+              onError: () => setValue('cardNumber', ''),
+            }}
+            cardExpiryInputProps={{
+              value: cardDetails.expiry,
+              onChange: (e) => {
+                setValue('expiry', e.target.value);
+                setCardDetails({
+                  ...cardDetails,
+                  expiry: e.target.value,
+                });
+              },
+              onError: () => setValue('expiry', ''),
+            }}
+            cardCVCInputProps={{
+              value: cardDetails.cvv,
+              onChange: (e) => {
+                setValue('cvv', e.target.value);
+                setCardDetails({
+                  ...cardDetails,
+                  cvv: e.target.value,
+                });
+              },
+              onError: () => setValue('cvv', ''),
+            }}
+            customTextLabels={{
+              cardNumberPlaceholder: 'Credit Card Number',
+            }}
+          />
+
+          <div className="grid grid-cols-2 gap-4 items-center">
+            {isPersonal && (
+              <div>
+                <Label htmlFor="cost">Cost</Label>
+                <Input
+                  id="cost"
+                  type="number"
+                  value={cardDetails.cost}
+                  onChange={(e) =>
+                    setCardDetails({ ...cardDetails, cost: e.target.value })
+                  }
+                />
+              </div>
+            )}
+            <div className={isPersonal ? 'col-span-1' : 'col-span-2'}>
+              <p className="font-roboto text-lg leading-[1.56] text-center font-bold">
+                Total: ${cardDetails.cost}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <img
+              alt="stripe"
+              src="/assets/stripe.png"
+              className="w-[90px] h-[19px] opacity-40"
+            />
+            <Button
+              type="submit"
+              disabled={loading}
+              className="bg-[#52b274] text-white hover:bg-[#52b274] relative"
+            >
+              {loading && (
+                <Loader2 className="mr-2 h-5 w-5 animate-spin absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2" />
+              )}
+              <span className={loading ? 'opacity-0' : ''}>Request Invite</span>
+            </Button>
+          </div>
+
+          {errorMessage && (
+            <div className="mt-2.5">
+              <span className="font-roboto text-red-600">
+                Error: {errorMessage}
+              </span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </form>
+  );
+}
+

--- a/quotevote-frontend/src/components/RequestAccess/PaymentMethod/index.ts
+++ b/quotevote-frontend/src/components/RequestAccess/PaymentMethod/index.ts
@@ -1,0 +1,2 @@
+export { PaymentMethod } from './PaymentMethod';
+

--- a/quotevote-frontend/src/components/RequestAccess/PersonalForm/PersonalForm.tsx
+++ b/quotevote-frontend/src/components/RequestAccess/PersonalForm/PersonalForm.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+/**
+ * PersonalForm Component
+ * 
+ * Multi-step form for personal plan request access.
+ * Migrated from Material UI to shadcn/ui components.
+ */
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import Image from 'next/image';
+
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { personalFormSchema } from '@/lib/validation/requestAccessSchema';
+import type { PersonalFormProps } from '@/types/components';
+import { PaymentMethod } from '../PaymentMethod/PaymentMethod';
+
+export function PersonalForm({
+  requestInviteSuccessful,
+  handleSubmit: externalHandleSubmit,
+  isContinued: externalIsContinued,
+  onContinue: externalOnContinue,
+  errors: externalErrors,
+  register: externalRegister,
+  setCardDetails: externalSetCardDetails,
+  cardDetails: externalCardDetails,
+  onSubmit: externalOnSubmit,
+  errorMessage: externalErrorMessage,
+  loading: externalLoading,
+}: Partial<PersonalFormProps>) {
+  // Internal form state if not provided externally
+  const [internalIsContinued, setInternalIsContinued] = useState(false);
+  const [internalCardDetails, setInternalCardDetails] = useState({
+    cardNumber: '',
+    expiry: '',
+    cvv: '',
+    cost: '0',
+  });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(personalFormSchema),
+  });
+
+  // Use external props if provided, otherwise use internal state
+  const isContinued = externalIsContinued ?? internalIsContinued;
+  const cardDetails = externalCardDetails ?? internalCardDetails;
+  const setCardDetails = externalSetCardDetails ?? setInternalCardDetails;
+  const onSubmit = externalOnSubmit ?? (async () => {});
+  const errorMessage = externalErrorMessage;
+  const loading = externalLoading ?? false;
+
+  const onContinue = externalOnContinue ?? ((_data: { firstName: string; lastName: string; email: string }) => {
+    setInternalIsContinued(true);
+  });
+
+  const finalHandleSubmit = externalHandleSubmit ?? handleSubmit;
+  const finalRegister = externalRegister ?? register;
+  const finalErrors = externalErrors ?? errors;
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen py-12 px-4">
+      <div className="w-full max-w-6xl">
+        <h1 className="text-center text-2xl md:text-4xl font-bold mb-4 md:mb-8">
+          {requestInviteSuccessful ? (
+            <>
+              Thank you for{' '}
+              <span className="text-[#52b274]">joining us</span>
+            </>
+          ) : (
+            <>
+              Get access to your{' '}
+              <span className="text-[#52b274]">Personal Plan!</span>
+            </>
+          )}
+        </h1>
+
+        {!requestInviteSuccessful && (
+          <p className="text-center text-lg md:text-xl mb-8">
+            Pay what you like, or pay nothing at all
+          </p>
+        )}
+
+        <div className="mt-8 md:mt-16">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
+            <div className="flex justify-center">
+              <Image
+                alt="Personal Plan"
+                src="/assets/PersonalPlan.png"
+                width={489}
+                height={350}
+                className="w-full max-w-[489px] h-auto max-h-[35vh] object-contain mx-auto"
+                priority
+              />
+            </div>
+
+            {requestInviteSuccessful ? (
+              <div className="flex justify-center items-center py-4">
+                <div className="bg-black bg-opacity-50 p-8 md:p-12 rounded-xl text-white text-center max-w-[60%] md:max-w-[400px] mx-auto">
+                  <p className="text-lg md:text-2xl leading-tight">
+                    When an account becomes available, an invite will be sent
+                    to the email address you provided.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-6">
+                <Card>
+                  <CardHeader className="flex flex-row items-center gap-4">
+                    <div className="w-[22px] h-7 rounded-md bg-[#52b274] bg-opacity-85 font-roboto text-lg leading-[1.56] text-white px-1.5 py-0.5 flex items-center justify-center">
+                      1
+                    </div>
+                    <h3 className="font-roboto text-lg leading-[1.56]">
+                      Your Personal Info
+                    </h3>
+                  </CardHeader>
+
+                  {!isContinued && (
+                    <form onSubmit={finalHandleSubmit((data: unknown) => {
+                      onContinue(data as { firstName: string; lastName: string; email: string });
+                    })}>
+                      <CardContent className="space-y-4">
+                        <div className="grid grid-cols-2 gap-4">
+                          <div>
+                            <Label htmlFor="firstName">First Name</Label>
+                            <Input
+                              id="firstName"
+                              {...finalRegister('firstName')}
+                              aria-invalid={!!finalErrors.firstName}
+                            />
+                            {finalErrors.firstName && (
+                              <p className="text-sm text-red-600 mt-1">
+                                {finalErrors.firstName.message}
+                              </p>
+                            )}
+                          </div>
+                          <div>
+                            <Label htmlFor="lastName">Last Name</Label>
+                            <Input
+                              id="lastName"
+                              {...finalRegister('lastName')}
+                              aria-invalid={!!finalErrors.lastName}
+                            />
+                            {finalErrors.lastName && (
+                              <p className="text-sm text-red-600 mt-1">
+                                {finalErrors.lastName.message}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                        <div>
+                          <Label htmlFor="email">Email</Label>
+                          <Input
+                            id="email"
+                            type="email"
+                            {...finalRegister('email')}
+                            aria-invalid={!!finalErrors.email}
+                          />
+                          {finalErrors.email && (
+                            <p className="text-sm text-red-600 mt-1">
+                              {finalErrors.email.message}
+                            </p>
+                          )}
+                        </div>
+                        <Button
+                          type="submit"
+                          className="bg-[#52b274] text-white hover:bg-[#52b274] float-right"
+                        >
+                          Continue
+                        </Button>
+                      </CardContent>
+                    </form>
+                  )}
+                </Card>
+
+                <PaymentMethod
+                  cardDetails={cardDetails}
+                  onSubmit={onSubmit}
+                  isContinued={isContinued}
+                  setCardDetails={setCardDetails}
+                  errorMessage={errorMessage}
+                  loading={loading}
+                  isPersonal={true}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/quotevote-frontend/src/components/RequestAccess/PersonalForm/index.ts
+++ b/quotevote-frontend/src/components/RequestAccess/PersonalForm/index.ts
@@ -1,0 +1,2 @@
+export { PersonalForm } from './PersonalForm';
+

--- a/quotevote-frontend/src/components/RequestAccess/Plans/Plans.tsx
+++ b/quotevote-frontend/src/components/RequestAccess/Plans/Plans.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+/**
+ * Plans Component
+ * 
+ * Component for selecting plan type (Personal, Business, Investors).
+ * Migrated from Material UI to shadcn/ui components.
+ */
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { isMobile } from 'react-device-detect';
+import Image from 'next/image';
+
+import { Button } from '@/components/ui/button';
+
+import { useAppStore } from '@/store';
+import type { PlansProps } from '@/types/components';
+
+export function Plans({}: PlansProps) {
+  const router = useRouter();
+  const setSelectedPlan = useAppStore((state) => state.setSelectedPlan);
+  const userData = useAppStore((state) => state.user.data);
+
+  useEffect(() => {
+    // Check if user is logged in and redirect if so
+    if (userData && '_id' in userData && userData._id) {
+      router.push('/search');
+    }
+  }, [userData, router]);
+
+  const handlePlanSelection = (type: 'personal' | 'business' | 'investors') => {
+    setSelectedPlan(type);
+    router.push('/auth/plans');
+  };
+
+  const buttonList = (
+    <div className="flex flex-col space-y-4 items-center justify-evenly">
+      <Button
+        variant="outline"
+        onClick={() => handlePlanSelection('personal')}
+        className="w-full max-w-xs"
+      >
+        Personal
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() => handlePlanSelection('business')}
+        className="w-full max-w-xs"
+      >
+        Business
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() => handlePlanSelection('investors')}
+        className="w-full max-w-xs"
+      >
+        Investors
+      </Button>
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-4">
+      <div className="w-full max-w-6xl">
+        <div className="flex flex-col items-center justify-center">
+          <h1 className="text-3xl md:text-4xl font-bold mb-8 md:mb-12">
+            Select To Learn More
+          </h1>
+
+          {/* Mobile view */}
+          {isMobile && buttonList}
+
+          {/* Desktop view */}
+          {!isMobile && (
+            <div className="flex flex-row items-center justify-evenly w-full gap-8">
+              <div className="flex flex-col items-center">
+                <Image
+                  className="w-[200px] h-[140px] mb-4"
+                  src="/assets/PersonalPlanAvatar.png"
+                  alt="personal"
+                  width={200}
+                  height={140}
+                />
+                <Button
+                  variant="outline"
+                  onClick={() => handlePlanSelection('personal')}
+                  className="w-full max-w-xs"
+                >
+                  Personal
+                </Button>
+              </div>
+              <div className="flex flex-col items-center">
+                <Image
+                  className="w-[200px] h-[140px] mb-4"
+                  src="/assets/BusinessPlanAvatar.png"
+                  alt="business"
+                  width={200}
+                  height={140}
+                />
+                <Button
+                  variant="outline"
+                  onClick={() => handlePlanSelection('business')}
+                  className="w-full max-w-xs"
+                >
+                  Business
+                </Button>
+              </div>
+              <div className="flex flex-col items-center">
+                <Image
+                  className="w-[200px] h-[140px] mb-4"
+                  src="/assets/InvestorPlanAvatar.png"
+                  alt="investor"
+                  width={200}
+                  height={140}
+                />
+                <Button
+                  variant="outline"
+                  onClick={() => handlePlanSelection('investors')}
+                  className="w-full max-w-xs"
+                >
+                  Investors
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/quotevote-frontend/src/components/RequestAccess/Plans/index.ts
+++ b/quotevote-frontend/src/components/RequestAccess/Plans/index.ts
@@ -1,0 +1,2 @@
+export { Plans } from './Plans';
+

--- a/quotevote-frontend/src/components/RequestAccess/RequestAccessForm.tsx
+++ b/quotevote-frontend/src/components/RequestAccess/RequestAccessForm.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+/**
+ * RequestAccessForm Component
+ * 
+ * Form component for requesting platform access via email invitation.
+ * Migrated from Material UI to shadcn/ui components.
+ */
+
+import { useState } from 'react';
+// @ts-expect-error - Apollo Client v4.0.9 has type resolution issues with useMutation and useApolloClient exports
+import { useApolloClient, useMutation } from '@apollo/client';
+import Link from 'next/link';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { REQUEST_USER_ACCESS_MUTATION } from '@/graphql/mutations';
+import { GET_CHECK_DUPLICATE_EMAIL } from '@/graphql/queries';
+import { requestAccessEmailSchema } from '@/lib/validation/requestAccessSchema';
+import type { RequestAccessFormProps } from '@/types/components';
+import { PersonalForm } from './PersonalForm';
+
+export function RequestAccessForm({ onSuccess }: RequestAccessFormProps) {
+  const [userDetails, setUserDetails] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [requestInviteSuccessful, setRequestInviteSuccessful] = useState(false);
+
+  const client = useApolloClient();
+  const [requestUserAccess, { loading }] = useMutation(
+    REQUEST_USER_ACCESS_MUTATION
+  );
+
+  const onSubmit = async () => {
+    setErrorMessage('');
+
+    // Validate email using Zod schema
+    const validationResult = requestAccessEmailSchema.safeParse({
+      email: userDetails,
+    });
+
+    if (!validationResult.success) {
+      setErrorMessage(validationResult.error.issues[0]?.message || 'Please enter a valid email address');
+      return;
+    }
+
+    try {
+      // Check for duplicate email
+      const { data } = await client.query({
+        query: GET_CHECK_DUPLICATE_EMAIL,
+        variables: { email: userDetails },
+        fetchPolicy: 'network-only',
+      });
+
+      const hasDuplicatedEmail = data?.checkDuplicateEmail?.length > 0;
+      if (hasDuplicatedEmail) {
+        setErrorMessage(
+          'This email address has already been used to request an invite.'
+        );
+        return;
+      }
+
+      // Submit request
+      const requestUserAccessInput = { email: userDetails };
+      await requestUserAccess({ variables: { requestUserAccessInput } });
+      setRequestInviteSuccessful(true);
+      toast.success('Request submitted successfully!');
+      if (onSuccess) onSuccess();
+    } catch (err) {
+      const error = err as Error;
+      if (error.message.includes('email: Path `email` is required.')) {
+        setErrorMessage('Email is required');
+      } else {
+        setErrorMessage('An unexpected error occurred. Please try again later.');
+        toast.error('Failed to submit request');
+      }
+    }
+  };
+
+  if (requestInviteSuccessful) {
+    return <PersonalForm requestInviteSuccessful={requestInviteSuccessful} />;
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full space-y-4 p-4">
+      <div className="w-full max-w-md">
+        <p className="text-center text-gray-800 mb-4 text-sm md:text-base leading-relaxed font-medium">
+          You need an account to contribute. Viewing is public, but posting,
+          voting, and quoting require an invite.
+        </p>
+
+        <div className="bg-gradient-to-br from-gray-50 to-gray-100 rounded-xl p-5 my-3 border-2 border-gray-200 transition-all duration-300 focus-within:border-[#52b274] focus-within:shadow-[0_0_0_4px_rgba(82,178,116,0.1)] focus-within:bg-gradient-to-br focus-within:from-white focus-within:to-gray-50">
+          <Label htmlFor="email" className="sr-only">
+            Email Address
+          </Label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="Enter Your Email Address"
+            value={userDetails}
+            onChange={(e) => setUserDetails(e.target.value)}
+            onKeyPress={(e) => {
+              if (e.key === 'Enter') {
+                onSubmit();
+              }
+            }}
+            className="bg-transparent border-none outline-none w-full text-base md:text-lg text-gray-800 font-medium p-0 placeholder:text-gray-500 placeholder:font-normal"
+          />
+        </div>
+
+        <div className="text-center mt-4 mb-2">
+          <Link
+            href="/auth/request-access#mission"
+            className="text-[#52b274] no-underline text-sm md:text-base font-medium transition-colors duration-300 hover:text-[#4a9f63] hover:underline"
+          >
+            Learn more about our mission here
+          </Link>
+        </div>
+
+        <Button
+          onClick={onSubmit}
+          disabled={loading}
+          className="w-full mt-6 py-3.5 px-6 text-base md:text-lg font-semibold bg-[#52b274] text-white rounded-[10px] shadow-[0_4px_12px_rgba(82,178,116,0.3)] transition-all duration-300 border-none cursor-pointer hover:bg-[#4a9f63] hover:shadow-[0_6px_16px_rgba(82,178,116,0.4)] hover:-translate-y-0.5 disabled:bg-gray-300 disabled:cursor-not-allowed disabled:shadow-none disabled:hover:translate-y-0"
+        >
+          {loading ? 'Sending...' : 'Request Invite'}
+        </Button>
+
+        {errorMessage && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-3 mt-4 text-center">
+            <p className="text-red-700 text-sm md:text-base font-medium m-0">
+              {errorMessage}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/quotevote-frontend/src/components/RequestAccess/index.ts
+++ b/quotevote-frontend/src/components/RequestAccess/index.ts
@@ -1,0 +1,8 @@
+export { RequestAccessForm } from './RequestAccessForm';
+export { PersonalForm } from './PersonalForm';
+export { BusinessForm } from './BusinessForm';
+export { PaymentMethod } from './PaymentMethod';
+export { CreditCardInput } from './CreditCardInput';
+export { Plans } from './Plans';
+export { InfoSections } from './InfoSections';
+

--- a/quotevote-frontend/src/graphql/mutations.ts
+++ b/quotevote-frontend/src/graphql/mutations.ts
@@ -504,3 +504,16 @@ export const DELETE_NOTIFICATION = gql`
     }
   }
 `
+
+/**
+ * Request user access mutation
+ * Used for requesting platform access via email invitation
+ */
+export const REQUEST_USER_ACCESS_MUTATION = gql`
+  mutation requestUserAccess($requestUserAccessInput: RequestUserAccessInput!) {
+    requestUserAccess(requestUserAccessInput: $requestUserAccessInput) {
+      _id
+      email
+    }
+  }
+`

--- a/quotevote-frontend/src/graphql/queries.ts
+++ b/quotevote-frontend/src/graphql/queries.ts
@@ -733,3 +733,13 @@ export const GET_NOTIFICATIONS = gql`
     }
   }
 `
+
+/**
+ * Check duplicate email query
+ * Used to verify if an email has already been used to request an invite
+ */
+export const GET_CHECK_DUPLICATE_EMAIL = gql`
+  query checkDuplicateEmail($email: String!) {
+    checkDuplicateEmail(email: $email)
+  }
+`

--- a/quotevote-frontend/src/lib/validation/requestAccessSchema.ts
+++ b/quotevote-frontend/src/lib/validation/requestAccessSchema.ts
@@ -1,0 +1,98 @@
+/**
+ * Zod validation schemas for RequestAccess forms
+ */
+
+import { z } from 'zod';
+
+/**
+ * Email validation pattern matching the original regex
+ */
+const EMAIL_PATTERN = /^(("[\w-+\s]+")|([\w-+]+(?:\.[\w-+]+)*)|("[\w-+\s]+")([\w-+]+(?:\.[\w-+]+)*))(@((?:[\w-+]+\.)*\w[\w-+]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$)|(@\[?((25[0-5]\.|2[0-4][\d]\.|1[\d]{2}\.|[\d]{1,2}\.))((25[0-5]|2[0-4][\d]|1[\d]{2}|[\d]{1,2})\.){2}(25[0-5]|2[0-4][\d]|1[\d]{2}|[\d]{1,2})\]?$)/i;
+
+/**
+ * Schema for email-only request access form
+ */
+export const requestAccessEmailSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'Email is required')
+    .regex(EMAIL_PATTERN, 'Please enter a valid email address'),
+});
+
+export type RequestAccessEmailFormData = z.infer<typeof requestAccessEmailSchema>;
+
+/**
+ * Schema for personal form (first step)
+ */
+export const personalFormSchema = z.object({
+  firstName: z
+    .string()
+    .min(1, 'First Name is required')
+    .min(1, 'First Name should be more than 1 character')
+    .max(20, 'First Name should be less than twenty characters'),
+  lastName: z
+    .string()
+    .min(1, 'Last Name is required')
+    .min(1, 'Last Name should be more than 1 character')
+    .max(20, 'Last Name should be less than twenty characters'),
+  email: z
+    .string()
+    .min(1, 'Email is required')
+    .email('Invalid email address'),
+});
+
+export type PersonalFormData = z.infer<typeof personalFormSchema>;
+
+/**
+ * Schema for business form (first step)
+ */
+export const businessFormSchema = z.object({
+  fullName: z
+    .string()
+    .min(1, 'Full Name is required')
+    .min(1, 'Full Name should be more than 1 character')
+    .max(20, 'Full Name should be less than twenty characters'),
+  companyName: z
+    .string()
+    .min(1, 'Company Name is required')
+    .min(1, 'Company Name should be more than 1 character')
+    .max(20, 'Company Name should be less than twenty characters'),
+  email: z
+    .string()
+    .min(1, 'Email is required')
+    .email('Invalid email address'),
+});
+
+export type BusinessFormData = z.infer<typeof businessFormSchema>;
+
+/**
+ * Schema for payment method form
+ */
+export const paymentMethodSchema = z.object({
+  cardNumber: z
+    .string()
+    .min(1, 'Card number is required')
+    .regex(/^[\d\s]{13,19}$/, 'Invalid card number'),
+  expiry: z
+    .string()
+    .min(1, 'Expiry date is required')
+    .regex(/^\d{2}\/\d{2}$/, 'Invalid expiry date (MM/YY format)'),
+  cvv: z
+    .string()
+    .min(1, 'CVC is required')
+    .regex(/^\d{3,4}$/, 'Invalid CVC'),
+  cost: z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (!val) return true; // Optional for business plan
+        const num = parseFloat(val);
+        return !isNaN(num) && num >= 0;
+      },
+      { message: 'Cost must be a valid number' }
+    ),
+});
+
+export type PaymentMethodFormData = z.infer<typeof paymentMethodSchema>;
+

--- a/quotevote-frontend/src/types/components.ts
+++ b/quotevote-frontend/src/types/components.ts
@@ -718,3 +718,195 @@ export interface LatestQuotesProps {
   limit?: number;
 }
 
+// RequestAccess Component Types
+export interface RequestAccessFormProps {
+  /**
+   * Callback function called when request is successful
+   */
+  onSuccess?: () => void;
+}
+
+export interface CardDetails {
+  cardNumber: string;
+  expiry: string;
+  cvv: string;
+  cost: string;
+}
+
+export interface PersonalFormProps {
+  /**
+   * Whether the request invite was successful
+   */
+  requestInviteSuccessful: boolean;
+  /**
+   * React Hook Form handleSubmit function
+   */
+  handleSubmit: (onSubmit: (data: unknown) => void) => (e?: React.BaseSyntheticEvent) => Promise<void>;
+  /**
+   * Whether the form has been continued to payment step
+   */
+  isContinued: boolean;
+  /**
+   * Callback when continue button is clicked
+   */
+  onContinue: (data: { firstName: string; lastName: string; email: string }) => void;
+  /**
+   * Form errors from react-hook-form
+   */
+  errors: Record<string, { message?: string }>;
+  /**
+   * React Hook Form register function
+   */
+  register: (rules?: unknown) => (ref: HTMLInputElement | null) => void;
+  /**
+   * Callback to set card details
+   */
+  setCardDetails: (details: CardDetails | ((prev: CardDetails) => CardDetails)) => void;
+  /**
+   * Current card details
+   */
+  cardDetails: CardDetails;
+  /**
+   * Callback when form is submitted
+   */
+  onSubmit: () => void | Promise<void>;
+  /**
+   * Error message to display
+   */
+  errorMessage?: string | null;
+  /**
+   * Whether the form is in loading state
+   */
+  loading?: boolean;
+}
+
+export interface BusinessFormProps {
+  /**
+   * Whether the request invite was successful
+   */
+  requestInviteSuccessful: boolean;
+  /**
+   * React Hook Form handleSubmit function
+   */
+  handleSubmit: (onSubmit: (data: unknown) => void) => (e?: React.BaseSyntheticEvent) => Promise<void>;
+  /**
+   * Whether the form has been continued to payment step
+   */
+  isContinued: boolean;
+  /**
+   * Callback when continue button is clicked
+   */
+  onContinue: (data: { fullName: string; companyName: string; email: string }) => void;
+  /**
+   * Form errors from react-hook-form
+   */
+  errors: Record<string, { message?: string }>;
+  /**
+   * React Hook Form register function
+   */
+  register: (rules?: unknown) => (ref: HTMLInputElement | null) => void;
+  /**
+   * Callback to set card details
+   */
+  setCardDetails: (details: CardDetails | ((prev: CardDetails) => CardDetails)) => void;
+  /**
+   * Current card details
+   */
+  cardDetails: CardDetails;
+  /**
+   * Callback when form is submitted
+   */
+  onSubmit: () => void | Promise<void>;
+  /**
+   * Error message to display
+   */
+  errorMessage?: string | null;
+  /**
+   * Whether the form is in loading state
+   */
+  loading?: boolean;
+}
+
+export interface PaymentMethodProps {
+  /**
+   * Whether the form has been continued to payment step
+   */
+  isContinued: boolean;
+  /**
+   * Current card details
+   */
+  cardDetails: CardDetails;
+  /**
+   * Callback when form is submitted
+   */
+  onSubmit: () => void | Promise<void>;
+  /**
+   * Callback to set card details
+   */
+  setCardDetails: (details: CardDetails | ((prev: CardDetails) => CardDetails)) => void;
+  /**
+   * Whether this is for personal plan (allows custom cost)
+   * @default true
+   */
+  isPersonal?: boolean;
+  /**
+   * Error message to display
+   */
+  errorMessage?: string | null;
+  /**
+   * Whether the form is in loading state
+   */
+  loading?: boolean;
+}
+
+export interface CreditCardInputProps {
+  /**
+   * Props for card number input
+   */
+  cardNumberInputProps?: {
+    value?: string;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onError?: () => void;
+    autoFocus?: boolean;
+    inputProps?: Record<string, unknown>;
+  };
+  /**
+   * Props for expiry input
+   */
+  cardExpiryInputProps?: {
+    value?: string;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onError?: () => void;
+    inputProps?: Record<string, unknown>;
+  };
+  /**
+   * Props for CVC input
+   */
+  cardCVCInputProps?: {
+    value?: string;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onError?: () => void;
+    inputProps?: Record<string, unknown>;
+  };
+  /**
+   * Container style
+   */
+  containerStyle?: React.CSSProperties;
+  /**
+   * Input style
+   */
+  inputStyle?: React.CSSProperties;
+  /**
+   * Custom text labels
+   */
+  customTextLabels?: {
+    cardNumberPlaceholder?: string;
+  };
+  /**
+   * Field class name
+   */
+  fieldClassName?: string;
+}
+
+export type PlansProps = Record<string, never>;
+


### PR DESCRIPTION
## Migrate RequestAccess Components from MUI to shadcn/ui

### Summary
Migrates all RequestAccess components from the old client (Material UI) to the new Next.js frontend (shadcn/ui), converting JSX to TypeScript and updating to the v2 design system.

### Changes
- Migrated components: `RequestAccessForm`, `PersonalForm`, `BusinessForm`, `PaymentMethod`, `CreditCardInput`, `Plans`, `InfoSections`
- Replaced Material UI with shadcn/ui primitives (Button, Input, Label, Card, etc.)
- Converted all `.jsx` files to `.tsx` with TypeScript types
- Added Zod validation schemas with react-hook-form
- Added GraphQL operations: `REQUEST_USER_ACCESS_MUTATION`, `GET_CHECK_DUPLICATE_EMAIL`
- Added TypeScript types in `@/types/components.ts`
- Replaced Redux with Zustand for plan selection
- Replaced React Router with Next.js navigation
- Added tests for `RequestAccessForm`
- Created test page at `app/test/request-access/page.tsx`

### Testing
- All components render correctly
- Form validation works for required fields
- Email validation and duplicate checking functional
- Tests pass for RequestAccessForm component
- Test page available at `/test/request-access`

### Type Safety
- No `any` types used
- All types properly defined in `@/types/`
- TypeScript compiles without errors

Closes #54