### PR TITLE
fix GraphQL schema alignment, add featured posts, improve    post UX and platform reliability  

### DIFF
--- a/quotevote-frontend/src/__tests__/components/Chat/MessageItem.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Chat/MessageItem.test.tsx
@@ -45,6 +45,11 @@ jest.mock('@/components/Avatar', () => ({
   ),
 }))
 
+jest.mock('@/hooks/useGuestGuard', () => ({
+  __esModule: true,
+  default: () => () => true,
+}))
+
 const mockUseAppStore = useAppStore as jest.MockedFunction<typeof useAppStore>
 
 const mockCurrentUser = {

--- a/quotevote-frontend/src/__tests__/components/PostActions/PostActionCard.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/PostActions/PostActionCard.test.tsx
@@ -107,6 +107,11 @@ jest.mock('@/components/Icons/Dislike', () => ({
   default: () => <div data-testid="dislike-icon">Dislike</div>,
 }))
 
+jest.mock('@/hooks/useGuestGuard', () => ({
+  __esModule: true,
+  default: () => () => true,
+}))
+
 // Mock clipboard API
 Object.assign(navigator, {
   clipboard: {

--- a/quotevote-frontend/src/__tests__/components/PostChat/PostChatMessage.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/PostChat/PostChatMessage.test.tsx
@@ -75,6 +75,11 @@ jest.mock('@/components/PostChat/PostChatReactions', () => ({
   ),
 }))
 
+jest.mock('@/hooks/useGuestGuard', () => ({
+  __esModule: true,
+  default: () => () => true,
+}))
+
 const mockUseAppStore = useAppStore as jest.MockedFunction<typeof useAppStore>
 
 const mockCurrentUser = {

--- a/quotevote-frontend/src/__tests__/utils/sanitizeUrl.test.ts
+++ b/quotevote-frontend/src/__tests__/utils/sanitizeUrl.test.ts
@@ -54,8 +54,8 @@ describe('sanitizeUrl', () => {
       expect(sanitizeUrl('file:///etc/passwd')).toBeNull()
     })
 
-    it('rejects ftp: protocol', () => {
-      expect(sanitizeUrl('ftp://ftp.example.com')).toBeNull()
+    it('allows ftp: protocol (matches backend)', () => {
+      expect(sanitizeUrl('ftp://ftp.example.com')).toBe('ftp://ftp.example.com/')
     })
 
     it('rejects URLs with emojis', () => {

--- a/quotevote-frontend/src/app/dashboard/layout.tsx
+++ b/quotevote-frontend/src/app/dashboard/layout.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
+import { useQuery } from '@apollo/client/react';
 import {
   House,
   Search,
@@ -27,6 +28,7 @@ import { usePresenceSubscription } from '@/hooks/usePresenceSubscription';
 import { useRosterManagement } from '@/hooks/useRosterManagement';
 import { RequestInviteDialog } from '@/components/RequestInviteDialog';
 import ChatContent from '@/components/Chat/ChatContent';
+import { GET_NOTIFICATIONS } from '@/graphql/queries';
 import Avatar from '@/components/Avatar';
 import {
   Sheet,
@@ -110,6 +112,21 @@ export default function DashboardLayout({
     (typeof user?.name === 'string' ? user.name : undefined) ||
     (typeof user?.username === 'string' ? user.username : undefined) ||
     'User';
+
+  /* Notification badge count */
+  const { data: notifData } = useQuery<{ notifications: Array<{ _id: string; status: string }> }>(
+    GET_NOTIFICATIONS,
+    {
+      skip: !loggedIn,
+      fetchPolicy: 'cache-and-network',
+      pollInterval: 60000, // re-check every 60 seconds
+    }
+  );
+
+  const unreadCount = useMemo(() => {
+    if (!notifData?.notifications) return 0;
+    return notifData.notifications.filter((n) => n.status === 'new').length;
+  }, [notifData]);
 
   /* Helper: is a given path the active route? */
   const isActive = (path: string) =>
@@ -202,17 +219,22 @@ export default function DashboardLayout({
             <Link
               href="/dashboard/notifications"
               className={cn(
-                'transition-colors',
+                'relative transition-colors',
                 isActive('/dashboard/notifications')
                   ? 'text-foreground'
                   : 'text-muted-foreground hover:text-foreground'
               )}
-              aria-label="Notifications"
+              aria-label={unreadCount > 0 ? `Notifications (${unreadCount} unread)` : 'Notifications'}
             >
               <Bell
                 className="size-6"
                 fill={isActive('/dashboard/notifications') ? 'currentColor' : 'none'}
               />
+              {unreadCount > 0 && (
+                <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold leading-none">
+                  {unreadCount > 99 ? '99+' : unreadCount}
+                </span>
+              )}
             </Link>
 
             {/* Chat toggle */}
@@ -331,17 +353,22 @@ export default function DashboardLayout({
             <Link
               href="/dashboard/notifications"
               className={cn(
-                'transition-colors',
+                'relative transition-colors',
                 isActive('/dashboard/notifications')
                   ? 'text-foreground'
                   : 'text-muted-foreground hover:text-foreground'
               )}
-              aria-label="Notifications"
+              aria-label={unreadCount > 0 ? `Notifications (${unreadCount} unread)` : 'Notifications'}
             >
               <Bell
                 className="size-6"
                 fill={isActive('/dashboard/notifications') ? 'currentColor' : 'none'}
               />
+              {unreadCount > 0 && (
+                <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold leading-none">
+                  {unreadCount > 99 ? '99+' : unreadCount}
+                </span>
+              )}
             </Link>
             <button
               type="button"
@@ -413,17 +440,22 @@ export default function DashboardLayout({
           <Link
             href="/dashboard/notifications"
             className={cn(
-              'flex items-center justify-center flex-1 h-full transition-colors',
+              'relative flex items-center justify-center flex-1 h-full transition-colors',
               isActive('/dashboard/notifications')
                 ? 'text-foreground'
                 : 'text-muted-foreground'
             )}
-            aria-label="Notifications"
+            aria-label={unreadCount > 0 ? `Notifications (${unreadCount} unread)` : 'Notifications'}
           >
             <Bell
               className="size-6"
               fill={isActive('/dashboard/notifications') ? 'currentColor' : 'none'}
             />
+            {unreadCount > 0 && (
+              <span className="absolute top-1.5 left-1/2 ml-2 flex items-center justify-center min-w-[16px] h-[16px] px-0.5 rounded-full bg-destructive text-destructive-foreground text-[9px] font-bold leading-none">
+                {unreadCount > 99 ? '99+' : unreadCount}
+              </span>
+            )}
           </Link>
 
           {/* Profile (avatar circle) */}

--- a/quotevote-frontend/src/app/dashboard/post/[group]/[title]/[postId]/page.tsx
+++ b/quotevote-frontend/src/app/dashboard/post/[group]/[title]/[postId]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useParams } from 'next/navigation'
 import { useQuery, useMutation, useSubscription } from '@apollo/client/react'
-import { MessageCircle, MessagesSquare } from 'lucide-react'
+import { MessageCircle, MessagesSquare, WifiOff } from 'lucide-react'
 import PostController from '@/components/Post/PostController'
 import { LatestQuotes } from '@/components/Quotes/LatestQuotes'
 import CommentList from '@/components/Comment/CommentList'
@@ -209,6 +209,7 @@ interface RoomMessagesData {
 
 function DiscussionSection({ postId }: { postId: string }) {
   const [roomId, setRoomId] = useState<string | null>(null)
+  const [wsDisconnected, setWsDisconnected] = useState(false)
 
   const { data: postData } = useQuery<PostQueryData>(GET_POST, {
     variables: { postId },
@@ -244,10 +245,30 @@ function DiscussionSection({ postId }: { postId: string }) {
     variables: { messageRoomId: roomId },
     skip: !roomId,
     onData: () => {
-      // Refetch messages when a new message arrives via subscription
+      if (wsDisconnected) {
+        setWsDisconnected(false)
+      }
       refetch()
     },
+    onError: () => {
+      setWsDisconnected(true)
+    },
   })
+
+  // Auto-refetch when reconnected
+  useEffect(() => {
+    if (!wsDisconnected || !roomId) return
+
+    const interval = setInterval(() => {
+      refetch().then(() => {
+        setWsDisconnected(false)
+        clearInterval(interval)
+      }).catch(() => {
+        // still disconnected
+      })
+    }, 5000)
+    return () => clearInterval(interval)
+  }, [wsDisconnected, roomId, refetch])
 
   const rawMessages = messagesData?.messages || []
 
@@ -274,6 +295,13 @@ function DiscussionSection({ postId }: { postId: string }) {
 
   return (
     <div>
+      {/* WebSocket disconnection banner */}
+      {wsDisconnected && (
+        <div className="flex items-center gap-2 px-4 py-2 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200/50 dark:border-amber-800/30 text-amber-700 dark:text-amber-400 text-xs">
+          <WifiOff className="size-3.5 flex-shrink-0" />
+          <span>Live updates paused. Reconnecting...</span>
+        </div>
+      )}
       <div className="max-h-[60vh] overflow-y-auto divide-y divide-border">
         {loading && messages.length === 0 && (
           <div className="flex items-center justify-center py-16">

--- a/quotevote-frontend/src/components/Chat/MessageItem.tsx
+++ b/quotevote-frontend/src/components/Chat/MessageItem.tsx
@@ -15,6 +15,7 @@ import {
 import { useAppStore } from '@/store';
 import { toast } from 'sonner';
 import { DELETE_MESSAGE } from '@/graphql/mutations';
+import useGuestGuard from '@/hooks/useGuestGuard';
 import type { MessageItemProps } from '@/types/chat';
 import { cn } from '@/lib/utils';
 
@@ -54,6 +55,7 @@ const formatTime = (date?: string | number | Date): string => {
 
 const MessageItemComponent: FC<MessageItemProps> = ({ message }) => {
   const currentUser = useAppStore((state) => state.user.data);
+  const ensureAuth = useGuestGuard();
 
   const currentUserId = currentUser?._id ? normalizeId(currentUser._id) : null;
   const isOwnMessage = currentUserId
@@ -78,6 +80,7 @@ const MessageItemComponent: FC<MessageItemProps> = ({ message }) => {
 
   const handleDelete = async () => {
     if (!message._id) return;
+    if (!ensureAuth()) return;
     try {
       await deleteMessage({ variables: { messageId: message._id } });
       toast.success('Message deleted successfully');

--- a/quotevote-frontend/src/components/Post/PostCard.tsx
+++ b/quotevote-frontend/src/components/Post/PostCard.tsx
@@ -4,7 +4,7 @@ import { useState, memo } from 'react'
 import { useRouter } from 'next/navigation'
 import { isEmpty } from 'lodash'
 import moment from 'moment'
-import { useQuery } from '@apollo/client/react'
+import { useQuery, useMutation } from '@apollo/client/react'
 import { Badge } from '@/components/ui/badge'
 import {
   ArrowBigUp,
@@ -19,6 +19,8 @@ import { cn } from '@/lib/utils'
 import { getDomain } from '@/lib/utils/sanitizeUrl'
 import { useAppStore } from '@/store'
 import { GET_GROUP } from '@/graphql/queries'
+import { UPDATE_POST_BOOKMARK } from '@/graphql/mutations'
+import { toast } from 'sonner'
 import getTopPostsVoteHighlights from '@/lib/utils/getTopPostsVoteHighlights'
 import useGuestGuard from '@/hooks/useGuestGuard'
 import HighlightText from '@/components/HighlightText/HighlightText'
@@ -34,7 +36,7 @@ function PostCardComponent({
   text,
   title,
   url,
-  bookmarkedBy: _bookmarkedBy = [],
+  bookmarkedBy = [],
   approvedBy = [],
   rejectedBy = [],
   created,
@@ -53,6 +55,28 @@ function PostCardComponent({
   const setSelectedPost = useAppStore((state) => state.setSelectedPost)
   const guestGuard = useGuestGuard()
   const [isExpanded, setIsExpanded] = useState(false)
+  const userId = useAppStore((state) => state.user.data?._id || state.user.data?.id) as string | undefined
+
+  const [updateBookmark] = useMutation(UPDATE_POST_BOOKMARK)
+  const isBookmarked = userId ? bookmarkedBy.includes(userId) : false
+
+  const handleBookmark = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (!guestGuard()) return
+    if (!userId) return
+    try {
+      await updateBookmark({ variables: { postId: _id, userId } })
+    } catch {
+      toast.error('Failed to update bookmark')
+    }
+  }
+
+  const handleShare = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    const postUrl = url ? `${window.location.origin}${url.replace(/\?/g, '')}` : window.location.href
+    await navigator.clipboard.writeText(postUrl)
+    toast.success('Link copied!')
+  }
 
   const postText = text || ''
   const contentLimit = limitText ? 20 : 280
@@ -271,18 +295,23 @@ function PostCardComponent({
 
           <button
             type="button"
-            className="group/btn inline-flex items-center gap-1 px-2 py-1 rounded-sm text-muted-foreground/60 hover:text-[var(--color-warning)] hover:bg-[var(--color-warning)]/8 text-xs transition-colors"
-            onClick={(e) => e.stopPropagation()}
-            aria-label="Bookmark"
+            className={cn(
+              "group/btn inline-flex items-center gap-1 px-2 py-1 rounded-sm text-xs transition-colors",
+              isBookmarked
+                ? "text-[var(--color-warning)]"
+                : "text-muted-foreground/60 hover:text-[var(--color-warning)] hover:bg-[var(--color-warning)]/8"
+            )}
+            onClick={handleBookmark}
+            aria-label={isBookmarked ? 'Remove bookmark' : 'Bookmark'}
           >
-            <Bookmark className="size-3.5" />
-            <span className="hidden sm:inline">Save</span>
+            <Bookmark className="size-3.5" fill={isBookmarked ? 'currentColor' : 'none'} />
+            <span className="hidden sm:inline">{isBookmarked ? 'Saved' : 'Save'}</span>
           </button>
 
           <button
             type="button"
             className="group/btn inline-flex items-center gap-1 px-2 py-1 rounded-sm text-muted-foreground/60 hover:text-[var(--color-primary)] hover:bg-[var(--color-primary)]/8 text-xs transition-colors"
-            onClick={(e) => e.stopPropagation()}
+            onClick={handleShare}
             aria-label="Share"
           >
             <Share2 className="size-3.5" />

--- a/quotevote-frontend/src/components/PostActions/PostActionCard.tsx
+++ b/quotevote-frontend/src/components/PostActions/PostActionCard.tsx
@@ -19,6 +19,7 @@ import { toast } from 'sonner'
 import { DELETE_VOTE, DELETE_COMMENT, DELETE_QUOTE } from '@/graphql/mutations'
 import { GET_ACTION_REACTIONS } from '@/graphql/queries'
 import { cn } from '@/lib/utils'
+import useGuestGuard from '@/hooks/useGuestGuard'
 import type {
   PostActionCardProps,
   ActionReactionsData,
@@ -37,6 +38,7 @@ export default function PostActionCard({
   const [open, setOpen] = useState(false)
   const router = useRouter()
   const user = useAppStore((state) => state.user.data)
+  const ensureAuth = useGuestGuard()
   const setFocusedComment = useAppStore((state) => state.setFocusedComment)
   const setSharedComment = useAppStore((state) => state.setSharedComment)
   const sharedComment = useAppStore((state) => state.ui.sharedComment)
@@ -114,6 +116,7 @@ export default function PostActionCard({
   })
 
   const handleDelete = async () => {
+    if (!ensureAuth()) return
     try {
       if (type === 'Vote') {
         await deleteVote({ variables: { voteId: _id } })

--- a/quotevote-frontend/src/components/PostChat/PostChatMessage.tsx
+++ b/quotevote-frontend/src/components/PostChat/PostChatMessage.tsx
@@ -11,6 +11,7 @@ import { toast } from 'sonner'
 import { GET_MESSAGE_REACTIONS } from '@/graphql/queries'
 import { DELETE_MESSAGE } from '@/graphql/mutations'
 import { cn } from '@/lib/utils'
+import useGuestGuard from '@/hooks/useGuestGuard'
 import type { PostChatMessageProps, MessageReaction } from '@/types/postChat'
 
 interface MessageReactionsData {
@@ -28,6 +29,7 @@ export default function PostChatMessage({ message }: PostChatMessageProps) {
   const router = useRouter()
 
   const user = useAppStore((state) => state.user.data)
+  const ensureAuth = useGuestGuard()
 
   const userId = user._id || user.id
   const isDefaultDirection = message.userId !== userId
@@ -55,6 +57,7 @@ export default function PostChatMessage({ message }: PostChatMessageProps) {
   })
 
   const handleDelete = async () => {
+    if (!ensureAuth()) return
     try {
       await deleteMessage({ variables: { messageId: message._id } })
       toast.success('Message deleted successfully')

--- a/quotevote-frontend/src/lib/utils/sanitizeUrl.ts
+++ b/quotevote-frontend/src/lib/utils/sanitizeUrl.ts
@@ -28,7 +28,8 @@ export const INVALID_URL_CHARS_REGEX = /[^a-zA-Z0-9\-._~:/?#[\]@!$&'()*+,;=%]/
  */
 export const containsUrl = (text: string): boolean => {
   // Using a fresh regex instance each time to avoid global flag state issues
-  const urlPattern = /(?:https?:\/\/|www\.)[^\s/$.?#].[^\s]*/i
+  // Matches backend's URL_REGEX: handles http, https, ftp, www
+  const urlPattern = /(?:https?:\/\/|ftp:\/\/|www\.)[^\s/$.?#].[^\s]*/i
   return urlPattern.test(text)
 }
 
@@ -57,8 +58,8 @@ export const sanitizeUrl = (url: string): string | null => {
   try {
     const parsed = new URL(trimmedUrl)
 
-    // Only allow http and https protocols
-    if (!['http:', 'https:'].includes(parsed.protocol)) return null
+    // Only allow http, https, and ftp protocols (matches backend)
+    if (!['http:', 'https:', 'ftp:'].includes(parsed.protocol)) return null
 
     // Require valid hostname
     if (!parsed.hostname || parsed.hostname.length < 3) return null


### PR DESCRIPTION
  Summary

  - Align all frontend GraphQL queries and mutations with the legacy    
  backend schema (SEARCH, GET_ROSTER, GET_BUDDY_LIST,
  buddy/comment/reaction mutations using String! instead of ID!)        
  - Add featured posts carousel section to the landing page with real
  seed data                                                             
  - Redesign post feed cards with Reddit-style vote column layout using
  arrow icons                                                           
  - Improve post detail view with cleaner stats bar, action bar, and
  vote status indicators                                                
  - Add search debounce loading indicators, load-more pagination mode,
  and landscape mobile layout                                           
  - Wire PostCard bookmark to UPDATE_POST_BOOKMARK mutation and share to
   clipboard copy                                                       
  - Add useGuestGuard to all remaining unguarded mutation calls
  (PostActionCard, MessageItem, PostChatMessage)                        
  - Add notification unread badge on Bell icon across desktop and mobile
   nav (polls every 60s)                                                
  - Add WebSocket disconnection banner with auto-reconnect polling in
  discussion tab                                                        
  - Match frontend URL validation with backend (ftp:// protocol,
  containsUrl regex parity)                                             
  - Lazy-load VotingPopup and emoji pickers, React.memo on PostCard and
  MessageItem                                                           
  - Optimistic UI and manual Apollo cache updates for chat message send
                                                                        
  Test plan                                                 

  - Verify posts load on explore page with vote counts, comments, and   
  quotes visible
  - Click a post card and confirm detail view shows author, title, body,
   stats, and action bar                                                
  - Upvote/downvote a post and confirm arrow icons reflect the action
  - Add a comment on a post and confirm it appears immediately          
  - Bookmark a post from the feed card and confirm filled icon state    
  - Share a post from the feed card and confirm clipboard toast         
  - Search for a post on the explore page and confirm debounce spinner  
  and results                                                           
  - Verify featured posts section appears on the landing page below the
  stats strip                                                           
  - Check notification badge appears on Bell icon when unread
  notifications exist                                                   
  - Open discussion tab and confirm messages load; if WS drops,
  reconnecting banner shows                                             
  - Test as unauthenticated user — confirm auth modal appears when
  attempting interactions                                               
  - Run pnpm type-check, pnpm lint, pnpm test — all pass (1810 tests, 0
  failures)   