### PR TITLE
feat(chat): add close/back control for mobile chat (RC1-027)

### DIFF
--- a/quotevote-frontend/src/__tests__/components/Chat/ChatContent.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Chat/ChatContent.test.tsx
@@ -118,6 +118,7 @@ jest.mock('@/components/Chat/StatusEditor', () => ({
 }))
 
 const mockUseAppStore = useAppStore as jest.MockedFunction<typeof useAppStore>
+const mockSetChatOpen = jest.fn()
 
 describe('ChatContent', () => {
   beforeEach(() => {
@@ -147,6 +148,7 @@ describe('ChatContent', () => {
           userStatus: 'online',
           userStatusMessage: '',
         },
+        setChatOpen: mockSetChatOpen,
       }
       return selector(state as ReturnType<typeof useAppStore>)
     })
@@ -267,6 +269,17 @@ describe('ChatContent', () => {
     // Status should be displayed (UserStatusDisplay shows the status message or label)
     // The status message is displayed in the UserStatusDisplay component
     expect(screen.getByText('Away message')).toBeInTheDocument()
+  })
+
+  it('renders close chat button and calls setChatOpen(false) when clicked', () => {
+    render(<ChatContent />)
+
+    const closeButton = screen.getByRole('button', { name: /close chat/i })
+    expect(closeButton).toBeInTheDocument()
+
+    fireEvent.click(closeButton)
+
+    expect(mockSetChatOpen).toHaveBeenCalledWith(false)
   })
 
   it('handles empty buddy list', () => {

--- a/quotevote-frontend/src/components/Chat/ChatContent.tsx
+++ b/quotevote-frontend/src/components/Chat/ChatContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from 'react';
-import { Settings } from 'lucide-react';
+import { Settings, X } from 'lucide-react';
 import { useQuery } from '@apollo/client/react';
 
 import ChatSearchInput from './ChatSearchInput';
@@ -81,6 +81,7 @@ function UserStatusDisplay() {
 
 function ChatContent() {
   const selectedRoomId = useAppStore((state) => state.chat.selectedRoom);
+  const setChatOpen = useAppStore((state) => state.setChatOpen);
   const buddyList = useAppStore(
     (state) => state.chat.buddyList
   ) as BuddyListItem[];
@@ -163,11 +164,20 @@ function ChatContent() {
             <Button
               size="icon"
               variant="outline"
-              className="flex-shrink-0 mr-1 border-white/40 bg-white/20 text-white hover:bg-white/30"
+              className="flex-shrink-0 border-white/40 bg-white/20 text-white hover:bg-white/30"
               onClick={() => setStatusEditorOpen(true)}
               aria-label="Set status"
             >
               <Settings className="h-4 w-4" />
+            </Button>
+            <Button
+              size="icon"
+              variant="outline"
+              className="flex-shrink-0 border-white/40 bg-white/20 text-white hover:bg-white/30"
+              onClick={() => setChatOpen(false)}
+              aria-label="Close chat"
+            >
+              <X className="h-4 w-4" />
             </Button>
           </div>
         </div>

--- a/quotevote-frontend/src/components/Chat/MessageBox.tsx
+++ b/quotevote-frontend/src/components/Chat/MessageBox.tsx
@@ -30,6 +30,7 @@ interface HeaderProps {
 function Header({ room }: HeaderProps) {
   const currentUser = useAppStore((state) => state.user.data)
   const setSelectedChatRoom = useAppStore((state) => state.setSelectedChatRoom)
+  const setChatOpen = useAppStore((state) => state.setChatOpen)
 
   const { blockBuddy, unblockBuddy, removeBuddy } = useRosterManagement()
   const { refetch: refetchChatRooms } = useQuery<{ messageRooms: ChatRoom[] }>(
@@ -118,6 +119,7 @@ function Header({ room }: HeaderProps) {
 
   const handleDeleteChat = () => {
     setSelectedChatRoom(null)
+    setChatOpen(false)
     toast('Chat closed')
   }
 

--- a/quotevote-frontend/src/components/Notifications/MobileDrawer.tsx
+++ b/quotevote-frontend/src/components/Notifications/MobileDrawer.tsx
@@ -30,9 +30,8 @@ export function MobileDrawer({
     <Sheet open={open} onOpenChange={onClose}>
       <SheetContent
         side={anchor}
-        className="w-full max-w-[400px] sm:w-[400px] p-0 flex flex-col"
+        className="w-full max-w-[400px] sm:w-[400px] p-0 flex flex-col pb-[env(safe-area-inset-bottom,0px)]"
         onInteractOutside={(e) => e.preventDefault()}
-        onEscapeKeyDown={(e) => e.preventDefault()}
       >
         {showHeader && (
           <SheetHeader className="px-4 py-3 border-b border-[var(--color-gray-light)]">


### PR DESCRIPTION
RC1-027 — Allow users to exit chat on mobile                          
                                                                      
Problem: 
Mobile users had no way to close the chat drawer once opened — outside taps, ESC, and back gestures were all blocked.
                                                                        
  Changes:                                                              
  - Added X close button to chat list header → dismisses the drawer     
  - "Close Chat" dropdown in room view now also closes the drawer (not just deselects the room)                                              
  - Removed ESC suppression on MobileDrawer so hardware back gestures work
  - Added pb-[env(safe-area-inset-bottom)] to MobileDrawer for notched devices
  - Added test covering the new close button

Closes #379 