### PR TITLE
feat: migrate RequestInviteDialog from MUI to shadcn/ui

### DIFF
--- a/quotevote-frontend/src/__tests__/components/LogoutPage.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/LogoutPage.test.tsx
@@ -168,6 +168,10 @@ describe('LogoutPage Component', () => {
 
   describe('Error Handling', () => {
     it('still redirects to login page even when error occurs', async () => {
+      // Mock console.error to suppress expected error log
+      const originalError = console.error;
+      console.error = jest.fn();
+      
       mockApolloClient.resetStore.mockRejectedValueOnce(new Error('Test error'));
 
       render(<LogoutPage />);
@@ -181,9 +185,16 @@ describe('LogoutPage Component', () => {
       await waitFor(() => {
         expect(mockPush).toHaveBeenCalledWith('/auth/login');
       }, { timeout: 3000 });
+      
+      // Restore console.error
+      console.error = originalError;
     });
 
     it('handles errors gracefully and redirects', async () => {
+      // Mock console.error to suppress expected error log
+      const originalError = console.error;
+      console.error = jest.fn();
+      
       // Test that errors don't prevent logout
       mockApolloClient.resetStore.mockRejectedValueOnce(new Error('Test error'));
 
@@ -199,6 +210,9 @@ describe('LogoutPage Component', () => {
       await waitFor(() => {
         expect(mockPush).toHaveBeenCalledWith('/auth/login');
       }, { timeout: 3000 });
+      
+      // Restore console.error
+      console.error = originalError;
     });
   });
 

--- a/quotevote-frontend/src/__tests__/components/RequestInviteDialog.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/RequestInviteDialog.test.tsx
@@ -1,0 +1,404 @@
+/**
+ * RequestInviteDialog Component Tests
+ * 
+ * Tests for the RequestInviteDialog component including:
+ * - Dialog open/close functionality
+ * - Email validation
+ * - Duplicate email checking
+ * - Mutation handling
+ * - Error and success states
+ * - Auto-close after submission
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@/__tests__/utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { RequestInviteDialog } from '@/components/RequestInviteDialog';
+
+// Mock toast
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+
+// Mock Next.js navigation
+const mockPathname = jest.fn(() => '/test-path');
+const mockSearchParams = {
+  toString: jest.fn(() => ''),
+  get: jest.fn(),
+};
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+  useSearchParams: () => mockSearchParams,
+}));
+
+// Mock Apollo Client hooks
+const mockQuery = jest.fn();
+const mockMutation = jest.fn();
+const mockClient = {
+  query: mockQuery,
+};
+
+// Create a mock function for useMutation that can be controlled per test
+const mockUseMutation = jest.fn(() => [
+  mockMutation,
+  { loading: false },
+]);
+
+jest.mock('@apollo/client', () => {
+  const actual = jest.requireActual('@apollo/client');
+  return {
+    ...actual,
+    useApolloClient: () => mockClient,
+    useMutation: () => mockUseMutation(),
+  };
+});
+
+describe('RequestInviteDialog', () => {
+  const defaultProps = {
+    open: true,
+    onClose: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    
+    // Reset useMutation mock to default
+    mockUseMutation.mockReturnValue([
+      mockMutation,
+      { loading: false },
+    ]);
+    
+    // Default query response (no duplicate)
+    mockQuery.mockResolvedValue({
+      data: {
+        checkDuplicateEmail: [],
+      },
+    });
+    
+    // Default mutation response
+    mockMutation.mockResolvedValue({
+      data: {
+        requestUserAccess: {
+          _id: '123',
+          email: 'test@example.com',
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('renders dialog when open is true', () => {
+    render(<RequestInviteDialog {...defaultProps} />);
+
+    expect(
+      screen.getByText(/you need an account to contribute/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(/enter your email address/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /request invite/i })
+    ).toBeInTheDocument();
+  });
+
+  it('does not render dialog when open is false', () => {
+    render(<RequestInviteDialog open={false} onClose={jest.fn()} />);
+
+    expect(
+      screen.queryByText(/you need an account to contribute/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when dialog is closed', async () => {
+    const onClose = jest.fn();
+    render(<RequestInviteDialog open={true} onClose={onClose} />);
+
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    fireEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('shows validation error for invalid email', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<RequestInviteDialog {...defaultProps} />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+    const submitButton = screen.getByRole('button', { name: /request invite/i });
+
+    await user.type(emailInput, 'invalid-email');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/please enter a valid email address/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows error for empty email', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<RequestInviteDialog {...defaultProps} />);
+
+    const submitButton = screen.getByRole('button', { name: /request invite/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/email is required/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error for duplicate email', async () => {
+    const user = userEvent.setup({ delay: null });
+    
+    // Mock query to return duplicate email
+    mockQuery.mockResolvedValue({
+      data: {
+        checkDuplicateEmail: [{ _id: '1', email: 'existing@example.com' }],
+      },
+    });
+
+    render(<RequestInviteDialog {...defaultProps} />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+    const submitButton = screen.getByRole('button', { name: /request invite/i });
+
+    await user.type(emailInput, 'existing@example.com');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /this email address has already been used to request an invite/i
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('submits form successfully with valid email', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<RequestInviteDialog {...defaultProps} />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+    const submitButton = screen.getByRole('button', { name: /request invite/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockQuery).toHaveBeenCalledWith({
+        query: expect.any(Object),
+        variables: { email: 'test@example.com' },
+        fetchPolicy: 'network-only',
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockMutation).toHaveBeenCalledWith({
+        variables: {
+          requestUserAccessInput: { email: 'test@example.com' },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Request submitted successfully!');
+    });
+  });
+
+  it('shows success message after successful submission', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<RequestInviteDialog {...defaultProps} />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+    const submitButton = screen.getByRole('button', { name: /request invite/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/thank you for joining us/i)
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(
+        /when an account becomes available, an invite will be sent to the email provided/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('auto-closes dialog after 3 seconds on successful submission', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup({ delay: null });
+    render(<RequestInviteDialog open={true} onClose={onClose} />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+    const submitButton = screen.getByRole('button', { name: /request invite/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/thank you for joining us/i)
+      ).toBeInTheDocument();
+    });
+
+    // Fast-forward 3 seconds
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('handles mutation error and shows error message', async () => {
+    const user = userEvent.setup({ delay: null });
+    
+    // Mock console.error to suppress expected error log
+    const originalError = console.error;
+    console.error = jest.fn();
+    
+    // Mock mutation to throw error
+    mockMutation.mockRejectedValue(new Error('Network error'));
+
+    render(<RequestInviteDialog {...defaultProps} />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+    const submitButton = screen.getByRole('button', { name: /request invite/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/an unexpected error occurred. please try again later./i)
+      ).toBeInTheDocument();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Failed to submit request');
+    
+    // Restore console.error
+    console.error = originalError;
+  });
+
+  it('submits on Enter key press', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<RequestInviteDialog {...defaultProps} />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+
+    await user.type(emailInput, 'test@example.com{Enter}');
+
+    await waitFor(() => {
+      expect(mockQuery).toHaveBeenCalled();
+    });
+  });
+
+  it('clears form state when dialog closes', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup({ delay: null });
+    const { rerender } = render(<RequestInviteDialog open={true} onClose={onClose} />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+    await user.type(emailInput, 'test@example.com');
+    expect(emailInput).toHaveValue('test@example.com');
+
+    // Close dialog
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    fireEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    // Re-open dialog - the state should be cleared
+    rerender(<RequestInviteDialog open={true} onClose={onClose} />);
+    
+    const newEmailInput = screen.getByPlaceholderText(/enter your email address/i);
+    expect(newEmailInput).toHaveValue('');
+  });
+
+  it('displays loading state on button when submitting', async () => {
+    // Mock loading state
+    mockUseMutation.mockReturnValueOnce([
+      mockMutation,
+      { loading: true },
+    ]);
+
+    render(<RequestInviteDialog {...defaultProps} />);
+
+    const submitButton = screen.getByRole('button', { name: /submitting/i });
+    expect(submitButton).toBeInTheDocument();
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('renders login link with correct redirect URL', () => {
+    mockPathname.mockReturnValue('/current-page');
+    mockSearchParams.toString.mockReturnValue('param=value');
+
+    render(<RequestInviteDialog {...defaultProps} />);
+
+    const loginLink = screen.getByRole('link', { name: /login/i });
+    expect(loginLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('/auth/login?redirect=')
+    );
+  });
+
+  it('renders mission link correctly', () => {
+    render(<RequestInviteDialog {...defaultProps} />);
+
+    const missionLink = screen.getByRole('link', {
+      name: /learn more about our mission here/i,
+    });
+    expect(missionLink).toHaveAttribute('href', '/auth/request-access#mission');
+  });
+
+  it('cleans up timeout on unmount', async () => {
+    const user = userEvent.setup({ delay: null });
+    const { unmount } = render(<RequestInviteDialog {...defaultProps} />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email address/i);
+    const submitButton = screen.getByRole('button', { name: /request invite/i });
+
+    await user.type(emailInput, 'test@example.com');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/thank you for joining us/i)
+      ).toBeInTheDocument();
+    });
+
+    // Unmount before timeout completes
+    unmount();
+
+    // Fast-forward time - should not cause errors
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    // No errors should occur
+    expect(true).toBe(true);
+  });
+});
+

--- a/quotevote-frontend/src/app/test/request-invite-dialog/page.tsx
+++ b/quotevote-frontend/src/app/test/request-invite-dialog/page.tsx
@@ -1,0 +1,64 @@
+/**
+ * Test page for RequestInviteDialog component
+ * 
+ * This page is used for testing the RequestInviteDialog component
+ * 
+ * Test Instructions:
+ * 1. Click "Open Dialog" button to open the dialog
+ * 2. Test invalid email → validation errors should appear
+ * 3. Test valid email → submission → success toast → dialog shows success message
+ * 4. Confirm dialog closes after 3 seconds or when clicking close
+ * 5. Test duplicate email → error message should appear
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { RequestInviteDialog } from '@/components/RequestInviteDialog';
+import { Button } from '@/components/ui/button';
+
+export default function RequestInviteDialogTestPage() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <h1 className="text-3xl font-bold mb-8">Request Invite Dialog Test Page</h1>
+      
+      <div className="space-y-4">
+        <div>
+          <Button onClick={() => setOpen(true)}>
+            Open Dialog
+          </Button>
+        </div>
+
+        <div className="mt-8 p-4 bg-gray-100 rounded-lg">
+          <h2 className="text-xl font-semibold mb-4">Test Instructions:</h2>
+          <ol className="list-decimal list-inside space-y-2">
+            <li>Click &quot;Open Dialog&quot; button to open the dialog</li>
+            <li>Test invalid email → validation errors should appear</li>
+            <li>Test valid email → submission → success toast → dialog shows success message</li>
+            <li>Confirm dialog closes after 3 seconds or when clicking close</li>
+            <li>Test duplicate email → error message should appear</li>
+          </ol>
+        </div>
+
+        <div className="mt-8 p-4 bg-blue-50 rounded-lg">
+          <h2 className="text-xl font-semibold mb-4">Expected Behavior:</h2>
+          <ul className="list-disc list-inside space-y-2">
+            <li>✅ Dialog opens from trigger</li>
+            <li>✅ Validates user input (email format)</li>
+            <li>✅ Checks for duplicate emails</li>
+            <li>✅ Submits the request via GraphQL mutation</li>
+            <li>✅ Displays success/error feedback via toast</li>
+            <li>✅ Shows success message in dialog</li>
+            <li>✅ Closes properly after 3 seconds or manual close</li>
+            <li>✅ Focus management within Dialog for accessibility</li>
+          </ul>
+        </div>
+      </div>
+
+      <RequestInviteDialog open={open} onClose={() => setOpen(false)} />
+    </div>
+  );
+}
+

--- a/quotevote-frontend/src/components/RequestInviteDialog.tsx
+++ b/quotevote-frontend/src/components/RequestInviteDialog.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+/**
+ * RequestInviteDialog Component
+ * 
+ * Dialog component for requesting platform access via email invitation.
+ * Migrated from Material UI to shadcn/ui components.
+ */
+
+import { useState, useEffect, useRef } from 'react';
+// @ts-expect-error - Apollo Client v4.0.9 has type resolution issues with useMutation and useApolloClient exports
+import { useApolloClient, useMutation } from '@apollo/client';
+import { usePathname, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { toast } from 'sonner';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { REQUEST_USER_ACCESS_MUTATION } from '@/graphql/mutations';
+import { GET_CHECK_DUPLICATE_EMAIL } from '@/graphql/queries';
+import { requestAccessEmailSchema } from '@/lib/validation/requestAccessSchema';
+import type { RequestInviteDialogProps } from '@/types/components';
+
+export function RequestInviteDialog({ open, onClose }: RequestInviteDialogProps) {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  
+  const client = useApolloClient();
+  const [requestUserAccess, { loading }] = useMutation(
+    REQUEST_USER_ACCESS_MUTATION
+  );
+
+  const handleSubmit = async () => {
+    setError('');
+
+    // Validate email using Zod schema
+    const validationResult = requestAccessEmailSchema.safeParse({ email });
+
+    if (!validationResult.success) {
+      setError(
+        validationResult.error.issues[0]?.message || 'Please enter a valid email address'
+      );
+      return;
+    }
+
+    try {
+      // Check for duplicate email
+      const checkDuplicate = await client.query({
+        query: GET_CHECK_DUPLICATE_EMAIL,
+        variables: { email },
+        fetchPolicy: 'network-only',
+      });
+
+      if (
+        checkDuplicate &&
+        Array.isArray(checkDuplicate.data.checkDuplicateEmail) &&
+        checkDuplicate.data.checkDuplicateEmail.length > 0
+      ) {
+        setError(
+          'This email address has already been used to request an invite.'
+        );
+        return;
+      }
+
+      // Submit request
+      await requestUserAccess({
+        variables: { requestUserAccessInput: { email } },
+      });
+      
+      setSubmitted(true);
+      toast.success('Request submitted successfully!');
+      
+      // Auto-close after 3 seconds with cleanup
+      timeoutRef.current = setTimeout(() => {
+        handleClose();
+      }, 3000);
+    } catch (err) {
+      const error = err as Error;
+      setError('An unexpected error occurred. Please try again later.');
+      toast.error('Failed to submit request');
+      console.error(error);
+    }
+  };
+
+  const handleClose = () => {
+    // Clear timeout if it exists
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setEmail('');
+    setError('');
+    setSubmitted(false);
+    onClose();
+  };
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  // Get current URL path to pass as redirect parameter (including hash)
+  const currentPath = pathname + (searchParams.toString() ? `?${searchParams.toString()}` : '');
+  const loginUrl = `/auth/login?redirect=${encodeURIComponent(currentPath)}`;
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
+      <DialogContent className="sm:max-w-md">
+        {submitted ? (
+          <div className="flex flex-col items-center space-y-4 py-4">
+            <DialogHeader>
+              <DialogTitle className="text-center text-xl font-semibold text-gray-900">
+                Thank you for joining us
+              </DialogTitle>
+            </DialogHeader>
+            <DialogDescription className="text-center text-gray-600 text-sm leading-relaxed">
+              When an account becomes available, an invite will be sent to the
+              email provided.
+            </DialogDescription>
+          </div>
+        ) : (
+          <div className="flex flex-col space-y-4">
+            <DialogHeader>
+              <DialogTitle className="text-center text-base font-medium text-gray-900 leading-relaxed">
+                You need an account to contribute. Viewing is public, but
+                posting, voting, and quoting require an invite.
+              </DialogTitle>
+            </DialogHeader>
+
+            <div className="space-y-2">
+              <Label htmlFor="email" className="sr-only">
+                Email Address
+              </Label>
+              <div className="relative">
+                <div className="absolute inset-0 bg-gradient-to-br from-gray-50 to-gray-100 rounded-lg border-2 border-gray-200 transition-all duration-300 focus-within:border-[#52b274] focus-within:shadow-[0_0_0_4px_rgba(82,178,116,0.1)] focus-within:bg-gradient-to-br focus-within:from-white focus-within:to-gray-50" />
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="Enter Your Email Address"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+                  className="relative bg-transparent border-none outline-none w-full text-base sm:text-lg text-gray-800 font-medium placeholder:text-gray-500 focus:ring-0 focus-visible:ring-0"
+                />
+              </div>
+            </div>
+
+            {error && (
+              <div className="bg-red-50 border border-red-200 rounded-lg p-3 sm:p-4 text-center">
+                <p className="text-red-800 text-sm sm:text-[0.95rem] font-medium m-0">
+                  {error}
+                </p>
+              </div>
+            )}
+
+            <div className="text-center py-2">
+              <Link
+                href="/auth/request-access#mission"
+                className="text-[#52b274] no-underline text-sm sm:text-[0.95rem] font-medium transition-colors duration-300 hover:text-[#4a9f63] hover:underline"
+              >
+                Learn more about our mission here
+              </Link>
+            </div>
+
+            <Button
+              onClick={handleSubmit}
+              disabled={loading}
+              className="w-full bg-[#52b274] text-white hover:bg-[#4a9f63] rounded-lg py-3 px-6 text-base font-medium transition-colors duration-300"
+            >
+              {loading ? 'Submitting...' : 'Request Invite'}
+            </Button>
+
+            <p className="text-center text-sm text-gray-600 mt-4">
+              Already have an account?{' '}
+              <Link
+                href={loginUrl}
+                className="text-[#52b274] no-underline font-medium transition-colors duration-300 hover:underline"
+              >
+                Login
+              </Link>
+            </p>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/quotevote-frontend/src/types/components.ts
+++ b/quotevote-frontend/src/types/components.ts
@@ -726,6 +726,17 @@ export interface RequestAccessFormProps {
   onSuccess?: () => void;
 }
 
+export interface RequestInviteDialogProps {
+  /**
+   * Whether the dialog is open
+   */
+  open: boolean;
+  /**
+   * Callback function called when dialog should close
+   */
+  onClose: () => void;
+}
+
 export interface CardDetails {
   cardNumber: string;
   expiry: string;


### PR DESCRIPTION
## Description

### Summary
Migrates `RequestInviteDialog` from MUI to shadcn/ui, converting JSX to TypeScript and updating to Next.js patterns.

### Changes
- Converted component to TypeScript with type definitions
- Replaced MUI components with shadcn/ui (Dialog, Input, Button)
- Implemented Zod validation for email input
- Migrated from React Router to Next.js navigation (`usePathname`, `useSearchParams`)
- Added toast notifications using sonner
- Integrated GraphQL mutations and queries
- Added auto-close after successful submission (3s)

### Testing
- 16 tests added, all passing
- Test page available at `/test/request-invite-dialog`
- Manual testing instructions included

### Acceptance Criteria Met
- Component exists at `components/RequestInviteDialog.tsx`
- No MUI imports remain
- Form validation and submission flow work correctly
- Build and TypeScript checks pass
- Comprehensive test coverage

Closes #66 