### PR TITLE
feat(error-boundary): add test page for component verification

### DIFF
--- a/quotevote-frontend/src/app/test/error-boundary/page.tsx
+++ b/quotevote-frontend/src/app/test/error-boundary/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { Button } from '@/components/ui/button';
+
+// 1. A component that will throw an error when a button is clicked
+function BuggyComponent() {
+  const [shouldThrow, setShouldThrow] = useState(false);
+
+  if (shouldThrow) {
+    throw new Error('💥 Intentional error from BuggyComponent!');
+  }
+
+  return (
+    <div className="p-4 border border-dashed border-gray-300 rounded-md">
+      <p className="text-sm text-gray-600 mb-3">
+        This is a child component. Click the button to trigger a render error.
+      </p>
+      <Button onClick={() => setShouldThrow(true)} variant="destructive">
+        Trigger Error
+      </Button>
+    </div>
+  );
+}
+
+// 2. A custom fallback component to display when an error is caught
+function CustomErrorFallback() {
+  return (
+    <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 rounded-md" role="alert">
+      <h3 className="font-bold">Oops! A Wild Error Appeared!</h3>
+      <p>Something went wrong inside this component, but the rest of the app is still running.</p>
+    </div>
+  );
+}
+
+
+// 3. The test page that uses the ErrorBoundary
+export default function ErrorBoundaryTestPage() {
+  return (
+    <div className="container mx-auto p-8 space-y-8">
+      <header>
+        <h1 className="text-3xl font-bold">ErrorBoundary Test Page</h1>
+        <p className="text-gray-500 mt-2">
+          This page demonstrates how the ErrorBoundary component gracefully handles UI errors.
+        </p>
+      </header>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Test Case 1: Default Fallback UI</h2>
+        <p className="mb-3">
+          This ErrorBoundary will use the default, beautifully styled fallback screen.
+        </p>
+        <div className="bg-gray-50 p-6 rounded-lg shadow-inner">
+          <ErrorBoundary>
+            <BuggyComponent />
+          </ErrorBoundary>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Test Case 2: Custom Fallback Component</h2>
+        <p className="mb-3">
+          This ErrorBoundary is given a custom, simpler fallback component via the `fallback` prop.
+        </p>
+        <div className="bg-gray-50 p-6 rounded-lg shadow-inner">
+          <ErrorBoundary fallback={<CustomErrorFallback />}>
+            <BuggyComponent />
+          </ErrorBoundary>
+        </div>
+      </section>
+
+      <section className="p-4 border border-green-300 bg-green-50 rounded-md">
+        <h2 className="text-xl font-semibold text-green-800">I am outside the boundary</h2>
+        <p className="text-green-700 mt-2">
+          This component is not wrapped in an ErrorBoundary. If an error occurs above, I should still be visible and interactive, proving the app hasn&apos;t crashed.
+        </p>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds the missing test page for the `ErrorBoundary` component, located at `app/test/error-boundary/page.tsx`.

This page is designed to intentionally trigger rendering errors within a child component, allowing developers and QA to visually and manually verify that the `ErrorBoundary` correctly catches the error and displays the appropriate fallback UI.

## Related Issue (Link to issue ticket)

Closes #61

## Motivation and Context

The `ErrorBoundary` component was successfully migrated to `main`, but the test page required by the issue's "Test Instructions" and "Acceptance Criteria" was missing. This PR adds that missing piece, which unblocks manual testing and fully completes all requirements of the original issue.

## How Has This Been Tested?

This change was tested manually by following these steps:
1.  Ran the application using `pnpm dev`.
2.  Navigated to the newly created page at `http://localhost:3000/test/error-boundary`.
3.  Clicked the "Trigger Error" button in both "Test Case 1" and "Test Case 2".
4.  **Verified** that the `ErrorBoundary` caught the error and displayed the correct fallback UI (the default styled component for Test Case 1, and the custom component for Test Case 2).
5.  **Verified** that the rest of the application outside the boundary remained interactive and did not crash.
6.  **Verified** that the error was correctly logged to the browser's developer console.

## Screenshots (if appropriate - Postman, etc):

*Please add a screenshot here of the test page showing the fallback UI after an error has been triggered.*

<img width="890" height="856" alt="Screenshot 2026-01-09 at 09 17 58" src="https://github.com/user-attachments/assets/276e5aee-adf4-4994-ac5a-098f98635fe1" />
--
<img width="1440" height="816" alt="Screenshot 2026-01-09 at 09 20 19" src="https://github.com/user-attachments/assets/606d2877-6a80-4e6f-a77d-30fa28b8d318" />
--
<img width="1440" height="816" alt="Screenshot 2026-01-09 at 09 20 33" src="https://github.com/user-attachments/assets/74e75b0f-e8c3-4630-a660-6f6ff5c69f69" />
--

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes. (The file itself is a test page).
- [x] All new and existing tests passed. (Manual tests passed).
