### PR TITLE
feat(guest-access): allow guests to browse read-only dashboard routes (RC1-003)

### DIFF
--- a/quotevote-frontend/middleware.ts
+++ b/quotevote-frontend/middleware.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import {
+  isGuestReadableDashboardRoute,
+} from './src/lib/dashboard-routes';
 
 // Routes that authenticated users should be redirected away from
 const AUTH_ROUTES = ['/auths/login', '/auths/signup', '/auths/request-access', '/auths/forgot-password'];
@@ -27,24 +30,25 @@ export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const token = request.cookies.get('qv-token')?.value;
 
-  // Protect /dashboard/* — redirect to login if no token
   if (pathname.startsWith('/dashboard')) {
     if (!token) {
-      const loginUrl = new URL('/auths/login', request.url);
-      loginUrl.searchParams.set('callbackUrl', pathname);
-      return NextResponse.redirect(loginUrl);
+      if (!isGuestReadableDashboardRoute(pathname)) {
+        const loginUrl = new URL('/auths/login', request.url);
+        loginUrl.searchParams.set('callbackUrl', pathname);
+        return NextResponse.redirect(loginUrl);
+      }
+
+      return NextResponse.next();
     }
 
-    // Admin-only route protection for /dashboard/control-panel
     if (pathname.startsWith('/dashboard/control-panel')) {
-      const payload = decodeJwtPayload(token);
+      const payload = token ? decodeJwtPayload(token) : null;
       if (!payload || payload.admin !== true) {
         return NextResponse.redirect(new URL('/dashboard/explore', request.url));
       }
     }
   }
 
-  // Redirect authenticated users away from auth pages (except always-accessible ones)
   if (pathname.startsWith('/auths')) {
     const isAlwaysAccessible = AUTH_ALWAYS_ACCESSIBLE.some((route) => pathname.startsWith(route));
     const isAuthRoute = AUTH_ROUTES.some((route) => pathname.startsWith(route));

--- a/quotevote-frontend/src/__tests__/app/page.test.tsx
+++ b/quotevote-frontend/src/__tests__/app/page.test.tsx
@@ -300,7 +300,7 @@ describe('LandingPage', () => {
       expect(resultBtn).not.toBeNull();
       await user.click(resultBtn!);
 
-      expect(mockPush).toHaveBeenCalledWith('/auths/login');
+      expect(mockPush).toHaveBeenCalledWith('/dashboard/explore?q=Democracy%20Matters');
     });
 
     it('does not show dropdown when query is empty', () => {

--- a/quotevote-frontend/src/__tests__/foundation/middleware.test.ts
+++ b/quotevote-frontend/src/__tests__/foundation/middleware.test.ts
@@ -40,17 +40,35 @@ describe('Middleware', () => {
   })
 
   describe('Dashboard protection', () => {
-    it('redirects unauthenticated users from /dashboard to /auths/login', () => {
+    it('allows unauthenticated users to browse /dashboard/explore', () => {
       middleware(createMockRequest('/dashboard/explore'))
+      expect(NextResponse.next).toHaveBeenCalled()
+      expect(NextResponse.redirect).not.toHaveBeenCalled()
+    })
+
+    it('allows unauthenticated users to view public post pages', () => {
+      middleware(createMockRequest('/dashboard/post/general/sample-title/abc123'))
+      expect(NextResponse.next).toHaveBeenCalled()
+      expect(NextResponse.redirect).not.toHaveBeenCalled()
+    })
+
+    it('allows unauthenticated users to view public profiles', () => {
+      middleware(createMockRequest('/dashboard/profile/testuser'))
+      expect(NextResponse.next).toHaveBeenCalled()
+      expect(NextResponse.redirect).not.toHaveBeenCalled()
+    })
+
+    it('redirects unauthenticated users from /dashboard/settings to /auths/login', () => {
+      middleware(createMockRequest('/dashboard/settings'))
       expect(NextResponse.redirect).toHaveBeenCalled()
       const redirectUrl = (NextResponse.redirect as jest.Mock).mock.calls[0][0] as URL
       expect(redirectUrl.pathname).toBe('/auths/login')
+      expect(redirectUrl.searchParams.get('callbackUrl')).toBe('/dashboard/settings')
     })
 
-    it('includes callbackUrl for dashboard redirect', () => {
-      middleware(createMockRequest('/dashboard/explore'))
-      const redirectUrl = (NextResponse.redirect as jest.Mock).mock.calls[0][0] as URL
-      expect(redirectUrl.searchParams.get('callbackUrl')).toBe('/dashboard/explore')
+    it('redirects unauthenticated users from /dashboard/profile to /auths/login', () => {
+      middleware(createMockRequest('/dashboard/profile'))
+      expect(NextResponse.redirect).toHaveBeenCalled()
     })
 
     it('allows authenticated users to pass through /dashboard', () => {

--- a/quotevote-frontend/src/__tests__/utils/dashboard-routes.test.ts
+++ b/quotevote-frontend/src/__tests__/utils/dashboard-routes.test.ts
@@ -1,0 +1,34 @@
+import {
+  isAuthRequiredDashboardRoute,
+  isGuestReadableDashboardRoute,
+} from '@/lib/dashboard-routes'
+
+describe('dashboard-routes', () => {
+  describe('isGuestReadableDashboardRoute', () => {
+    it('allows explore and post routes', () => {
+      expect(isGuestReadableDashboardRoute('/dashboard/explore')).toBe(true)
+      expect(isGuestReadableDashboardRoute('/dashboard/post/general/title/id')).toBe(true)
+    })
+
+    it('allows public profile pages', () => {
+      expect(isGuestReadableDashboardRoute('/dashboard/profile/alice')).toBe(true)
+    })
+
+    it('does not allow own profile shell without username', () => {
+      expect(isGuestReadableDashboardRoute('/dashboard/profile')).toBe(false)
+    })
+
+    it('does not allow account-only routes', () => {
+      expect(isGuestReadableDashboardRoute('/dashboard/settings')).toBe(false)
+      expect(isGuestReadableDashboardRoute('/dashboard/notifications')).toBe(false)
+    })
+  })
+
+  describe('isAuthRequiredDashboardRoute', () => {
+    it('marks account routes as auth required', () => {
+      expect(isAuthRequiredDashboardRoute('/dashboard/settings')).toBe(true)
+      expect(isAuthRequiredDashboardRoute('/dashboard/notifications')).toBe(true)
+      expect(isAuthRequiredDashboardRoute('/dashboard/profile')).toBe(true)
+    })
+  })
+})

--- a/quotevote-frontend/src/app/components/LandingPage/LandingPageContent.tsx
+++ b/quotevote-frontend/src/app/components/LandingPage/LandingPageContent.tsx
@@ -35,6 +35,7 @@ import { useAppStore } from '@/store';
 import { SEARCH, GET_FEATURED_POSTS } from '@/graphql/queries';
 import { REQUEST_USER_ACCESS_MUTATION } from '@/graphql/mutations';
 import { useDebounce } from '@/hooks/useDebounce';
+import { toAppPostUrl } from '@/lib/utils/sanitizeUrl';
 import type { Post } from '@/types/post';
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -1588,9 +1589,19 @@ function HeroSearch({ router }: HeroSearchProps) {
     if (e.key === 'Escape') setIsOpen(false);
   };
 
-  const handleResultClick = () => {
+  const handlePostClick = (item: ContentResult) => {
     setIsOpen(false);
-    router.push('/auths/login');
+    if (item.url) {
+      router.push(toAppPostUrl(item.url));
+      return;
+    }
+    router.push(`/dashboard/explore?q=${encodeURIComponent(item.title)}`);
+  };
+
+  const handleCreatorClick = (creator: CreatorResult) => {
+    setIsOpen(false);
+    const profileSlug = creator.username || creator._id;
+    router.push(`/dashboard/profile/${profileSlug}`);
   };
 
   return (
@@ -1695,7 +1706,7 @@ function HeroSearch({ router }: HeroSearchProps) {
                     <button
                       key={item._id}
                       type="button"
-                      onClick={handleResultClick}
+                      onClick={() => handlePostClick(item)}
                       className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors text-left"
                     >
                       <div
@@ -1725,7 +1736,7 @@ function HeroSearch({ router }: HeroSearchProps) {
                     <button
                       key={creator._id}
                       type="button"
-                      onClick={handleResultClick}
+                      onClick={() => handleCreatorClick(creator)}
                       className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors text-left"
                     >
                       <div className="w-8 h-8 rounded-full overflow-hidden flex-shrink-0 bg-gray-200 flex items-center justify-center">
@@ -1750,7 +1761,10 @@ function HeroSearch({ router }: HeroSearchProps) {
               <div className="border-t border-gray-100 px-4 py-3">
                 <button
                   type="button"
-                  onClick={handleResultClick}
+                  onClick={() => {
+                    setIsOpen(false);
+                    router.push(`/dashboard/explore?q=${encodeURIComponent(debouncedQuery)}`);
+                  }}
                   className="text-sm font-medium transition-colors hover:underline"
                   style={{ color: 'var(--color-primary)' }}
                 >

--- a/quotevote-frontend/src/components/Activity/ActivityList.tsx
+++ b/quotevote-frontend/src/components/Activity/ActivityList.tsx
@@ -17,6 +17,7 @@ import {
   GET_USER_ACTIVITY,
 } from '@/graphql/queries'
 import useGuestGuard from '@/hooks/useGuestGuard'
+import { toAppPostUrl } from '@/lib/utils/sanitizeUrl'
 import type { ActivityListProps, ActivityEntity } from '@/types/activity'
 
 function LoadActivityCard({
@@ -121,16 +122,8 @@ function LoadActivityCard({
   const isLiked = currentUser?._id && typeof currentUser._id === 'string' ? bookmarkedBy.includes(currentUser._id) : false
 
   const handleCardClick = () => {
-    // Check if user is in guest mode
-    if (!ensureAuth()) {
-      // Redirect to search page for guest users
-      router.push('/search')
-      return
-    }
-
-    // For authenticated users, proceed with normal post navigation
     setSelectedPost(postId)
-    router.push(url.replace(/\?/g, ''))
+    router.push(toAppPostUrl(url.replace(/\?/g, '')))
   }
 
   return (

--- a/quotevote-frontend/src/components/Activity/PaginatedActivityList.tsx
+++ b/quotevote-frontend/src/components/Activity/PaginatedActivityList.tsx
@@ -19,6 +19,7 @@ import {
 import { useAppStore } from '@/store'
 import useGuestGuard from '@/hooks/useGuestGuard'
 import { useRouter } from 'next/navigation'
+import { toAppPostUrl } from '@/lib/utils/sanitizeUrl'
 import type { PaginatedActivityListProps, ActivityEntity } from '@/types/activity'
 
 function LoadActivityCard({
@@ -123,16 +124,8 @@ function LoadActivityCard({
   const isLiked = currentUser?._id && typeof currentUser._id === 'string' ? bookmarkedBy.includes(currentUser._id) : false
 
   const handleCardClick = () => {
-    // Check if user is in guest mode
-    if (!ensureAuth()) {
-      // Redirect to search page for guest users
-      router.push('/search')
-      return
-    }
-
-    // For authenticated users, proceed with normal post navigation
     setSelectedPost(postId)
-    router.push(url.replace(/\?/g, ''))
+    router.push(toAppPostUrl(url.replace(/\?/g, '')))
   }
 
   return (

--- a/quotevote-frontend/src/components/Post/PostCard.tsx
+++ b/quotevote-frontend/src/components/Post/PostCard.tsx
@@ -208,7 +208,7 @@ function PostCardComponent({
     e.stopPropagation()
     const uname = creator?.username
     if (!uname) return
-    if (guestGuard()) router.push(`/dashboard/profile/${uname}`)
+    router.push(`/dashboard/profile/${uname}`)
   }
 
   const username = creator?.username || 'Anonymous'

--- a/quotevote-frontend/src/lib/dashboard-routes.ts
+++ b/quotevote-frontend/src/lib/dashboard-routes.ts
@@ -1,0 +1,30 @@
+/**
+ * Dashboard route access rules for guest (logged-out) sessions.
+ * Read-only routes are browsable without auth; participation is gated client-side.
+ */
+
+const GUEST_READABLE_PREFIXES = ['/dashboard/explore', '/dashboard/post'] as const;
+
+const AUTH_REQUIRED_PREFIXES = [
+  '/dashboard/settings',
+  '/dashboard/notifications',
+  '/dashboard/manage-invites',
+  '/dashboard/control-panel',
+] as const;
+
+/** Public profile pages: /dashboard/profile/:username (not /dashboard/profile alone). */
+function isPublicProfileRoute(pathname: string): boolean {
+  return /^\/dashboard\/profile\/[^/]+/.test(pathname);
+}
+
+export function isGuestReadableDashboardRoute(pathname: string): boolean {
+  if (GUEST_READABLE_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))) {
+    return true;
+  }
+  return isPublicProfileRoute(pathname);
+}
+
+export function isAuthRequiredDashboardRoute(pathname: string): boolean {
+  if (pathname === '/dashboard/profile') return true;
+  return AUTH_REQUIRED_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}


### PR DESCRIPTION
## Summary
- Allow unauthenticated guests to access read-only dashboard routes: explore, post pages, and public profiles (`/dashboard/profile/:username`)
- Keep auth-required routes (settings, notifications, own profile shell, etc.) redirecting to login with `callbackUrl`
- Update landing hero search and activity/post navigation so guests reach content instead of being sent to login

## Test plan
- [ ] Visit `/dashboard/explore` while logged out — page loads without redirect
- [ ] Open a post URL while logged out — post page loads
- [ ] Open `/dashboard/profile/:username` while logged out — public profile loads
- [ ] Visit `/dashboard/settings` while logged out — redirects to `/auths/login?callbackUrl=...`
- [ ] Landing page hero search: post result → post page, creator result → profile, "See all" → explore with query
- [ ] `pnpm test -- src/__tests__/foundation/middleware.test.ts src/__tests__/utils/dashboard-routes.test.ts` passes


Made with [Cursor](https://cursor.com)