### PR TITLE
feat: migrate LogoutPage component to Next.js frontend

### DIFF
--- a/quotevote-frontend/src/__tests__/components/LogoutPage.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/LogoutPage.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * LogoutPage Component Tests
+ * 
+ * Comprehensive tests for the LogoutPage component.
+ * Tests cover:
+ * - Component rendering and loading state
+ * - Logout functionality (token removal, Apollo reset, Zustand logout)
+ * - Navigation to login page
+ * - Error handling
+ */
+
+import { render, screen, waitFor, act } from '../utils/test-utils';
+import { LogoutPage } from '@/components/LogoutPage';
+import { useAppStore } from '@/store';
+
+// Mock Next.js router
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockBack = jest.fn();
+const mockPrefetch = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({
+    push: mockPush,
+    replace: mockReplace,
+    prefetch: mockPrefetch,
+    back: mockBack,
+  })),
+  usePathname: jest.fn(() => '/'),
+  useSearchParams: jest.fn(() => new URLSearchParams()),
+}));
+
+// Mock Apollo Client
+const mockApolloClient = {
+  stop: jest.fn(),
+  resetStore: jest.fn().mockResolvedValue(undefined),
+};
+
+jest.mock('@/lib/apollo', () => ({
+  getApolloClient: jest.fn(() => mockApolloClient),
+}));
+
+describe('LogoutPage Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPush.mockClear();
+    mockApolloClient.stop.mockClear();
+    mockApolloClient.resetStore.mockClear();
+
+    // Reset store state to logged in
+    useAppStore.setState({
+      user: {
+        loading: false,
+        loginError: null,
+        data: {
+          _id: 'user123',
+          username: 'testuser',
+          name: 'Test User',
+        },
+      },
+    });
+
+    // Mock localStorage
+    if (typeof window !== 'undefined') {
+      Object.defineProperty(window, 'localStorage', {
+        value: {
+          getItem: jest.fn(() => 'mock-token'),
+          setItem: jest.fn(),
+          removeItem: jest.fn(),
+          clear: jest.fn(),
+        },
+        writable: true,
+      });
+    }
+
+    // Mock timers
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  describe('Rendering', () => {
+    it('renders loading state with loader and message', () => {
+      render(<LogoutPage />);
+
+      expect(screen.getByText('Logging you out...')).toBeInTheDocument();
+      expect(
+        screen.getByText('Please wait while we securely log you out.')
+      ).toBeInTheDocument();
+      
+      // Check for loader (it has aria-label="Loading")
+      expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+    });
+
+    it('applies custom className when provided', () => {
+      const { container } = render(<LogoutPage className="custom-class" />);
+      const rootDiv = container.firstChild as HTMLElement;
+      expect(rootDiv).toHaveClass('custom-class');
+    });
+  });
+
+  describe('Logout Functionality', () => {
+    it('removes token from localStorage', async () => {
+      render(<LogoutPage />);
+
+      await waitFor(() => {
+        expect(window.localStorage.removeItem).toHaveBeenCalledWith('token');
+      });
+    });
+
+    it('stops and resets Apollo Client store', async () => {
+      render(<LogoutPage />);
+
+      await waitFor(() => {
+        expect(mockApolloClient.stop).toHaveBeenCalled();
+        expect(mockApolloClient.resetStore).toHaveBeenCalled();
+      });
+    });
+
+    it('calls logout from Zustand store', async () => {
+      render(<LogoutPage />);
+
+      await waitFor(() => {
+        const storeState = useAppStore.getState();
+        expect(storeState.user.data).toEqual({});
+      });
+    });
+
+    it('redirects to login page after logout', async () => {
+      render(<LogoutPage />);
+
+      // Fast-forward timers to trigger redirect
+      jest.advanceTimersByTime(200);
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/auth/login');
+      });
+    });
+
+    it('performs all logout steps in correct order', async () => {
+      const removeItemSpy = jest.spyOn(window.localStorage, 'removeItem');
+      
+      render(<LogoutPage />);
+
+      // Fast-forward timers
+      jest.advanceTimersByTime(200);
+
+      await waitFor(() => {
+        // Check that token is removed first
+        expect(removeItemSpy).toHaveBeenCalledWith('token');
+        
+        // Then Apollo Client is stopped and reset
+        expect(mockApolloClient.stop).toHaveBeenCalled();
+        expect(mockApolloClient.resetStore).toHaveBeenCalled();
+        
+        // Then Zustand logout is called
+        const storeState = useAppStore.getState();
+        expect(storeState.user.data).toEqual({});
+        
+        // Finally redirect happens
+        expect(mockPush).toHaveBeenCalledWith('/auth/login');
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('still redirects to login page even when error occurs', async () => {
+      mockApolloClient.resetStore.mockRejectedValueOnce(new Error('Test error'));
+
+      render(<LogoutPage />);
+
+      // Fast-forward timers past error delay (2 seconds)
+      await act(async () => {
+        jest.advanceTimersByTime(2200);
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/auth/login');
+      }, { timeout: 3000 });
+    });
+
+    it('handles errors gracefully and redirects', async () => {
+      // Test that errors don't prevent logout
+      mockApolloClient.resetStore.mockRejectedValueOnce(new Error('Test error'));
+
+      render(<LogoutPage />);
+
+      // Wait for redirect to happen (even with error)
+      await act(async () => {
+        jest.advanceTimersByTime(2200);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/auth/login');
+      }, { timeout: 3000 });
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles case when localStorage is not available', async () => {
+      // Remove localStorage mock
+      Object.defineProperty(window, 'localStorage', {
+        value: undefined,
+        writable: true,
+      });
+
+      render(<LogoutPage />);
+
+      // Fast-forward timers to allow async operations
+      jest.advanceTimersByTime(200);
+
+      await waitFor(
+        () => {
+          // Should still complete logout and redirect
+          expect(mockPush).toHaveBeenCalledWith('/auth/login');
+        },
+        { timeout: 3000 }
+      );
+    });
+
+    it('handles slow Apollo reset gracefully', async () => {
+      // Make resetStore take longer
+      mockApolloClient.resetStore.mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 500))
+      );
+
+      render(<LogoutPage />);
+
+      // Fast-forward timers
+      jest.advanceTimersByTime(600);
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/auth/login');
+      });
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has proper ARIA labels for loading state', () => {
+      render(<LogoutPage />);
+
+      const loader = screen.getByLabelText('Loading');
+      expect(loader).toBeInTheDocument();
+      expect(loader).toHaveAttribute('role', 'status');
+    });
+
+    it('has screen reader text for loading', () => {
+      render(<LogoutPage />);
+
+      expect(screen.getByText('Loading...', { selector: '.sr-only' })).toBeInTheDocument();
+    });
+  });
+});
+

--- a/quotevote-frontend/src/app/logout/page.tsx
+++ b/quotevote-frontend/src/app/logout/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { LogoutPage } from '@/components/LogoutPage';
+
+/**
+ * Logout Page Route
+ * 
+ * Next.js App Router page for the logout route.
+ * Uses the LogoutPage component to handle logout functionality.
+ */
+export default function LogoutRoute() {
+  return <LogoutPage />;
+}
+

--- a/quotevote-frontend/src/components/LogoutPage.tsx
+++ b/quotevote-frontend/src/components/LogoutPage.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getApolloClient } from '@/lib/apollo';
+import { useAppStore } from '@/store';
+import { Loader } from '@/components/common/Loader';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { LogOut } from 'lucide-react';
+import type { LogoutPageProps } from '@/types/components';
+
+/**
+ * LogoutPage Component
+ * 
+ * Handles user logout by:
+ * - Clearing authentication token from localStorage
+ * - Resetting Apollo Client store
+ * - Clearing Zustand auth state
+ * - Redirecting to login page
+ * 
+ * Shows a loading state while performing logout operations.
+ */
+export function LogoutPage({ className }: LogoutPageProps) {
+  const router = useRouter();
+  const logout = useAppStore((state) => state.logout);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const performLogout = async () => {
+      try {
+        setError(null);
+
+        // Clear token from localStorage
+        if (typeof window !== 'undefined' && window.localStorage) {
+          localStorage.removeItem('token');
+        }
+
+        // Reset Apollo Client store
+        const client = getApolloClient();
+        client.stop();
+        await client.resetStore();
+
+        // Clear Zustand auth state
+        logout();
+
+        // Small delay to ensure cleanup completes
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // Redirect to login page
+        router.push('/auth/login');
+      } catch (err) {
+        // If there's an error, still try to redirect
+        const errorMessage = err instanceof Error 
+          ? err.message 
+          : typeof err === 'string' 
+            ? err 
+            : 'An error occurred during logout';
+        setError(errorMessage);
+        console.error('Logout error:', err);
+        
+        // Redirect even on error after a short delay
+        setTimeout(() => {
+          router.push('/auth/login');
+        }, 2000);
+      }
+    };
+
+    performLogout();
+  }, [router, logout]);
+
+  if (error) {
+    return (
+      <div className={`flex flex-col items-center justify-center min-h-screen p-4 ${className || ''}`}>
+        <Alert variant="destructive" className="max-w-md">
+          <LogOut className="h-4 w-4" />
+          <AlertTitle>Logout Error</AlertTitle>
+          <AlertDescription>
+            {error}
+            <br />
+            <span className="text-sm mt-2 block">Redirecting to login page...</span>
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+      <div className={`flex flex-col items-center justify-center min-h-screen p-4 ${className || ''}`}>
+        <div className="flex flex-col items-center gap-4">
+          <Loader size={40} absolutelyPositioned={false} />
+        <div className="text-center">
+          <p className="text-lg font-medium text-foreground">Logging you out...</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            Please wait while we securely log you out.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/quotevote-frontend/src/types/components.ts
+++ b/quotevote-frontend/src/types/components.ts
@@ -1049,3 +1049,14 @@ export interface GuestFooterProps {
   isRequestAccess?: boolean;
 }
 
+// ============================================================================
+// LogoutPage Component Types
+// ============================================================================
+
+export interface LogoutPageProps {
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+


### PR DESCRIPTION
## Description

Migrates the `LogoutPage` component from the old React Router/Vite client to the new Next.js 16 frontend.

## Changes

- ✅ Migrated `LogoutPage.jsx` → `LogoutPage.tsx` with full TypeScript support
- ✅ Replaced React Router `Redirect` with Next.js `useRouter`
- ✅ Replaced Apollo hooks with `getApolloClient()` utility
- ✅ Integrated with Zustand store for auth state management
- ✅ Replaced MUI components with shadcn/ui (Alert, Loader)
- ✅ Added loading state and error handling UI
- ✅ Created Next.js route at `/logout` via `app/logout/page.tsx`
- ✅ Added `LogoutPageProps` type definition
- ✅ Comprehensive test suite (13 tests, all passing)

## Technical Details

- Client Component (`'use client'`) due to side effects (localStorage, navigation)
- Clears auth token, resets Apollo Client store, and Zustand state
- Redirects to `/auth/login` after logout completion
- Handles edge cases (missing localStorage, async errors)

## Testing

- ✅ All 13 tests passing
- ✅ No linting errors
- ✅ TypeScript compilation successful

## Issue Reference

Closes #64 