### PR TITLE
feat: migrate special routes to Next.js App Router

### DIFF
--- a/quotevote-frontend/src/__tests__/components/CustomButtons.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/CustomButtons.test.tsx
@@ -165,7 +165,7 @@ describe('CustomButtons Components', () => {
         if (button) {
           fireEvent.click(button);
           expect(onNavigate).toHaveBeenCalled();
-          expect(mockPush).toHaveBeenCalledWith('/ControlPanel');
+          expect(mockPush).toHaveBeenCalledWith('/dashboard/control-panel');
         }
       } else {
         expect(container).toBeInTheDocument();

--- a/quotevote-frontend/src/app/dashboard/control-panel/layout.tsx
+++ b/quotevote-frontend/src/app/dashboard/control-panel/layout.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+/**
+ * Control Panel Layout
+ * 
+ * Nested layout for the admin control panel.
+ * Migrated from Admin.jsx to Next.js App Router.
+ * 
+ * This layout provides admin-specific structure while inheriting
+ * the dashboard layout's MainNavBar and RequestInviteDialog.
+ */
+
+import type { ReactNode } from 'react';
+
+interface ControlPanelLayoutProps {
+  children: ReactNode;
+}
+
+export default function ControlPanelLayout({
+  children,
+}: ControlPanelLayoutProps): ReactNode {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 py-8">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/quotevote-frontend/src/app/error/page.tsx
+++ b/quotevote-frontend/src/app/error/page.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+/**
+ * Error Page
+ * 
+ * Displays error messages for 404 and expired/invalid links.
+ * Migrated from ErrorPage.jsx to Next.js App Router with Tailwind and shadcn/ui.
+ */
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AlertCircle, FileQuestion } from 'lucide-react';
+import Link from 'next/link';
+
+function ErrorPageContent(): React.ReactNode {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  
+  // Check if user came from signup page (expired/invalid token)
+  const fromSignup = searchParams.get('from') === 'signup';
+
+  const handleBack = () => {
+    router.push('/dashboard/search');
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4 bg-background">
+      <div className="max-w-lg w-full text-center space-y-6">
+        <div className="space-y-2">
+          {fromSignup ? (
+            <>
+              <AlertCircle className="h-16 w-16 mx-auto text-yellow-600 dark:text-yellow-400 mb-4" />
+              <h1 className="text-4xl font-bold text-foreground">Link Expired</h1>
+              <h2 className="text-2xl font-semibold text-muted-foreground">
+                Invalid or Expired Link
+              </h2>
+            </>
+          ) : (
+            <>
+              <FileQuestion className="h-16 w-16 mx-auto text-muted-foreground mb-4" />
+              <h1 className="text-4xl font-bold text-foreground">404</h1>
+              <h2 className="text-2xl font-semibold text-muted-foreground">
+                Page not found
+              </h2>
+            </>
+          )}
+        </div>
+
+        <Alert variant={fromSignup ? 'warning' : 'default'} className="text-left">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>
+            {fromSignup ? 'Invitation Link Expired' : 'Page Not Found'}
+          </AlertTitle>
+          <AlertDescription>
+            {fromSignup
+              ? 'Your invitation link has expired or is invalid. Invitation links are valid for 24 hours. Please request a new invitation or contact support.'
+              : 'Oooops! Looks like you got lost.'}
+          </AlertDescription>
+        </Alert>
+
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          {fromSignup ? (
+            <>
+              <Button asChild variant="default">
+                <Link href="/request-access">Request New Invite</Link>
+              </Button>
+              <Button onClick={handleBack} variant="outline">
+                Go to Search
+              </Button>
+            </>
+          ) : (
+            <Button onClick={handleBack} variant="default" className="w-full sm:w-auto">
+              Go to Search
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ErrorPage(): React.ReactNode {
+  return (
+    <Suspense fallback={
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <p className="text-lg text-muted-foreground">Loading...</p>
+        </div>
+      </div>
+    }>
+      <ErrorPageContent />
+    </Suspense>
+  );
+}

--- a/quotevote-frontend/src/app/unauth/page.tsx
+++ b/quotevote-frontend/src/app/unauth/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+/**
+ * Unauthenticated Page
+ * 
+ * Displays a token expired message and redirects to login.
+ * Migrated from TokenExpired.jsx to Next.js App Router with shadcn/ui components.
+ */
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { AlertCircle } from 'lucide-react';
+
+export default function UnauthPage(): React.ReactNode {
+  const router = useRouter();
+
+  const handleLogin = () => {
+    router.push('/login');
+  };
+
+  // Auto-redirect after a short delay
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.push('/login');
+    }, 5000);
+
+    return () => clearTimeout(timer);
+  }, [router]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <div className="max-w-md w-full">
+        <Alert variant="warning" className="mb-4">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Token Expired!</AlertTitle>
+          <AlertDescription>
+            Please login to continue.
+          </AlertDescription>
+        </Alert>
+        <Button 
+          onClick={handleLogin}
+          className="w-full"
+          variant="default"
+        >
+          Go to Login
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/quotevote-frontend/src/components/CustomButtons/AdminIconButton.tsx
+++ b/quotevote-frontend/src/components/CustomButtons/AdminIconButton.tsx
@@ -21,7 +21,7 @@ export function AdminIconButton({ fontSize, onNavigate }: AdminIconButtonProps) 
     if (onNavigate) {
       onNavigate();
     }
-    router.push('/ControlPanel');
+    router.push('/dashboard/control-panel');
   };
 
   // Only render if user is admin

--- a/quotevote-frontend/src/components/CustomButtons/SettingsIconButton.tsx
+++ b/quotevote-frontend/src/components/CustomButtons/SettingsIconButton.tsx
@@ -39,7 +39,7 @@ export function SettingsIconButton({ fontSize }: SettingsIconButtonProps) {
   };
 
   const handleInviteControlPanel = () => {
-    router.push('/hhsb/ControlPanel');
+    router.push('/dashboard/control-panel');
     setOpen(false);
   };
 

--- a/quotevote-frontend/src/components/settings/SettingsContent.tsx
+++ b/quotevote-frontend/src/components/settings/SettingsContent.tsx
@@ -271,7 +271,7 @@ export default function SettingsContent({ setOpen }: SettingsContentProps) {
                 type="button"
                 variant="secondary"
                 onClick={() => {
-                    router.push('/ControlPanel')
+                    router.push('/dashboard/control-panel')
                     if (setOpen) setOpen(false)
                 }}
                 disabled={loading}


### PR DESCRIPTION
## Description

Migrates special-purpose routes from React Router to Next.js 16 App Router, including unauthenticated pages, error pages, and admin control panel layout structure.

## Changes Made

### Routes Created
- **`/unauth`** - Token expired page (migrated from `TokenExpired.jsx`)
  - Auto-redirects to login after 5 seconds
  - Uses shadcn/ui Alert and Button components
  
- **`/error`** - Error/404 page (migrated from `ErrorPage.jsx`)
  - Supports both 404 and expired link scenarios
  - Handles `?from=signup` query parameter for expired invitations
  
- **`/logout`** - Logout page (verified existing implementation)
  - Correctly triggers logout logic from Phase 3
  
- **`/dashboard/control-panel`** - Admin control panel layout
  - Nested layout structure (migrated from `Admin.jsx`)
  - Inherits MainNavBar from parent dashboard layout

### Route References Updated
- Updated `AdminIconButton.tsx`: `/ControlPanel` → `/dashboard/control-panel`
- Updated `SettingsContent.tsx`: `/ControlPanel` → `/dashboard/control-panel`
- Updated `SettingsIconButton.tsx`: `/hhsb/ControlPanel` → `/dashboard/control-panel`
- Updated test expectations in `CustomButtons.test.tsx`

## Technical Details

- ✅ All JSX converted to TSX with proper TypeScript types
- ✅ No `any` types used
- ✅ Path aliases used (`@/components/ui`, `@/lib/utils`, etc.)
- ✅ shadcn/ui components replace Material-UI
- ✅ Tailwind CSS for styling
- ✅ Next.js App Router patterns (file-based routing, layouts)
- ✅ Client components marked with `'use client'` directive

## Testing

- ✅ TypeScript compilation passes
- ✅ Linter checks pass
- ✅ All routes accessible at expected paths
- ✅ Route references updated throughout codebase

## Issue Reference

Closes #70 - Create App Router Structure (Special Routes)