### PR TITLE
feat: migrate HighlightText component to Next.js frontend

### DIFF
--- a/quotevote-frontend/src/__tests__/components/HighlightText.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/HighlightText.test.tsx
@@ -1,0 +1,391 @@
+/**
+ * HighlightText Component Tests
+ * 
+ * Tests that verify:
+ * - Component renders correctly with different props
+ * - Single and multiple highlight terms work
+ * - Case sensitivity option works
+ * - Auto-escape option works
+ * - Empty and edge cases are handled gracefully
+ * - Custom styling is applied
+ * - No matches scenario works correctly
+ */
+
+import React from 'react'
+import { render, screen } from '../utils/test-utils'
+import HighlightText from '@/components/HighlightText'
+
+// Mock react-highlight-words to test the component behavior
+jest.mock('react-highlight-words', () => {
+  return {
+    __esModule: true,
+    default: ({
+      textToHighlight,
+      searchWords,
+      caseSensitive,
+      autoEscape,
+      highlightClassName,
+    }: {
+      textToHighlight: string
+      searchWords: string[]
+      caseSensitive?: boolean
+      autoEscape?: boolean
+      highlightClassName?: string
+    }) => {
+      // Simple mock implementation that wraps matched words
+      let result = textToHighlight
+      searchWords.forEach((word) => {
+        const flags = caseSensitive ? 'g' : 'gi'
+        const regex = autoEscape
+          ? new RegExp(word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), flags)
+          : new RegExp(word, flags)
+        result = result.replace(
+          regex,
+          (match) => `<mark class="${highlightClassName}">${match}</mark>`
+        )
+      })
+      return React.createElement('span', {
+        dangerouslySetInnerHTML: { __html: result },
+        'data-testid': 'highlighter',
+      })
+    },
+  }
+})
+
+describe('HighlightText Component', () => {
+  describe('Basic Rendering', () => {
+    it('renders text without crashing', () => {
+      const { container } = render(
+        <HighlightText text="Hello World" highlightTerms={[]} />
+      )
+
+      expect(container).toBeInTheDocument()
+      expect(container.textContent).toBe('Hello World')
+    })
+
+    it('renders text when no highlight terms provided', () => {
+      const { container } = render(<HighlightText text="Hello World" />)
+
+      expect(container.textContent).toBe('Hello World')
+    })
+
+    it('renders with custom className', () => {
+      const { container } = render(
+        <HighlightText
+          text="Hello World"
+          highlightTerms={[]}
+          className="custom-class"
+        />
+      )
+
+      const span = container.querySelector('span')
+      expect(span).toHaveClass('custom-class')
+    })
+  })
+
+  describe('Single Highlight Term', () => {
+    it('highlights a single term', () => {
+      render(
+        <HighlightText
+          text="The dog is chasing the cat"
+          highlightTerms="dog"
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter).toBeInTheDocument()
+      expect(highlighter.innerHTML).toContain('dog')
+    })
+
+    it('highlights multiple occurrences of a single term', () => {
+      render(
+        <HighlightText
+          text="The dog is chasing the dog"
+          highlightTerms="dog"
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      const matches = highlighter.innerHTML.match(/<mark/g)
+      expect(matches).toHaveLength(2)
+    })
+
+    it('handles empty string as highlight term', () => {
+      const { container } = render(
+        <HighlightText text="Hello World" highlightTerms="" />
+      )
+
+      expect(container.textContent).toBe('Hello World')
+    })
+  })
+
+  describe('Multiple Highlight Terms', () => {
+    it('highlights multiple terms from array', () => {
+      render(
+        <HighlightText
+          text="The dog is chasing the cat. Or perhaps they're just playing?"
+          highlightTerms={['and', 'or', 'the']}
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter).toBeInTheDocument()
+      expect(highlighter.innerHTML).toContain('the')
+      expect(highlighter.innerHTML).toContain('Or')
+    })
+
+    it('handles empty array of highlight terms', () => {
+      const { container } = render(
+        <HighlightText text="Hello World" highlightTerms={[]} />
+      )
+
+      expect(container.textContent).toBe('Hello World')
+    })
+
+    it('filters out empty strings from highlight terms array', () => {
+      render(
+        <HighlightText
+          text="Hello World"
+          highlightTerms={['Hello', '', '  ', 'World']}
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter).toBeInTheDocument()
+      expect(highlighter.innerHTML).toContain('Hello')
+      expect(highlighter.innerHTML).toContain('World')
+    })
+
+    it('handles array with only empty strings', () => {
+      const { container } = render(
+        <HighlightText text="Hello World" highlightTerms={['', '  ']} />
+      )
+
+      expect(container.textContent).toBe('Hello World')
+    })
+  })
+
+  describe('Case Sensitivity', () => {
+    it('matches case-insensitively by default', () => {
+      render(
+        <HighlightText
+          text="The dog is chasing the Dog"
+          highlightTerms="dog"
+          caseSensitive={false}
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      const matches = highlighter.innerHTML.match(/<mark/g)
+      expect(matches).toHaveLength(2) // Both "dog" and "Dog" should match
+    })
+
+    it('matches case-sensitively when enabled', () => {
+      render(
+        <HighlightText
+          text="The dog is chasing the Dog"
+          highlightTerms="dog"
+          caseSensitive={true}
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      const matches = highlighter.innerHTML.match(/<mark/g)
+      expect(matches).toHaveLength(1) // Only "dog" should match
+    })
+  })
+
+  describe('Auto-Escape', () => {
+    it('escapes special regex characters by default', () => {
+      render(
+        <HighlightText
+          text="Price: $100.00 (50% off)"
+          highlightTerms="$100"
+          autoEscape={true}
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter.innerHTML).toContain('$100')
+    })
+
+    it('handles special characters without escaping when autoEscape is false', () => {
+      render(
+        <HighlightText
+          text="Test (parentheses) and [brackets]"
+          highlightTerms="(parentheses)"
+          autoEscape={false}
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter).toBeInTheDocument()
+    })
+  })
+
+  describe('Custom Styling', () => {
+    it('applies default highlight className', () => {
+      render(
+        <HighlightText
+          text="Hello World"
+          highlightTerms="Hello"
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter.innerHTML).toContain('bg-yellow-200')
+      expect(highlighter.innerHTML).toContain('font-semibold')
+    })
+
+    it('applies custom highlight className', () => {
+      render(
+        <HighlightText
+          text="Hello World"
+          highlightTerms="Hello"
+          highlightClassName="bg-blue-500 text-white"
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter.innerHTML).toContain('bg-blue-500')
+      expect(highlighter.innerHTML).toContain('text-white')
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('handles empty text string', () => {
+      render(<HighlightText text="" highlightTerms="test" />)
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter).toBeInTheDocument()
+    })
+
+    it('handles text with only whitespace', () => {
+      const { container } = render(
+        <HighlightText text="   " highlightTerms="test" />
+      )
+
+      expect(container.textContent).toBe('   ')
+    })
+
+    it('handles text with special characters', () => {
+      render(
+        <HighlightText
+          text="Hello! @world #hashtag $money"
+          highlightTerms="world"
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter).toBeInTheDocument()
+    })
+
+    it('handles text with newlines', () => {
+      const { container } = render(
+        <HighlightText
+          text="Line 1\nLine 2\nLine 3"
+          highlightTerms="Line"
+        />
+      )
+
+      expect(container.textContent).toContain('Line 1')
+      expect(container.textContent).toContain('Line 2')
+      expect(container.textContent).toContain('Line 3')
+    })
+
+    it('handles very long text', () => {
+      const longText = 'word '.repeat(1000)
+      const { container } = render(
+        <HighlightText text={longText} highlightTerms="word" />
+      )
+
+      expect(container.textContent).toContain('word')
+    })
+
+    it('handles unicode characters', () => {
+      render(
+        <HighlightText
+          text="Hello 世界 🌍"
+          highlightTerms="Hello"
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter).toBeInTheDocument()
+    })
+
+    it('handles no matches scenario', () => {
+      const { container } = render(
+        <HighlightText
+          text="Hello World"
+          highlightTerms="xyz"
+        />
+      )
+
+      expect(container.textContent).toBe('Hello World')
+    })
+  })
+
+  describe('Component Structure', () => {
+    it('wraps content in span element', () => {
+      const { container } = render(
+        <HighlightText text="Hello World" highlightTerms={[]} />
+      )
+
+      const span = container.querySelector('span')
+      expect(span).toBeInTheDocument()
+    })
+
+    it('does not throw hydration warnings', () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      render(<HighlightText text="Hello World" highlightTerms="Hello" />)
+
+      expect(consoleError).not.toHaveBeenCalledWith(
+        expect.stringContaining('hydration'),
+        expect.anything()
+      )
+
+      consoleError.mockRestore()
+    })
+  })
+
+  describe('Real-world Scenarios', () => {
+    it('highlights search terms in a sentence', () => {
+      render(
+        <HighlightText
+          text="The dog is chasing the cat. Or perhaps they're just playing?"
+          highlightTerms={['and', 'or', 'the']}
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter).toBeInTheDocument()
+    })
+
+    it('highlights user search query in results', () => {
+      render(
+        <HighlightText
+          text="John Doe - Software Engineer"
+          highlightTerms="John"
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter.innerHTML).toContain('John')
+    })
+
+    it('handles multiple overlapping terms gracefully', () => {
+      render(
+        <HighlightText
+          text="The quick brown fox"
+          highlightTerms={['quick', 'quick brown']}
+        />
+      )
+
+      const highlighter = screen.getByTestId('highlighter')
+      expect(highlighter).toBeInTheDocument()
+    })
+  })
+})
+

--- a/quotevote-frontend/src/app/test/highlight-text/page.tsx
+++ b/quotevote-frontend/src/app/test/highlight-text/page.tsx
@@ -1,0 +1,329 @@
+'use client'
+
+import { useState } from 'react'
+import HighlightText from '@/components/HighlightText'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+
+/**
+ * Test Page for HighlightText Component
+ * 
+ * This page demonstrates the HighlightText component functionality:
+ * - Single match highlighting
+ * - Multiple matches highlighting
+ * - Case sensitivity option
+ * - Auto-escape option
+ * - Custom styling
+ * - Edge cases (empty text, no matches, special characters)
+ */
+export default function HighlightTextTestPage() {
+  const [text, setText] = useState(
+    "The dog is chasing the cat. Or perhaps they're just playing?"
+  )
+  const [highlightTerm, setHighlightTerm] = useState('the')
+  const [caseSensitive, setCaseSensitive] = useState(false)
+  const [autoEscape, setAutoEscape] = useState(true)
+  const [customClass, setCustomClass] = useState('bg-yellow-200 font-semibold')
+
+  // Example texts for quick testing
+  const exampleTexts = [
+    "The dog is chasing the cat. Or perhaps they're just playing?",
+    "Hello World! This is a test string with multiple words.",
+    "Price: $100.00 (50% off) - Special characters test!",
+    "Search results for 'react' and 'typescript' in this text.",
+    "Case sensitive test: The THE the",
+  ]
+
+  const exampleTerms = [
+    ['and', 'or', 'the'],
+    ['Hello', 'World'],
+    ['$100', '50%'],
+    ['react', 'typescript'],
+    ['The'],
+  ]
+
+  return (
+    <div className="container mx-auto p-8 space-y-8">
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold mb-2">HighlightText Component Test</h1>
+        <p className="text-muted-foreground">
+          Test page for HighlightText component. This component highlights search
+          terms or key phrases within text using react-highlight-words.
+        </p>
+      </div>
+
+      {/* Interactive Test Section */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Interactive Test</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="text-input">Text to Highlight</Label>
+            <Input
+              id="text-input"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="Enter text to highlight"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="term-input">Highlight Term(s)</Label>
+            <Input
+              id="term-input"
+              value={highlightTerm}
+              onChange={(e) => setHighlightTerm(e.target.value)}
+              placeholder="Enter term(s) to highlight (comma-separated for multiple)"
+            />
+            <p className="text-sm text-muted-foreground">
+              Separate multiple terms with commas (e.g., &quot;the, and, or&quot;)
+            </p>
+          </div>
+
+          <div className="flex items-center space-x-4">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="case-sensitive"
+                checked={caseSensitive}
+                onCheckedChange={(checked) =>
+                  setCaseSensitive(checked === true)
+                }
+              />
+              <Label htmlFor="case-sensitive">Case Sensitive</Label>
+            </div>
+
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="auto-escape"
+                checked={autoEscape}
+                onCheckedChange={(checked) => setAutoEscape(checked === true)}
+              />
+              <Label htmlFor="auto-escape">Auto Escape</Label>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="class-input">Custom Highlight Class</Label>
+            <Input
+              id="class-input"
+              value={customClass}
+              onChange={(e) => setCustomClass(e.target.value)}
+              placeholder="bg-yellow-200 font-semibold"
+            />
+          </div>
+
+          <div className="p-4 bg-muted rounded-lg">
+            <h3 className="font-semibold mb-2">Result:</h3>
+            <div className="text-base">
+              <HighlightText
+                text={text}
+                highlightTerms={
+                  highlightTerm
+                    .split(',')
+                    .map((t) => t.trim())
+                    .filter((t) => t.length > 0)
+                }
+                caseSensitive={caseSensitive}
+                autoEscape={autoEscape}
+                highlightClassName={customClass}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Example Tests */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Example Tests</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Single Match */}
+          <div className="space-y-2">
+            <h3 className="font-semibold">1. Single Match</h3>
+            <div className="p-4 bg-muted rounded-lg">
+              <HighlightText
+                text="Hello World"
+                highlightTerms="World"
+              />
+            </div>
+          </div>
+
+          {/* Multiple Matches */}
+          <div className="space-y-2">
+            <h3 className="font-semibold">2. Multiple Matches</h3>
+            <div className="p-4 bg-muted rounded-lg">
+              <HighlightText
+                text="The dog is chasing the cat. Or perhaps they're just playing?"
+                highlightTerms={['and', 'or', 'the']}
+              />
+            </div>
+          </div>
+
+          {/* No Matches */}
+          <div className="space-y-2">
+            <h3 className="font-semibold">3. No Matches</h3>
+            <div className="p-4 bg-muted rounded-lg">
+              <HighlightText
+                text="Hello World"
+                highlightTerms="xyz"
+              />
+            </div>
+          </div>
+
+          {/* Case Sensitive */}
+          <div className="space-y-2">
+            <h3 className="font-semibold">4. Case Sensitive</h3>
+            <div className="p-4 bg-muted rounded-lg space-y-2">
+              <div>
+                <p className="text-sm text-muted-foreground mb-1">
+                  Case Insensitive (default):
+                </p>
+                <HighlightText
+                  text="The dog is chasing the Dog"
+                  highlightTerms="dog"
+                  caseSensitive={false}
+                />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground mb-1">
+                  Case Sensitive:
+                </p>
+                <HighlightText
+                  text="The dog is chasing the Dog"
+                  highlightTerms="dog"
+                  caseSensitive={true}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Special Characters */}
+          <div className="space-y-2">
+            <h3 className="font-semibold">5. Special Characters</h3>
+            <div className="p-4 bg-muted rounded-lg">
+              <HighlightText
+                text="Price: $100.00 (50% off)"
+                highlightTerms="$100"
+                autoEscape={true}
+              />
+            </div>
+          </div>
+
+          {/* Custom Styling */}
+          <div className="space-y-2">
+            <h3 className="font-semibold">6. Custom Styling</h3>
+            <div className="p-4 bg-muted rounded-lg space-y-2">
+              <div>
+                <p className="text-sm text-muted-foreground mb-1">
+                  Default (yellow background):
+                </p>
+                <HighlightText
+                  text="Hello World"
+                  highlightTerms="Hello"
+                />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground mb-1">
+                  Custom (blue background):
+                </p>
+                <HighlightText
+                  text="Hello World"
+                  highlightTerms="Hello"
+                  highlightClassName="bg-blue-500 text-white px-1 rounded"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Edge Cases */}
+          <div className="space-y-2">
+            <h3 className="font-semibold">7. Edge Cases</h3>
+            <div className="p-4 bg-muted rounded-lg space-y-2">
+              <div>
+                <p className="text-sm text-muted-foreground mb-1">
+                  Empty text:
+                </p>
+                <HighlightText text="" highlightTerms="test" />
+                <span className="text-muted-foreground">(empty)</span>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground mb-1">
+                  Empty highlight terms:
+                </p>
+                <HighlightText text="Hello World" highlightTerms={[]} />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground mb-1">
+                  Text with newlines:
+                </p>
+                <HighlightText
+                  text="Line 1\nLine 2\nLine 3"
+                  highlightTerms="Line"
+                />
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Quick Test Buttons */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Quick Test Examples</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {exampleTexts.map((exampleText, index) => (
+              <Button
+                key={index}
+                variant="outline"
+                onClick={() => {
+                  setText(exampleText)
+                  setHighlightTerm(
+                    Array.isArray(exampleTerms[index])
+                      ? exampleTerms[index].join(', ')
+                      : exampleTerms[index][0]
+                  )
+                }}
+                className="h-auto p-4 text-left justify-start"
+              >
+                <div>
+                  <p className="font-semibold mb-1">Example {index + 1}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {exampleText.substring(0, 50)}...
+                  </p>
+                </div>
+              </Button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Component Features */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Component Features</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="list-disc list-inside space-y-2">
+            <li>✅ Migrated from JSX to TSX with full TypeScript support</li>
+            <li>✅ Supports single or multiple highlight terms</li>
+            <li>✅ Case-sensitive and case-insensitive matching</li>
+            <li>✅ Auto-escape for special regex characters</li>
+            <li>✅ Custom highlight styling with Tailwind CSS</li>
+            <li>✅ Graceful handling of edge cases (empty text, no matches)</li>
+            <li>✅ Uses react-highlight-words library</li>
+            <li>✅ No dangerouslySetInnerHTML (uses React element composition)</li>
+            <li>✅ Performant for longer text blocks</li>
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+

--- a/quotevote-frontend/src/components/HighlightText/HighlightText.tsx
+++ b/quotevote-frontend/src/components/HighlightText/HighlightText.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import Highlighter from 'react-highlight-words'
+import type { HighlightTextProps } from '@/types/components'
+import { cn } from '@/lib/utils'
+
+/**
+ * HighlightText Component
+ * 
+ * A flexible component for highlighting search terms or key phrases within text.
+ * Uses react-highlight-words under the hood with proper TypeScript types and
+ * Tailwind CSS styling.
+ * 
+ * @param text - The text content to highlight
+ * @param highlightTerms - Single search term or array of search terms to highlight
+ * @param caseSensitive - Whether the search is case-sensitive
+ * @param autoEscape - Whether to auto-escape special regex characters
+ * @param highlightClassName - Custom CSS class name for highlighted spans
+ * @param className - Additional CSS classes for the container
+ * @param findChunks - Custom function to find chunks (advanced usage)
+ * 
+ * @example
+ * <HighlightText 
+ *   text="The dog is chasing the cat. Or perhaps they're just playing?"
+ *   highlightTerms={['and', 'or', 'the']}
+ * />
+ * 
+ * @example
+ * <HighlightText 
+ *   text="Hello World"
+ *   highlightTerms="World"
+ *   caseSensitive={true}
+ * />
+ */
+export default function HighlightText({
+  text,
+  highlightTerms = [],
+  caseSensitive = false,
+  autoEscape = true,
+  highlightClassName = 'bg-yellow-200 font-semibold',
+  className,
+  findChunks,
+}: HighlightTextProps) {
+  // Normalize highlightTerms to array
+  const searchWords = Array.isArray(highlightTerms)
+    ? highlightTerms
+    : highlightTerms
+    ? [highlightTerms]
+    : []
+
+  // Filter out empty strings
+  const validSearchWords = searchWords.filter((term) => term.trim().length > 0)
+
+  // If no valid search terms, just render the text
+  if (validSearchWords.length === 0) {
+    return <span className={className}>{text}</span>
+  }
+
+  return (
+    <span className={className}>
+      <Highlighter
+        textToHighlight={text}
+        searchWords={validSearchWords}
+        autoEscape={autoEscape}
+        caseSensitive={caseSensitive}
+        highlightClassName={cn(highlightClassName)}
+        findChunks={findChunks}
+      />
+    </span>
+  )
+}
+

--- a/quotevote-frontend/src/components/HighlightText/index.ts
+++ b/quotevote-frontend/src/components/HighlightText/index.ts
@@ -1,0 +1,2 @@
+export { default } from './HighlightText'
+

--- a/quotevote-frontend/src/types/components.ts
+++ b/quotevote-frontend/src/types/components.ts
@@ -995,3 +995,45 @@ export interface SidebarSearchViewProps {
   Display?: 'block' | 'flex' | 'none' | string;
 }
 
+export interface HighlightTextProps {
+  /**
+   * The text content to highlight
+   */
+  text: string;
+  /**
+   * Single search term or array of search terms to highlight
+   * @default []
+   */
+  highlightTerms?: string | string[];
+  /**
+   * Whether the search is case-sensitive
+   * @default false
+   */
+  caseSensitive?: boolean;
+  /**
+   * Whether to auto-escape special regex characters in search terms
+   * @default true
+   */
+  autoEscape?: boolean;
+  /**
+   * Custom CSS class name for highlighted spans
+   * @default 'bg-yellow-200 font-semibold'
+   */
+  highlightClassName?: string;
+  /**
+   * Additional CSS classes for the container
+   */
+  className?: string;
+  /**
+   * Custom function to find chunks (advanced usage)
+   * Matches the FindChunks interface from react-highlight-words
+   */
+  findChunks?: (options: {
+    textToHighlight: string;
+    searchWords: Array<string | RegExp>;
+    caseSensitive?: boolean;
+    autoEscape?: boolean;
+    sanitize?: (text: string) => string;
+  }) => Array<{ start: number; end: number }>;
+}
+


### PR DESCRIPTION
# Migrate HighlightText Component

## Description

Migrates HighlightText component from React 17/Vite to Next.js 16/TypeScript. Converts JSX to TSX, adds TypeScript types, Tailwind CSS styling, and comprehensive tests.

Closes #63

## Changes

- ✅ Created `HighlightText.tsx` component with full TypeScript support
- ✅ Added `HighlightTextProps` interface to `@/types/components.ts`
- ✅ Supports single/multiple highlight terms, case sensitivity, auto-escape
- ✅ Tailwind CSS styling (replaces MUI)
- ✅ 28 comprehensive tests (all passing)
- ✅ Test page at `/test/highlight-text`

## Testing

- [x] 28 unit tests passing
- [x] TypeScript type-check passes
- [x] Linting passes
- [x] Manual testing completed

## Files Changed

- `src/components/HighlightText/HighlightText.tsx` (new)
- `src/components/HighlightText/index.ts` (new)
- `src/types/components.ts` (added interface)
- `src/__tests__/components/HighlightText.test.tsx` (new)
- `src/app/test/highlight-text/page.tsx` (new)

