### PR TITLE
feat: migrate PopoverMenu from MUI to shadcn/ui

### DIFF
--- a/quotevote-frontend/src/__tests__/components/PopoverMenu.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/PopoverMenu.test.tsx
@@ -1,0 +1,353 @@
+/**
+ * PopoverMenu Component Tests
+ * 
+ * Comprehensive tests for the PopoverMenu component migrated from MUI to shadcn/ui.
+ * Tests cover:
+ * - Component rendering (mobile-only display)
+ * - Popover open/close functionality
+ * - Menu item clicks and navigation
+ * - Keyboard navigation (Tab, Enter, Escape)
+ * - Selected state highlighting
+ * - Accessibility (ARIA roles and labels)
+ */
+
+import { render, screen, waitFor } from '@/__tests__/utils/test-utils'
+import userEvent from '@testing-library/user-event'
+import { PopoverMenu } from '@/components/PopoverMenu'
+import type { AppRoute } from '@/types/components'
+
+// Mock Next.js Link component
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+    onClick,
+    ...props
+  }: {
+    children: React.ReactNode
+    href: string
+    onClick?: () => void
+    [key: string]: unknown
+  }) {
+    return (
+      <a href={href} onClick={onClick} {...props}>
+        {children}
+      </a>
+    )
+  }
+})
+
+const mockAppRoutes: AppRoute[] = [
+  {
+    path: 'search',
+    name: 'Search',
+    layout: '/',
+  },
+  {
+    path: 'post',
+    name: 'Posts',
+    layout: '/',
+  },
+  {
+    path: 'Profile',
+    name: 'My Profile',
+    layout: '/',
+  },
+  {
+    path: '/logout',
+    name: 'Logout',
+    layout: '/logout',
+  },
+]
+
+const mockAppRoutesWithIcons: AppRoute[] = [
+  {
+    path: 'search',
+    name: 'Search',
+    layout: '/',
+    icon: () => <span data-testid="search-icon">🔍</span>,
+  },
+  {
+    path: 'post',
+    name: 'Posts',
+    layout: '/',
+    icon: () => <span data-testid="post-icon">📝</span>,
+  },
+]
+
+describe('PopoverMenu Component', () => {
+  const defaultProps = {
+    appRoutes: mockAppRoutes,
+    handleClick: jest.fn(),
+    handleClose: jest.fn(),
+    open: false,
+    page: 'Search',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('should render the menu trigger button', () => {
+      render(<PopoverMenu {...defaultProps} />)
+
+      const triggerButton = screen.getByLabelText('Open menu')
+      expect(triggerButton).toBeInTheDocument()
+    })
+
+    it('should render the page title', () => {
+      render(<PopoverMenu {...defaultProps} />)
+
+      expect(screen.getByText('Search')).toBeInTheDocument()
+    })
+
+    it('should be hidden on desktop (md and above)', () => {
+      const { container } = render(<PopoverMenu {...defaultProps} />)
+
+      // Check for md:hidden class
+      const wrapper = container.firstChild as HTMLElement
+      expect(wrapper).toHaveClass('md:hidden')
+    })
+
+    it('should render menu items when popover is open', async () => {
+      render(<PopoverMenu {...defaultProps} open={true} />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('menuitem', { name: /search/i })).toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: /posts/i })).toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: /my profile/i })).toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: /logout/i })).toBeInTheDocument()
+      })
+    })
+
+    it('should render icons when provided', async () => {
+      render(
+        <PopoverMenu
+          {...defaultProps}
+          appRoutes={mockAppRoutesWithIcons}
+          open={true}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('search-icon')).toBeInTheDocument()
+        expect(screen.getByTestId('post-icon')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Open/Close Functionality', () => {
+    it('should call handleClick when trigger button is clicked', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+
+      render(<PopoverMenu {...defaultProps} handleClick={handleClick} />)
+
+      const triggerButton = screen.getByLabelText('Open menu')
+      await user.click(triggerButton)
+
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call handleClose when popover is closed', async () => {
+      const user = userEvent.setup()
+      const handleClose = jest.fn()
+
+      render(<PopoverMenu {...defaultProps} open={true} handleClose={handleClose} />)
+
+      // Click outside or press Escape to close
+      await user.keyboard('{Escape}')
+
+      await waitFor(() => {
+        expect(handleClose).toHaveBeenCalled()
+      })
+    })
+
+    it('should close popover when menu item is clicked', async () => {
+      const user = userEvent.setup()
+      const handleClose = jest.fn()
+
+      render(<PopoverMenu {...defaultProps} open={true} handleClose={handleClose} />)
+
+      const searchLink = screen.getByRole('menuitem', { name: /search/i })
+      await user.click(searchLink)
+
+      expect(handleClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Navigation', () => {
+    it('should generate correct href for menu items', async () => {
+      render(<PopoverMenu {...defaultProps} open={true} />)
+
+      await waitFor(() => {
+        const searchLink = screen.getByRole('menuitem', { name: /search/i })
+        expect(searchLink).toHaveAttribute('href', '/search')
+
+        const logoutLink = screen.getByRole('menuitem', { name: /logout/i })
+        expect(logoutLink).toHaveAttribute('href', '/logout/logout')
+      })
+    })
+
+    it('should navigate to correct route when menu item is clicked', async () => {
+      const user = userEvent.setup()
+      const handleClose = jest.fn()
+
+      render(<PopoverMenu {...defaultProps} open={true} handleClose={handleClose} />)
+
+      const postsLink = screen.getByRole('menuitem', { name: /posts/i })
+      await user.click(postsLink)
+
+      expect(postsLink).toHaveAttribute('href', '/post')
+      expect(handleClose).toHaveBeenCalled()
+    })
+  })
+
+  describe('Selected State', () => {
+    it('should highlight the selected menu item', async () => {
+      render(<PopoverMenu {...defaultProps} open={true} page="Search" />)
+
+      await waitFor(() => {
+        const searchItem = screen.getByRole('menuitem', { name: /search/i })
+        expect(searchItem).toHaveClass('bg-accent', 'text-accent-foreground', 'font-medium')
+        expect(searchItem).toHaveAttribute('aria-current', 'page')
+      })
+    })
+
+    it('should not highlight non-selected menu items', async () => {
+      render(<PopoverMenu {...defaultProps} open={true} page="Search" />)
+
+      await waitFor(() => {
+        const postsItem = screen.getByRole('menuitem', { name: /posts/i })
+        expect(postsItem).not.toHaveClass('bg-accent', 'font-medium')
+        expect(postsItem).not.toHaveAttribute('aria-current')
+      })
+    })
+  })
+
+  describe('Keyboard Navigation', () => {
+    it('should support Tab navigation', async () => {
+      const user = userEvent.setup()
+      render(<PopoverMenu {...defaultProps} open={true} />)
+
+      // Focus should be on the trigger initially
+      const triggerButton = screen.getByLabelText('Open menu')
+      triggerButton.focus()
+
+      // Tab to first menu item
+      await user.tab()
+
+      await waitFor(() => {
+        const firstMenuItem = screen.getByRole('menuitem', { name: /search/i })
+        expect(firstMenuItem).toHaveFocus()
+      })
+    })
+
+    it('should support Enter key to activate menu item', async () => {
+      const user = userEvent.setup()
+      const handleClose = jest.fn()
+
+      render(<PopoverMenu {...defaultProps} open={true} handleClose={handleClose} />)
+
+      const searchItem = screen.getByRole('menuitem', { name: /search/i })
+      searchItem.focus()
+
+      await user.keyboard('{Enter}')
+
+      expect(handleClose).toHaveBeenCalled()
+    })
+
+    it('should support Escape key to close popover', async () => {
+      const user = userEvent.setup()
+      const handleClose = jest.fn()
+
+      render(<PopoverMenu {...defaultProps} open={true} handleClose={handleClose} />)
+
+      await user.keyboard('{Escape}')
+
+      await waitFor(() => {
+        expect(handleClose).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have proper ARIA labels', () => {
+      render(<PopoverMenu {...defaultProps} />)
+
+      const triggerButton = screen.getByLabelText('Open menu')
+      expect(triggerButton).toHaveAttribute('aria-label', 'Open menu')
+    })
+
+    it('should have proper ARIA roles for navigation menu', async () => {
+      render(<PopoverMenu {...defaultProps} open={true} />)
+
+      await waitFor(() => {
+        const nav = screen.getByRole('menu', { name: /navigation menu/i })
+        expect(nav).toBeInTheDocument()
+
+        const menuItems = screen.getAllByRole('menuitem')
+        expect(menuItems.length).toBeGreaterThan(0)
+      })
+    })
+
+    it('should mark selected item with aria-current', async () => {
+      render(<PopoverMenu {...defaultProps} open={true} page="Search" />)
+
+      await waitFor(() => {
+        const searchItem = screen.getByRole('menuitem', { name: /search/i })
+        expect(searchItem).toHaveAttribute('aria-current', 'page')
+      })
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle empty routes array', () => {
+      render(
+        <PopoverMenu
+          {...defaultProps}
+          appRoutes={[]}
+          open={true}
+        />
+      )
+
+      const nav = screen.getByRole('menu', { name: /navigation menu/i })
+      expect(nav).toBeInTheDocument()
+      expect(nav.children.length).toBe(0)
+    })
+
+    it('should handle routes with special characters in path', async () => {
+      const specialRoutes: AppRoute[] = [
+        {
+          path: 'path-with-dashes',
+          name: 'Path With Dashes',
+          layout: '/',
+        },
+      ]
+
+      render(
+        <PopoverMenu
+          {...defaultProps}
+          appRoutes={specialRoutes}
+          open={true}
+        />
+      )
+
+      await waitFor(() => {
+        const link = screen.getByRole('menuitem', { name: /path with dashes/i })
+        expect(link).toHaveAttribute('href', '/path-with-dashes')
+      })
+    })
+
+    it('should apply custom className', () => {
+      const { container } = render(
+        <PopoverMenu {...defaultProps} className="custom-class" />
+      )
+
+      const wrapper = container.firstChild as HTMLElement
+      expect(wrapper).toHaveClass('custom-class')
+    })
+  })
+})
+

--- a/quotevote-frontend/src/app/test/popover-menu/page.tsx
+++ b/quotevote-frontend/src/app/test/popover-menu/page.tsx
@@ -1,0 +1,241 @@
+'use client'
+
+import { useState } from 'react'
+import { PopoverMenu } from '@/components/PopoverMenu'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import type { AppRoute } from '@/types/components'
+
+/**
+ * Test Page for PopoverMenu Component
+ * 
+ * This page demonstrates the PopoverMenu component functionality:
+ * - Trigger button and open/close behavior
+ * - Menu item clicks and navigation
+ * - Keyboard accessibility (Tab, Enter, Escape)
+ * - Selected state highlighting
+ * - Mobile-only display
+ */
+export default function PopoverMenuTestPage() {
+  const [open, setOpen] = useState(false)
+  const [currentPage, setCurrentPage] = useState('Search')
+
+  const mockAppRoutes: AppRoute[] = [
+    {
+      path: 'search',
+      name: 'Search',
+      layout: '/',
+    },
+    {
+      path: 'post',
+      name: 'Posts',
+      layout: '/',
+    },
+    {
+      path: 'Profile',
+      name: 'My Profile',
+      layout: '/',
+    },
+    {
+      path: '/logout',
+      name: 'Logout',
+      layout: '/logout',
+    },
+    {
+      path: 'ControlPanel',
+      name: 'Control Panel',
+      layout: '/',
+      requiresAuth: true,
+    },
+  ]
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    setOpen(true)
+  }
+
+  const handleClose = () => {
+    setOpen(false)
+  }
+
+  const handlePageChange = (pageName: string) => {
+    setCurrentPage(pageName)
+    setOpen(false)
+  }
+
+  return (
+    <div className="min-h-screen bg-background p-8">
+      <div className="max-w-4xl mx-auto space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold mb-2">PopoverMenu Component Test</h1>
+          <p className="text-muted-foreground">
+            Test page for the migrated PopoverMenu component
+          </p>
+        </div>
+
+        <Card className="p-6">
+          <CardHeader>
+            <CardTitle>Component Demo</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="bg-primary rounded-lg p-4">
+              <PopoverMenu
+                appRoutes={mockAppRoutes}
+                open={open}
+                handleClick={handleClick}
+                handleClose={handleClose}
+                page={currentPage}
+              />
+            </div>
+
+            <div className="mt-4 p-4 bg-muted rounded-lg">
+              <h3 className="font-semibold mb-2">Current State:</h3>
+              <ul className="list-disc list-inside space-y-1 text-sm">
+                <li>Popover open: {open ? 'Yes' : 'No'}</li>
+                <li>Current page: {currentPage}</li>
+              </ul>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="p-6">
+          <CardHeader>
+            <CardTitle>Test Instructions</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <div>
+                <h3 className="font-semibold mb-2">1. Basic Functionality</h3>
+                <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
+                  <li>Click the menu icon (hamburger) to open the popover</li>
+                  <li>Click a menu item to navigate and close the popover</li>
+                  <li>Click outside the popover to close it</li>
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="font-semibold mb-2">2. Keyboard Navigation</h3>
+                <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
+                  <li>Press <kbd className="px-1.5 py-0.5 bg-muted rounded text-xs">Tab</kbd> to navigate between menu items</li>
+                  <li>Press <kbd className="px-1.5 py-0.5 bg-muted rounded text-xs">Enter</kbd> to activate a menu item</li>
+                  <li>Press <kbd className="px-1.5 py-0.5 bg-muted rounded text-xs">Escape</kbd> to close the popover</li>
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="font-semibold mb-2">3. Visual States</h3>
+                <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
+                  <li>Verify the current page is highlighted in the menu</li>
+                  <li>Check hover states on menu items</li>
+                  <li>Verify focus states during keyboard navigation</li>
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="font-semibold mb-2">4. Responsive Behavior</h3>
+                <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
+                  <li>Component should only be visible on mobile devices (below md breakpoint)</li>
+                  <li>On desktop (md and above), the component should be hidden</li>
+                  <li>Resize your browser window to test responsive behavior</li>
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="font-semibold mb-2">5. Accessibility</h3>
+                <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
+                  <li>Verify ARIA labels are present on the trigger button</li>
+                  <li>Check that menu items have proper ARIA roles</li>
+                  <li>Verify the selected item has aria-current=&quot;page&quot;</li>
+                </ul>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="p-6">
+          <CardHeader>
+            <CardTitle>Interactive Controls</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <h3 className="font-semibold mb-2">Change Current Page</h3>
+              <div className="flex flex-wrap gap-2">
+                {mockAppRoutes.map((route) => (
+                  <Button
+                    key={route.path}
+                    variant={currentPage === route.name ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => handlePageChange(route.name)}
+                  >
+                    {route.name}
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <h3 className="font-semibold mb-2">Control Popover</h3>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setOpen(true)}
+                >
+                  Open Popover
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setOpen(false)}
+                >
+                  Close Popover
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="p-6">
+          <CardHeader>
+            <CardTitle>Component Props</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2 text-sm">
+              <div>
+                <code className="bg-muted px-2 py-1 rounded">appRoutes</code>
+                <p className="text-muted-foreground mt-1">
+                  Array of route objects with path, name, layout, and optional icon
+                </p>
+              </div>
+              <div>
+                <code className="bg-muted px-2 py-1 rounded">open</code>
+                <p className="text-muted-foreground mt-1">
+                  Boolean controlling whether the popover is open
+                </p>
+              </div>
+              <div>
+                <code className="bg-muted px-2 py-1 rounded">handleClick</code>
+                <p className="text-muted-foreground mt-1">
+                  Callback function called when the trigger button is clicked
+                </p>
+              </div>
+              <div>
+                <code className="bg-muted px-2 py-1 rounded">handleClose</code>
+                <p className="text-muted-foreground mt-1">
+                  Callback function called when the popover should be closed
+                </p>
+              </div>
+              <div>
+                <code className="bg-muted px-2 py-1 rounded">page</code>
+                <p className="text-muted-foreground mt-1">
+                  Current page name used to highlight the active menu item
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+

--- a/quotevote-frontend/src/components/PopoverMenu.tsx
+++ b/quotevote-frontend/src/components/PopoverMenu.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import Link from "next/link"
+import { Menu } from "lucide-react"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import type { PopoverMenuProps } from "@/types/components"
+
+/**
+ * PopoverMenu Component
+ * 
+ * A mobile-only navigation menu that displays application routes in a popover.
+ * Replaces the MUI PopoverMenu with shadcn/ui Popover primitives.
+ * Includes an AppBar-like header structure with menu button and page title.
+ * 
+ * @example
+ * ```tsx
+ * const [open, setOpen] = useState(false)
+ * const routes = [{ path: 'search', name: 'Search', layout: '/' }]
+ * 
+ * <PopoverMenu
+ *   appRoutes={routes}
+ *   open={open}
+ *   handleClick={() => setOpen(true)}
+ *   handleClose={() => setOpen(false)}
+ *   page="Search"
+ * />
+ * ```
+ */
+export function PopoverMenu({
+  appRoutes,
+  handleClick,
+  handleClose,
+  open,
+  page,
+  className,
+}: PopoverMenuProps) {
+  return (
+    <div className={cn("md:hidden", className)}>
+      <header className="sticky top-0 z-50 w-full border-b bg-primary text-primary-foreground">
+        <div className="flex h-14 items-center px-4">
+          <Popover open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleClick}
+                aria-label="Open menu"
+                className="mr-2 text-white hover:bg-white/10"
+              >
+                <Menu className="h-6 w-6" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="start"
+              className="w-56 p-1"
+              onOpenAutoFocus={(e) => e.preventDefault()}
+            >
+              <nav className="flex flex-col" role="menu" aria-label="Navigation menu">
+                {appRoutes.map((appRoute) => {
+                  const href = `${appRoute.layout}${appRoute.path}`
+                  const isSelected = appRoute.name === page
+
+                  return (
+                    <Link
+                      key={appRoute.path}
+                      href={href}
+                      onClick={handleClose}
+                      className={cn(
+                        "flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors",
+                        "focus:bg-accent focus:text-accent-foreground",
+                        "hover:bg-accent hover:text-accent-foreground",
+                        isSelected && "bg-accent text-accent-foreground font-medium",
+                        "cursor-pointer"
+                      )}
+                      role="menuitem"
+                      aria-current={isSelected ? "page" : undefined}
+                    >
+                      {appRoute.icon && (
+                        <span className="flex-shrink-0">
+                          <appRoute.icon className="h-4 w-4" />
+                        </span>
+                      )}
+                      <span>{appRoute.name}</span>
+                    </Link>
+                  )
+                })}
+              </nav>
+            </PopoverContent>
+          </Popover>
+          <h1 className="text-lg font-semibold text-white">{page}</h1>
+        </div>
+      </header>
+    </div>
+  )
+}
+

--- a/quotevote-frontend/src/types/components.ts
+++ b/quotevote-frontend/src/types/components.ts
@@ -1060,3 +1060,76 @@ export interface LogoutPageProps {
   className?: string;
 }
 
+// ============================================================================
+// PopoverMenu Component Types
+// ============================================================================
+
+/**
+ * Route definition for navigation menu items
+ */
+export interface AppRoute {
+  /**
+   * Route path segment
+   */
+  path: string;
+  /**
+   * Display name for the route
+   */
+  name: string;
+  /**
+   * Layout path prefix (e.g., '/' or '/logout')
+   */
+  layout: string;
+  /**
+   * Optional icon component
+   */
+  icon?: React.ComponentType<{ className?: string }>;
+  /**
+   * Whether authentication is required for this route
+   * @default false
+   */
+  requiresAuth?: boolean;
+  /**
+   * Optional RTL name for right-to-left languages
+   */
+  rtlName?: string;
+  /**
+   * Optional mini abbreviation
+   */
+  mini?: string;
+  /**
+   * Optional RTL mini abbreviation
+   */
+  rtlMini?: string;
+}
+
+/**
+ * Props for PopoverMenu component
+ */
+export interface PopoverMenuProps {
+  /**
+   * Array of application routes to display in the menu
+   */
+  appRoutes: AppRoute[];
+  /**
+   * Handler function called when the menu trigger is clicked
+   */
+  handleClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  /**
+   * Handler function called when the menu should be closed
+   */
+  handleClose: () => void;
+  /**
+   * Whether the popover menu is open
+   */
+  open: boolean;
+  /**
+   * Current page name to highlight the active menu item
+   */
+  page: string;
+  /**
+   * Additional CSS classes for the container
+   */
+  className?: string;
+}
+


### PR DESCRIPTION
## Description

Migrates `PopoverMenu` component from MUI to shadcn/ui, converting from JSX to TypeScript with proper type definitions.

## Changes Made

- ✅ Migrated `PopoverMenu.jsx` → `components/PopoverMenu.tsx`
- ✅ Replaced MUI Popover/Menu with shadcn/ui Popover primitives
- ✅ Converted to TypeScript with types in `@/types/components.ts`
- ✅ Replaced react-router `Link` with Next.js `Link`
- ✅ Applied Tailwind CSS styling (mobile-only with `md:hidden`)
- ✅ Added comprehensive test suite (21 tests)
- ✅ Created test page at `app/test/popover-menu/page.tsx`

## Testing

- ✅ All 21 tests pass
- ✅ TypeScript type checks pass
- ✅ No linter errors
- ✅ Test page available at `/test/popover-menu`

## Type Safety

- ✅ No `any` types used
- ✅ All types defined in `@/types/components.ts`
- ✅ TypeScript compiles without errors

## Issue Reference

Closes #65 