### PR TITLE
feat(backend): Migrate SubscriptionEvents constants to TypeScript

### DIFF
--- a/quotevote-backend/app/data/utils/constants.ts
+++ b/quotevote-backend/app/data/utils/constants.ts
@@ -1,0 +1,18 @@
+export const SubscriptionEvents = {
+  MESSAGE_CREATED: 'MESSAGE_CREATED',
+  USER_MESSAGE_CREATED: 'USER_MESSAGE_CREATED',
+  USER_REACTION: 'USER_REACTION',
+  COMMENT_CREATED: 'COMMENT_CREATED',
+  NOTIFICATION_CREATED: 'NOTIFICATION_CREATED',
+} as const;
+
+export type SubscriptionEvent =
+  typeof SubscriptionEvents[keyof typeof SubscriptionEvents];
+
+// Export individual constants for backward compatibility, ensuring existing imports continue to function.
+
+export const MESSAGE_CREATED = SubscriptionEvents.MESSAGE_CREATED;
+export const USER_MESSAGE_CREATED = SubscriptionEvents.USER_MESSAGE_CREATED;
+export const USER_REACTION = SubscriptionEvents.USER_REACTION;
+export const COMMENT_CREATED = SubscriptionEvents.COMMENT_CREATED;
+export const NOTIFICATION_CREATED = SubscriptionEvents.NOTIFICATION_CREATED;


### PR DESCRIPTION


## Description

This pull request migrates the `SubscriptionEvents` constants from the legacy JavaScript file in the old monorepo to a new, type-safe TypeScript file within the `quotevote-backend`.

The following changes were made:
- Created a new file at `quotevote-backend/app/data/utils/constants.ts`.
- Grouped the related `SubscriptionEvents` constants into a single object.
- Used the `as const` assertion to provide strong, literal type safety for each constant.

## Related Issue (Link to issue ticket)

- Closes #118

## Motivation and Context

This change is part of the larger effort to migrate the QuoteVote application to a modern, type-safe Next.js and TypeScript stack. Migrating these constants improves developer experience, reduces the chance of runtime errors, and enhances code maintainability by grouping related values.

## How Has This Been Tested?

The changes were tested by:
1.  Manually verifying that all constant values from the original `constants.js` file in the `quotevote-monorepo` were correctly transferred to the new `constants.ts` file.
2.  Ensuring the new file is correctly structured and uses TypeScript features as intended for improved type safety.

No new automated tests were added as this is a direct migration of constant values. Existing and future tests that consume these constants will validate their usage.

## Screenshots (if appropriate)

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
