### PR TITLE
feat: migrate SearchContainer components from MUI to shadcn/ui

### DIFF
--- a/quotevote-frontend/src/components/SearchContainer/SearchResults.tsx
+++ b/quotevote-frontend/src/components/SearchContainer/SearchResults.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import Link from 'next/link'
+import { Card, CardHeader, CardContent } from '@/components/ui/card'
+import { LoadingSpinner } from '@/components/LoadingSpinner'
+import type { SearchResultsProps } from '@/types/components'
+import { cn } from '@/lib/utils'
+
+/**
+ * SearchResultsView Component
+ * 
+ * Displays search results for content and creators in categorized sections.
+ * Shows loading state, error state, and empty state messages.
+ * 
+ * @param searchResults - Search results data from GraphQL query
+ * @param isLoading - Whether the search is currently loading
+ * @param isError - Error object if search failed
+ */
+export default function SearchResultsView({
+  searchResults,
+  isLoading = false,
+  isError = null,
+}: SearchResultsProps) {
+  // Show error state
+  if (isError) {
+    return (
+      <Card className="z-20 p-2">
+        <CardContent className="p-4">
+          <p className="text-sm text-destructive">
+            An error has occurred.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="z-10 overflow-y-scroll h-full max-h-full">
+      {/* Loading state */}
+      {isLoading ? (
+        <Card className="z-20 p-2">
+          <CardContent className="flex items-center justify-center p-4">
+            <LoadingSpinner size={24} />
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {/* Iterate over search result categories */}
+          {Object.keys(searchResults).map((resultCategory, id) => {
+            const category = searchResults[resultCategory as keyof typeof searchResults]
+
+            // Handle array results
+            if (!Array.isArray(category)) {
+              return null
+            }
+
+            // Empty results
+            if (category.length === 0) {
+              let typename = ''
+              switch (resultCategory) {
+                case 'searchCreator':
+                  typename = 'Username'
+                  break
+                case 'searchContent':
+                  typename = 'Content'
+                  break
+                default:
+                  typename = ''
+                  break
+              }
+
+              return (
+                <Card
+                  key={`${resultCategory}${id}`}
+                  className="z-10 flex flex-col bg-gray-50"
+                >
+                  <CardHeader className="table-cell text-ellipsis w-[100px] whitespace-nowrap bg-transparent text-base py-2 px-4 font-bold text-gray-500 border-b border-gray-200">
+                    {typename}
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-gray-600">No Results</p>
+                  </CardContent>
+                </Card>
+              )
+            }
+
+            // Results with data
+            const isUser = resultCategory === 'searchCreator'
+            const typename = category[0]?.__typename || (isUser ? 'User' : 'Content')
+
+            return (
+              <Card
+                key={`${resultCategory}${id}`}
+                className="z-10 flex flex-col bg-gray-50"
+              >
+                <CardHeader className="table-cell text-ellipsis w-[100px] whitespace-nowrap bg-transparent text-base py-2 px-4 font-bold text-gray-500 border-b border-gray-200">
+                  {typename}
+                </CardHeader>
+                <CardContent className="w-full table-cell bg-white border-l border-gray-300 border-b-2 border-gray-200 rounded-b-md">
+                  {category.map((content) => {
+                    const result = isUser
+                      ? (content as { name: string }).name
+                      : (content as { title: string }).title
+                    const link = isUser
+                      ? `/${(content as { name: string }).name.replace(/\s/g, '')}`
+                      : `/boards/${(content as { domain: { key: string; _id: string } }).domain.key}/content/${(content as { domain: { _id: string } }).domain._id}`
+
+                    return (
+                      <Link
+                        key={(content as { _id: string })._id}
+                        href={link}
+                        className={cn(
+                          'block p-5 border-b border-gray-100',
+                          'hover:bg-gray-50 transition-colors',
+                          'last:border-none'
+                        )}
+                      >
+                        {result}
+                      </Link>
+                    )
+                  })}
+                </CardContent>
+              </Card>
+            )
+          })}
+          {/* End of results marker */}
+          <div className="my-16 z-10">End of Results</div>
+        </>
+      )}
+    </div>
+  )
+}
+
+

--- a/quotevote-frontend/src/components/SearchContainer/UsernameResults.tsx
+++ b/quotevote-frontend/src/components/SearchContainer/UsernameResults.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import Link from 'next/link'
+import { Loader2 } from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import Avatar from '@/components/Avatar'
+import type { UsernameResultsProps } from '@/types/components'
+import { cn } from '@/lib/utils'
+
+/**
+ * UsernameResults Component
+ * 
+ * Displays a dropdown list of user search results with avatars and badges.
+ * Shows loading state, error state, and empty state messages.
+ * 
+ * @param users - Array of user search results
+ * @param loading - Whether the search is currently loading
+ * @param error - Error object if search failed
+ * @param onUserSelect - Callback when a user is selected
+ * @param query - Current search query text
+ */
+export default function UsernameResults({
+  users = [],
+  loading = false,
+  error = null,
+  onUserSelect,
+  query = '',
+}: UsernameResultsProps) {
+  // No results state
+  if (!loading && (!users || users.length === 0) && query.length > 0) {
+    return (
+      <Card className="absolute top-full left-0 right-0 max-h-[300px] overflow-y-auto z-[1000] mt-1 shadow-lg">
+        <CardContent className="p-4 text-center text-gray-500">
+          <p className="text-sm">
+            No users found matching &quot;{query}&quot;
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // Loading state
+  if (loading) {
+    return (
+      <Card className="absolute top-full left-0 right-0 max-h-[300px] overflow-y-auto z-[1000] mt-1 shadow-lg">
+        <CardContent className="flex items-center justify-center p-4">
+          <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+          <p className="text-sm text-gray-600 ml-2">Searching users...</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <Card className="absolute top-full left-0 right-0 max-h-[300px] overflow-y-auto z-[1000] mt-1 shadow-lg">
+        <CardContent className="p-4 text-center">
+          <p className="text-sm text-destructive">
+            Error searching users
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // No users to display
+  if (!users || users.length === 0) {
+    return null
+  }
+
+  // Results list
+  return (
+    <Card className="absolute top-full left-0 right-0 max-h-[300px] overflow-y-auto z-[1000] mt-1 shadow-lg">
+      <CardContent className="p-0">
+        <div className="divide-y divide-gray-200">
+          {users.map((user) => {
+            const handleClick = () => {
+              if (onUserSelect) {
+                onUserSelect(user)
+              }
+            }
+
+            return (
+              <Link
+                key={user._id}
+                href={`/${user.username}`}
+                onClick={handleClick}
+                className={cn(
+                  'flex items-center gap-3 p-3',
+                  'hover:bg-gray-50 transition-colors',
+                  'cursor-pointer'
+                )}
+              >
+                <div className="flex-shrink-0">
+                  <Avatar
+                    src={user.avatar}
+                    alt={user.name || user.username}
+                    size={40}
+                  />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium text-gray-900 truncate">
+                      @{user.username}
+                    </p>
+                    {user.contributorBadge && (
+                      <Badge variant="default" className="text-xs px-1.5 py-0.5">
+                        Contributor
+                      </Badge>
+                    )}
+                  </div>
+                  {user.name && (
+                    <p className="text-sm text-gray-500 truncate">
+                      {user.name}
+                    </p>
+                  )}
+                </div>
+              </Link>
+            )
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+

--- a/quotevote-frontend/src/components/SearchContainer/index.ts
+++ b/quotevote-frontend/src/components/SearchContainer/index.ts
@@ -1,0 +1,3 @@
+export { default as SearchResults } from './SearchResults'
+export { default as UsernameResults } from './UsernameResults'
+

--- a/quotevote-frontend/src/components/SearchContainer/index.tsx
+++ b/quotevote-frontend/src/components/SearchContainer/index.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+import { Search } from 'lucide-react'
+// TODO: Fix Apollo Client v4.0.9 type resolution issues
+// @ts-expect-error - Apollo Client v4.0.9 has type resolution issues with useQuery export
+import { useQuery } from '@apollo/client'
+
+import { SEARCH } from '@/graphql/queries'
+import { useDebounce } from '@/hooks/useDebounce'
+import { Input } from '@/components/ui/input'
+import { Card, CardHeader } from '@/components/ui/card'
+import SearchResultsView from './SearchResults'
+import type { SidebarSearchViewProps } from '@/types/components'
+import { cn } from '@/lib/utils'
+
+/**
+ * SidebarSearchView Component
+ * 
+ * A search container component that provides a search input with debounced queries
+ * and displays search results for content and creators.
+ * 
+ * @param Display - Display style for the container (default: 'block')
+ */
+export default function SidebarSearchView({ Display = 'block' }: SidebarSearchViewProps) {
+  const [searchText, setSearchText] = useState('')
+  const debouncedSearchText = useDebounce(searchText, 300)
+
+  const { loading, error, data } = useQuery(SEARCH, {
+    variables: { text: debouncedSearchText },
+    skip: !debouncedSearchText.trim(),
+  })
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchText(e.target.value)
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex-1',
+        Display === 'flex' ? 'flex' : Display === 'none' ? 'hidden' : 'block',
+        'm-1 mr-4',
+        'h-[90vh]'
+      )}
+    >
+      <Card className="z-10 h-fit">
+        <CardHeader className="bg-white m-1 pl-0 pr-1">
+          <div className="relative rounded-md bg-white/15 hover:bg-white/25 mr-2 ml-0 w-full sm:ml-2 sm:w-auto">
+            <div className="absolute inset-y-0 left-0 flex items-center justify-center pointer-events-none pl-3">
+              <Search className="h-5 w-5 text-gray-400" aria-hidden="true" />
+            </div>
+            <Input
+              type="text"
+              placeholder="Search…"
+              value={searchText}
+              onChange={handleTextChange}
+              className="pl-10 w-full sm:w-[20ch]"
+              aria-label="search"
+            />
+          </div>
+        </CardHeader>
+      </Card>
+      {data && (
+        <SearchResultsView
+          searchResults={data}
+          isLoading={loading}
+          isError={error}
+        />
+      )}
+    </div>
+  )
+}
+
+

--- a/quotevote-frontend/src/graphql/queries.ts
+++ b/quotevote-frontend/src/graphql/queries.ts
@@ -634,6 +634,31 @@ export const SEARCH_USERNAMES = gql`
 `
 
 /**
+ * Search query for content and creators
+ */
+export const SEARCH = gql`
+  query search($text: String!) {
+    searchContent(text: $text) {
+      _id
+      title
+      creatorId
+      domain {
+        key
+        _id
+      }
+    }
+    searchCreator(text: $text) {
+      _id
+      name
+      avatar
+      creator {
+        _id
+      }
+    }
+  }
+`
+
+/**
  * Get message reactions query
  * Used by PostChatReactions component
  */

--- a/quotevote-frontend/src/hooks/useDebounce.ts
+++ b/quotevote-frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,38 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+/**
+ * Custom hook for debouncing a value
+ * @param value - The value to debounce
+ * @param delay - Delay in milliseconds (default: 300)
+ * @returns Debounced value
+ * 
+ * @example
+ * ```tsx
+ * const [searchTerm, setSearchTerm] = useState('')
+ * const debouncedSearchTerm = useDebounce(searchTerm, 500)
+ * 
+ * useEffect(() => {
+ *   // This will only run after user stops typing for 500ms
+ *   performSearch(debouncedSearchTerm)
+ * }, [debouncedSearchTerm])
+ * ```
+ */
+export function useDebounce<T>(value: T, delay: number = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}
+
+

--- a/quotevote-frontend/src/types/components.ts
+++ b/quotevote-frontend/src/types/components.ts
@@ -910,3 +910,88 @@ export interface CreditCardInputProps {
 
 export type PlansProps = Record<string, never>;
 
+// SearchContainer Component Types
+export interface SearchContentResult {
+  _id: string;
+  title: string;
+  creatorId: string;
+  domain: {
+    key: string;
+    _id: string;
+  };
+  __typename?: string;
+}
+
+export interface SearchCreatorResult {
+  _id: string;
+  name: string;
+  avatar?: string;
+  creator?: {
+    _id: string;
+  };
+  __typename?: string;
+}
+
+export interface SearchResultsData {
+  searchContent?: SearchContentResult[];
+  searchCreator?: SearchCreatorResult[];
+}
+
+export interface SearchResultsProps {
+  /**
+   * Search results data from GraphQL query
+   */
+  searchResults: SearchResultsData;
+  /**
+   * Whether the search is currently loading
+   * @default false
+   */
+  isLoading?: boolean;
+  /**
+   * Error object if search failed
+   */
+  isError?: Error | { message?: string } | null;
+}
+
+export interface UsernameSearchUser {
+  _id: string;
+  username: string;
+  name: string;
+  avatar?: string;
+  contributorBadge?: boolean;
+}
+
+export interface UsernameResultsProps {
+  /**
+   * Array of user search results
+   * @default []
+   */
+  users?: UsernameSearchUser[];
+  /**
+   * Whether the search is currently loading
+   * @default false
+   */
+  loading?: boolean;
+  /**
+   * Error object if search failed
+   */
+  error?: Error | { message?: string } | null;
+  /**
+   * Callback when a user is selected
+   */
+  onUserSelect?: (user: UsernameSearchUser) => void;
+  /**
+   * Current search query text
+   * @default ''
+   */
+  query?: string;
+}
+
+export interface SidebarSearchViewProps {
+  /**
+   * Display style for the container
+   * @default 'block'
+   */
+  Display?: 'block' | 'flex' | 'none' | string;
+}
+


### PR DESCRIPTION
## Description
Migrated SearchContainer components from Material UI to shadcn/ui with TypeScript conversion. Replaced MUI search inputs and layout with shadcn/ui primitives and Tailwind CSS, updated search logic with debouncing and filtering, and validated end-to-end search functionality.

## Issue Reference
Closes #55 

## Changes Made
- Migrated all SearchContainer components from `src-old/components/SearchContainer/` to `components/SearchContainer/`
- Converted all `.jsx` files to `.tsx` with proper TypeScript types
- Replaced MUI components (Input, Button) with shadcn/ui equivalents
- Implemented debounced input handling for search queries
- Updated search logic with GraphQL query execution and result mapping
- Applied Tailwind styling for responsive layout
- Added TypeScript types for search parameters, results, and handlers
- Updated imports across the app to use `@/components/SearchContainer`

## Testing
- [x] Search flows tested: empty state, results, no-results, error state
- [x] Debounced queries verified
- [x] TypeScript compilation passes
- [x] Build passes without issues

## Type Safety
- [x] No `any` types used
- [x] All types properly defined for search parameters and results
- [x] TypeScript compiles without errors