### PR TITLE
feat(auth): open login modal for protected actions instead of redirect (RC1-001)

### DIFF
--- a/quotevote-frontend/middleware.ts
+++ b/quotevote-frontend/middleware.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import {
+  isGuestReadableDashboardRoute,
+} from './src/lib/dashboard-routes';
 
 // Routes that authenticated users should be redirected away from
 const AUTH_ROUTES = ['/auths/login', '/auths/signup', '/auths/request-access', '/auths/forgot-password'];
@@ -27,24 +30,25 @@ export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const token = request.cookies.get('qv-token')?.value;
 
-  // Protect /dashboard/* — redirect to login if no token
   if (pathname.startsWith('/dashboard')) {
     if (!token) {
-      const loginUrl = new URL('/auths/login', request.url);
-      loginUrl.searchParams.set('callbackUrl', pathname);
-      return NextResponse.redirect(loginUrl);
+      if (!isGuestReadableDashboardRoute(pathname)) {
+        const loginUrl = new URL('/auths/login', request.url);
+        loginUrl.searchParams.set('callbackUrl', pathname);
+        return NextResponse.redirect(loginUrl);
+      }
+
+      return NextResponse.next();
     }
 
-    // Admin-only route protection for /dashboard/control-panel
     if (pathname.startsWith('/dashboard/control-panel')) {
-      const payload = decodeJwtPayload(token);
+      const payload = token ? decodeJwtPayload(token) : null;
       if (!payload || payload.admin !== true) {
         return NextResponse.redirect(new URL('/dashboard/explore', request.url));
       }
     }
   }
 
-  // Redirect authenticated users away from auth pages (except always-accessible ones)
   if (pathname.startsWith('/auths')) {
     const isAlwaysAccessible = AUTH_ALWAYS_ACCESSIBLE.some((route) => pathname.startsWith(route));
     const isAuthRoute = AUTH_ROUTES.some((route) => pathname.startsWith(route));

--- a/quotevote-frontend/src/__tests__/app/page.test.tsx
+++ b/quotevote-frontend/src/__tests__/app/page.test.tsx
@@ -300,7 +300,7 @@ describe('LandingPage', () => {
       expect(resultBtn).not.toBeNull();
       await user.click(resultBtn!);
 
-      expect(mockPush).toHaveBeenCalledWith('/auths/login');
+      expect(mockPush).toHaveBeenCalledWith('/dashboard/explore?q=Democracy%20Matters');
     });
 
     it('does not show dropdown when query is empty', () => {

--- a/quotevote-frontend/src/__tests__/components/Profile/ProfileHeaderMessage.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/ProfileHeaderMessage.test.tsx
@@ -49,6 +49,12 @@ jest.mock('@/hooks/useProfileBackground', () => ({
   useProfileBackground: () => ({ color: '#fff', pattern: 'none' }),
 }));
 
+const mockEnsureAuth = jest.fn(() => true);
+jest.mock('@/hooks/useGuestGuard', () => ({
+  __esModule: true,
+  default: () => mockEnsureAuth,
+}));
+
 const mockUseQuery = jest.fn();
 const mockUseMutation = jest.fn();
 jest.mock('@apollo/client/react', () => ({
@@ -85,6 +91,7 @@ describe('ProfileHeader — Message button', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockEnsureAuth.mockReturnValue(true);
     mockUseMutation.mockReturnValue([jest.fn(), { loading: false, error: undefined }]);
     setSelectedChatRoom = jest.fn();
     setChatOpen = jest.fn();
@@ -153,6 +160,23 @@ describe('ProfileHeader — Message button', () => {
     render(<ProfileHeader profileUser={mockProfileUser} />);
     fireEvent.click(screen.getByRole('button', { name: /message/i }));
 
+    expect(setSelectedChatRoom).not.toHaveBeenCalled();
+    expect(setChatOpen).not.toHaveBeenCalled();
+  });
+
+  it('opens auth gate instead of chat when guest clicks Message', () => {
+    mockEnsureAuth.mockReturnValue(false);
+    setupQueries(null);
+    useAppStore.setState({
+      user: { loading: false, loginError: null, data: {} },
+      setSelectedChatRoom,
+      setChatOpen,
+    });
+
+    render(<ProfileHeader profileUser={mockProfileUser} />);
+    fireEvent.click(screen.getByRole('button', { name: /message/i }));
+
+    expect(mockEnsureAuth).toHaveBeenCalled();
     expect(setSelectedChatRoom).not.toHaveBeenCalled();
     expect(setChatOpen).not.toHaveBeenCalled();
   });

--- a/quotevote-frontend/src/__tests__/components/RequestInviteDialog.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/RequestInviteDialog.test.tsx
@@ -104,7 +104,7 @@ describe('RequestInviteDialog', () => {
       screen.getByPlaceholderText(/enter your email address/i)
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /request invite/i })
+      screen.getByRole('button', { name: /^Request Invite$/ })
     ).toBeInTheDocument();
   });
 
@@ -133,7 +133,7 @@ describe('RequestInviteDialog', () => {
     render(<RequestInviteDialog {...defaultProps} />);
 
     const emailInput = screen.getByPlaceholderText(/enter your email address/i);
-    const submitButton = screen.getByRole('button', { name: /request invite/i });
+    const submitButton = screen.getByRole('button', { name: /^Request Invite$/ });
 
     await user.type(emailInput, 'invalid-email');
     await user.click(submitButton);
@@ -149,7 +149,7 @@ describe('RequestInviteDialog', () => {
     const user = userEvent.setup({ delay: null });
     render(<RequestInviteDialog {...defaultProps} />);
 
-    const submitButton = screen.getByRole('button', { name: /request invite/i });
+    const submitButton = screen.getByRole('button', { name: /^Request Invite$/ });
     await user.click(submitButton);
 
     await waitFor(() => {
@@ -170,7 +170,7 @@ describe('RequestInviteDialog', () => {
     render(<RequestInviteDialog {...defaultProps} />);
 
     const emailInput = screen.getByPlaceholderText(/enter your email address/i);
-    const submitButton = screen.getByRole('button', { name: /request invite/i });
+    const submitButton = screen.getByRole('button', { name: /^Request Invite$/ });
 
     await user.type(emailInput, 'existing@example.com');
     await user.click(submitButton);
@@ -187,7 +187,7 @@ describe('RequestInviteDialog', () => {
     render(<RequestInviteDialog {...defaultProps} />);
 
     const emailInput = screen.getByPlaceholderText(/enter your email address/i);
-    const submitButton = screen.getByRole('button', { name: /request invite/i });
+    const submitButton = screen.getByRole('button', { name: /^Request Invite$/ });
 
     await user.type(emailInput, 'test@example.com');
     await user.click(submitButton);
@@ -221,7 +221,7 @@ describe('RequestInviteDialog', () => {
     render(<RequestInviteDialog {...defaultProps} />);
 
     const emailInput = screen.getByPlaceholderText(/enter your email address/i);
-    const submitButton = screen.getByRole('button', { name: /request invite/i });
+    const submitButton = screen.getByRole('button', { name: /^Request Invite$/ });
 
     await user.type(emailInput, 'test@example.com');
     await user.click(submitButton);
@@ -246,7 +246,7 @@ describe('RequestInviteDialog', () => {
     render(<RequestInviteDialog open={true} onClose={onClose} />);
 
     const emailInput = screen.getByPlaceholderText(/enter your email address/i);
-    const submitButton = screen.getByRole('button', { name: /request invite/i });
+    const submitButton = screen.getByRole('button', { name: /^Request Invite$/ });
 
     await user.type(emailInput, 'test@example.com');
     await user.click(submitButton);
@@ -282,7 +282,7 @@ describe('RequestInviteDialog', () => {
     render(<RequestInviteDialog {...defaultProps} />);
 
     const emailInput = screen.getByPlaceholderText(/enter your email address/i);
-    const submitButton = screen.getByRole('button', { name: /request invite/i });
+    const submitButton = screen.getByRole('button', { name: /^Request Invite$/ });
 
     await user.type(emailInput, 'test@example.com');
     await user.click(submitButton);
@@ -359,10 +359,10 @@ describe('RequestInviteDialog', () => {
 
     render(<RequestInviteDialog {...defaultProps} />);
 
-    const loginLink = screen.getByRole('link', { name: /login/i });
+    const loginLink = screen.getByRole('link', { name: /open full login page/i });
     expect(loginLink).toHaveAttribute(
       'href',
-      expect.stringContaining('/login?redirect=')
+      expect.stringContaining('/auths/login?callbackUrl=')
     );
   });
 
@@ -370,9 +370,9 @@ describe('RequestInviteDialog', () => {
     render(<RequestInviteDialog {...defaultProps} />);
 
     const missionLink = screen.getByRole('link', {
-      name: /learn more about our mission here/i,
+      name: /learn more about our mission/i,
     });
-    expect(missionLink).toHaveAttribute('href', '/auth/request-access#mission');
+    expect(missionLink).toHaveAttribute('href', '/auths/request-access#mission');
   });
 
   it('cleans up timeout on unmount', async () => {
@@ -381,7 +381,7 @@ describe('RequestInviteDialog', () => {
     const { unmount } = render(<RequestInviteDialog {...defaultProps} />);
 
     const emailInput = screen.getByPlaceholderText(/enter your email address/i);
-    const submitButton = screen.getByRole('button', { name: /request invite/i });
+    const submitButton = screen.getByRole('button', { name: /^Request Invite$/ });
 
     await user.type(emailInput, 'test@example.com');
     await user.click(submitButton);

--- a/quotevote-frontend/src/__tests__/context/AuthModalContext.test.tsx
+++ b/quotevote-frontend/src/__tests__/context/AuthModalContext.test.tsx
@@ -7,7 +7,7 @@ function TestComponent() {
   return (
     <div>
       <div data-testid="modal-state">{isModalOpen ? 'open' : 'closed'}</div>
-      <button data-testid="open-button" onClick={openAuthModal}>
+      <button data-testid="open-button" onClick={() => openAuthModal()}>
         Open
       </button>
       <button data-testid="close-button" onClick={closeAuthModal}>

--- a/quotevote-frontend/src/__tests__/foundation/middleware.test.ts
+++ b/quotevote-frontend/src/__tests__/foundation/middleware.test.ts
@@ -40,17 +40,35 @@ describe('Middleware', () => {
   })
 
   describe('Dashboard protection', () => {
-    it('redirects unauthenticated users from /dashboard to /auths/login', () => {
+    it('allows unauthenticated users to browse /dashboard/explore', () => {
       middleware(createMockRequest('/dashboard/explore'))
+      expect(NextResponse.next).toHaveBeenCalled()
+      expect(NextResponse.redirect).not.toHaveBeenCalled()
+    })
+
+    it('allows unauthenticated users to view public post pages', () => {
+      middleware(createMockRequest('/dashboard/post/general/sample-title/abc123'))
+      expect(NextResponse.next).toHaveBeenCalled()
+      expect(NextResponse.redirect).not.toHaveBeenCalled()
+    })
+
+    it('allows unauthenticated users to view public profiles', () => {
+      middleware(createMockRequest('/dashboard/profile/testuser'))
+      expect(NextResponse.next).toHaveBeenCalled()
+      expect(NextResponse.redirect).not.toHaveBeenCalled()
+    })
+
+    it('redirects unauthenticated users from /dashboard/settings to /auths/login', () => {
+      middleware(createMockRequest('/dashboard/settings'))
       expect(NextResponse.redirect).toHaveBeenCalled()
       const redirectUrl = (NextResponse.redirect as jest.Mock).mock.calls[0][0] as URL
       expect(redirectUrl.pathname).toBe('/auths/login')
+      expect(redirectUrl.searchParams.get('callbackUrl')).toBe('/dashboard/settings')
     })
 
-    it('includes callbackUrl for dashboard redirect', () => {
-      middleware(createMockRequest('/dashboard/explore'))
-      const redirectUrl = (NextResponse.redirect as jest.Mock).mock.calls[0][0] as URL
-      expect(redirectUrl.searchParams.get('callbackUrl')).toBe('/dashboard/explore')
+    it('redirects unauthenticated users from /dashboard/profile to /auths/login', () => {
+      middleware(createMockRequest('/dashboard/profile'))
+      expect(NextResponse.redirect).toHaveBeenCalled()
     })
 
     it('allows authenticated users to pass through /dashboard', () => {

--- a/quotevote-frontend/src/__tests__/hooks/usePresenceHeartbeat.test.ts
+++ b/quotevote-frontend/src/__tests__/hooks/usePresenceHeartbeat.test.ts
@@ -1,12 +1,19 @@
 import { renderHook, act } from '@testing-library/react'
 import { useMutation } from '@apollo/client/react'
 import { usePresenceHeartbeat } from '@/hooks/usePresenceHeartbeat'
+import { isAuthenticated } from '@/lib/utils/auth'
 
 // Mock Apollo Client
 jest.mock('@apollo/client/react', () => ({
     ...jest.requireActual('@apollo/client/react'),
     useMutation: jest.fn(),
 }))
+
+jest.mock('@/lib/utils/auth', () => ({
+    isAuthenticated: jest.fn(),
+}))
+
+const mockIsAuthenticated = isAuthenticated as jest.MockedFunction<typeof isAuthenticated>
 
 describe('usePresenceHeartbeat', () => {
     let mockHeartbeat: jest.Mock
@@ -15,6 +22,7 @@ describe('usePresenceHeartbeat', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         jest.useFakeTimers()
+        mockIsAuthenticated.mockReturnValue(true)
         mockHeartbeat = jest.fn().mockResolvedValue({ data: { heartbeat: { success: true } } })
         mockError = undefined
 
@@ -23,6 +31,14 @@ describe('usePresenceHeartbeat', () => {
 
     afterEach(() => {
         jest.useRealTimers()
+    })
+
+    it('should not send heartbeat when user is not authenticated', () => {
+        mockIsAuthenticated.mockReturnValue(false)
+
+        renderHook(() => usePresenceHeartbeat())
+
+        expect(mockHeartbeat).not.toHaveBeenCalled()
     })
 
     it('should send initial heartbeat immediately', () => {

--- a/quotevote-frontend/src/__tests__/utils/dashboard-routes.test.ts
+++ b/quotevote-frontend/src/__tests__/utils/dashboard-routes.test.ts
@@ -1,0 +1,34 @@
+import {
+  isAuthRequiredDashboardRoute,
+  isGuestReadableDashboardRoute,
+} from '@/lib/dashboard-routes'
+
+describe('dashboard-routes', () => {
+  describe('isGuestReadableDashboardRoute', () => {
+    it('allows explore and post routes', () => {
+      expect(isGuestReadableDashboardRoute('/dashboard/explore')).toBe(true)
+      expect(isGuestReadableDashboardRoute('/dashboard/post/general/title/id')).toBe(true)
+    })
+
+    it('allows public profile pages', () => {
+      expect(isGuestReadableDashboardRoute('/dashboard/profile/alice')).toBe(true)
+    })
+
+    it('does not allow own profile shell without username', () => {
+      expect(isGuestReadableDashboardRoute('/dashboard/profile')).toBe(false)
+    })
+
+    it('does not allow account-only routes', () => {
+      expect(isGuestReadableDashboardRoute('/dashboard/settings')).toBe(false)
+      expect(isGuestReadableDashboardRoute('/dashboard/notifications')).toBe(false)
+    })
+  })
+
+  describe('isAuthRequiredDashboardRoute', () => {
+    it('marks account routes as auth required', () => {
+      expect(isAuthRequiredDashboardRoute('/dashboard/settings')).toBe(true)
+      expect(isAuthRequiredDashboardRoute('/dashboard/notifications')).toBe(true)
+      expect(isAuthRequiredDashboardRoute('/dashboard/profile')).toBe(true)
+    })
+  })
+})

--- a/quotevote-frontend/src/app/auths/(split)/login/PageContent.tsx
+++ b/quotevote-frontend/src/app/auths/(split)/login/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -36,6 +36,8 @@ type LoginFormData = z.infer<typeof loginSchema>
 
 export default function LoginPageContent() {
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const callbackUrl = searchParams.get('callbackUrl') || searchParams.get('redirect') || '/dashboard/explore'
   const setUserData = useAppStore((s) => s.setUserData)
   const [submitting, setSubmitting] = useState(false)
   const [tosAccepted, setTosAccepted] = useState(false)
@@ -60,7 +62,7 @@ export default function LoginPageContent() {
       const result = await loginUser(values.email, values.password)
       if (result.success && result.data) {
         setUserData(result.data.user as Record<string, unknown>)
-        router.push('/dashboard/explore')
+        router.push(callbackUrl.startsWith('/') ? callbackUrl : '/dashboard/explore')
       } else {
         toast.error(result.error || 'Login failed')
       }

--- a/quotevote-frontend/src/app/components/LandingPage/LandingPageContent.tsx
+++ b/quotevote-frontend/src/app/components/LandingPage/LandingPageContent.tsx
@@ -35,6 +35,7 @@ import { useAppStore } from '@/store';
 import { SEARCH, GET_FEATURED_POSTS } from '@/graphql/queries';
 import { REQUEST_USER_ACCESS_MUTATION } from '@/graphql/mutations';
 import { useDebounce } from '@/hooks/useDebounce';
+import { toAppPostUrl } from '@/lib/utils/sanitizeUrl';
 import type { Post } from '@/types/post';
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -1588,9 +1589,19 @@ function HeroSearch({ router }: HeroSearchProps) {
     if (e.key === 'Escape') setIsOpen(false);
   };
 
-  const handleResultClick = () => {
+  const handlePostClick = (item: ContentResult) => {
     setIsOpen(false);
-    router.push('/auths/login');
+    if (item.url) {
+      router.push(toAppPostUrl(item.url));
+      return;
+    }
+    router.push(`/dashboard/explore?q=${encodeURIComponent(item.title)}`);
+  };
+
+  const handleCreatorClick = (creator: CreatorResult) => {
+    setIsOpen(false);
+    const profileSlug = creator.username || creator._id;
+    router.push(`/dashboard/profile/${profileSlug}`);
   };
 
   return (
@@ -1695,7 +1706,7 @@ function HeroSearch({ router }: HeroSearchProps) {
                     <button
                       key={item._id}
                       type="button"
-                      onClick={handleResultClick}
+                      onClick={() => handlePostClick(item)}
                       className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors text-left"
                     >
                       <div
@@ -1725,7 +1736,7 @@ function HeroSearch({ router }: HeroSearchProps) {
                     <button
                       key={creator._id}
                       type="button"
-                      onClick={handleResultClick}
+                      onClick={() => handleCreatorClick(creator)}
                       className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors text-left"
                     >
                       <div className="w-8 h-8 rounded-full overflow-hidden flex-shrink-0 bg-gray-200 flex items-center justify-center">
@@ -1750,7 +1761,10 @@ function HeroSearch({ router }: HeroSearchProps) {
               <div className="border-t border-gray-100 px-4 py-3">
                 <button
                   type="button"
-                  onClick={handleResultClick}
+                  onClick={() => {
+                    setIsOpen(false);
+                    router.push(`/dashboard/explore?q=${encodeURIComponent(debouncedQuery)}`);
+                  }}
                   className="text-sm font-medium transition-colors hover:underline"
                   style={{ color: 'var(--color-primary)' }}
                 >

--- a/quotevote-frontend/src/app/dashboard/layout.tsx
+++ b/quotevote-frontend/src/app/dashboard/layout.tsx
@@ -30,7 +30,6 @@ import { routeHasPersistentChatPanel } from '@/lib/utils/chatLayout';
 import { usePresenceHeartbeat } from '@/hooks/usePresenceHeartbeat';
 import { usePresenceSubscription } from '@/hooks/usePresenceSubscription';
 import { useRosterManagement } from '@/hooks/useRosterManagement';
-import { RequestInviteDialog } from '@/components/RequestInviteDialog';
 import ChatContent from '@/components/Chat/ChatContent';
 import { GET_NOTIFICATIONS, GET_CHAT_ROOMS } from '@/graphql/queries';
 import { DisplayAvatar } from '@/components/DisplayAvatar';
@@ -112,7 +111,7 @@ export default function DashboardLayout({
 }): React.ReactNode {
   const pathname = usePathname();
   const router = useRouter();
-  const { isModalOpen, closeAuthModal } = useAuthModal();
+  const { openAuthModal } = useAuthModal();
   const setSelectedPage = useAppStore((s) => s.setSelectedPage);
   const setChatOpen = useAppStore((s) => s.setChatOpen);
   const user = useAppStore((s) => s.user.data);
@@ -166,6 +165,18 @@ export default function DashboardLayout({
       logout();
     }
     router.push('/auths/login');
+  };
+
+  const requireAuthForAction = (action: () => void, view: 'invite' | 'login' = 'login') => {
+    if (!loggedIn) {
+      openAuthModal({ view });
+      return;
+    }
+    action();
+  };
+
+  const handleCreateClick = () => {
+    requireAuthForAction(() => setSubmitDialogOpen(true));
   };
 
   return (
@@ -223,7 +234,7 @@ export default function DashboardLayout({
             {/* Create */}
             <button
               type="button"
-              onClick={() => setSubmitDialogOpen(true)}
+              onClick={handleCreateClick}
               className="flex items-center gap-1.5 h-9 px-4 rounded-full bg-[#52b274] text-white text-[13px] font-semibold shadow-[0_2px_6px_rgba(82,178,116,0.40)] hover:bg-[#4a9e63] hover:shadow-[0_3px_10px_rgba(82,178,116,0.50)] active:scale-95 transition-all duration-150 cursor-pointer border-0 flex-shrink-0"
               aria-label="Create new quote"
             >
@@ -309,6 +320,16 @@ export default function DashboardLayout({
                 </DropdownMenuContent>
               </DropdownMenu>
             )}
+
+            {!loggedIn && (
+              <button
+                type="button"
+                onClick={() => openAuthModal({ view: 'login' })}
+                className="flex items-center gap-1.5 h-9 px-4 rounded-full border border-[#52b274] text-[#52b274] text-[13px] font-semibold hover:bg-[#52b274]/10 transition-all duration-150 cursor-pointer flex-shrink-0"
+              >
+                Sign in
+              </button>
+            )}
           </div>
         </div>
       </header>
@@ -369,7 +390,7 @@ export default function DashboardLayout({
         {/* Create — floating green circle */}
         <button
           type="button"
-          onClick={() => setSubmitDialogOpen(true)}
+          onClick={handleCreateClick}
           className="flex flex-col items-center justify-center flex-1 h-full cursor-pointer border-0 bg-transparent"
           aria-label="Create"
         >
@@ -382,10 +403,11 @@ export default function DashboardLayout({
         </button>
 
         {/* Notifications */}
-        <Link
-          href="/dashboard/notifications"
+        <button
+          type="button"
+          onClick={() => requireAuthForAction(() => router.push('/dashboard/notifications'))}
           className={cn(
-            'relative flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors duration-150',
+            'relative flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors duration-150 border-0 bg-transparent cursor-pointer',
             isActive('/dashboard/notifications') ? 'text-[#52b274]' : 'text-muted-foreground'
           )}
           aria-label="Notifications"
@@ -399,7 +421,7 @@ export default function DashboardLayout({
             )}
           </div>
           <span className="text-[10px] font-semibold">Activity</span>
-        </Link>
+        </button>
 
         {/* Profile — opens an account menu (Your Profile, Settings & Privacy,
             Sign out) instead of navigating directly. */}
@@ -467,17 +489,18 @@ export default function DashboardLayout({
             </DropdownMenuContent>
           </DropdownMenu>
         ) : (
-          <Link
-            href="/dashboard/profile"
+          <button
+            type="button"
+            onClick={() => openAuthModal({ view: 'login' })}
             className={cn(
-              'flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors duration-150',
-              isActive('/dashboard/profile') ? 'text-[#52b274]' : 'text-muted-foreground'
+              'flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors duration-150 border-0 bg-transparent cursor-pointer',
+              'text-muted-foreground'
             )}
-            aria-label="Profile"
+            aria-label="Sign in"
           >
             <User className="size-[22px]" />
-            <span className="text-[10px] font-semibold">Profile</span>
-          </Link>
+            <span className="text-[10px] font-semibold">Sign in</span>
+          </button>
         )}
       </nav>
 
@@ -524,7 +547,6 @@ export default function DashboardLayout({
       </main>
 
       <ChatPanel />
-      <RequestInviteDialog open={isModalOpen} onClose={closeAuthModal} />
 
       <Dialog open={submitDialogOpen} onOpenChange={setSubmitDialogOpen}>
         {/* z-[70] keeps the full-screen create form above the mobile bottom

--- a/quotevote-frontend/src/app/layout.tsx
+++ b/quotevote-frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "sonner";
 import { ApolloProviderWrapper } from "@/lib/apollo";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { AuthModalProvider } from "@/context/AuthModalContext";
+import { AuthGateDialog } from "@/components/AuthGateDialog";
 import { ThemeContextProvider } from "@/context/ThemeContext";
 import { cn } from "@/lib/utils";
 // import { Eyebrow } from "./components/Eyebrow/Eyebrow";
@@ -70,6 +71,7 @@ export default function RootLayout({
               <AuthModalProvider>
                 {/* <Eyebrow /> */}
                 {children}
+                <AuthGateDialog />
                 <Toaster position="top-right" richColors />
               </AuthModalProvider>
             </ThemeContextProvider>

--- a/quotevote-frontend/src/components/Activity/ActivityList.tsx
+++ b/quotevote-frontend/src/components/Activity/ActivityList.tsx
@@ -17,6 +17,7 @@ import {
   GET_USER_ACTIVITY,
 } from '@/graphql/queries'
 import useGuestGuard from '@/hooks/useGuestGuard'
+import { toAppPostUrl } from '@/lib/utils/sanitizeUrl'
 import type { ActivityListProps, ActivityEntity } from '@/types/activity'
 
 function LoadActivityCard({
@@ -121,16 +122,8 @@ function LoadActivityCard({
   const isLiked = currentUser?._id && typeof currentUser._id === 'string' ? bookmarkedBy.includes(currentUser._id) : false
 
   const handleCardClick = () => {
-    // Check if user is in guest mode
-    if (!ensureAuth()) {
-      // Redirect to search page for guest users
-      router.push('/search')
-      return
-    }
-
-    // For authenticated users, proceed with normal post navigation
     setSelectedPost(postId)
-    router.push(url.replace(/\?/g, ''))
+    router.push(toAppPostUrl(url.replace(/\?/g, '')))
   }
 
   return (

--- a/quotevote-frontend/src/components/Activity/PaginatedActivityList.tsx
+++ b/quotevote-frontend/src/components/Activity/PaginatedActivityList.tsx
@@ -19,6 +19,7 @@ import {
 import { useAppStore } from '@/store'
 import useGuestGuard from '@/hooks/useGuestGuard'
 import { useRouter } from 'next/navigation'
+import { toAppPostUrl } from '@/lib/utils/sanitizeUrl'
 import type { PaginatedActivityListProps, ActivityEntity } from '@/types/activity'
 
 function LoadActivityCard({
@@ -123,16 +124,8 @@ function LoadActivityCard({
   const isLiked = currentUser?._id && typeof currentUser._id === 'string' ? bookmarkedBy.includes(currentUser._id) : false
 
   const handleCardClick = () => {
-    // Check if user is in guest mode
-    if (!ensureAuth()) {
-      // Redirect to search page for guest users
-      router.push('/search')
-      return
-    }
-
-    // For authenticated users, proceed with normal post navigation
     setSelectedPost(postId)
-    router.push(url.replace(/\?/g, ''))
+    router.push(toAppPostUrl(url.replace(/\?/g, '')))
   }
 
   return (

--- a/quotevote-frontend/src/components/AuthGateDialog.tsx
+++ b/quotevote-frontend/src/components/AuthGateDialog.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { Suspense, useEffect } from 'react'
+import { useAuthModal } from '@/context/AuthModalContext'
+import { RequestInviteDialog } from '@/components/RequestInviteDialog'
+import { registerAuthGateHandler } from '@/lib/auth-gate'
+
+/**
+ * Global auth gate dialog — mounted once in the root layout so guests on any
+ * route see the invite/login modal instead of being redirected away.
+ */
+export function AuthGateDialog() {
+  const { isModalOpen, modalView, openAuthModal, closeAuthModal } = useAuthModal()
+
+  useEffect(() => {
+    registerAuthGateHandler((options) => openAuthModal(options))
+    return () => registerAuthGateHandler(null)
+  }, [openAuthModal])
+
+  return (
+    <Suspense fallback={null}>
+      <RequestInviteDialog
+        open={isModalOpen}
+        onClose={closeAuthModal}
+        view={modalView}
+      />
+    </Suspense>
+  )
+}

--- a/quotevote-frontend/src/components/Post/PostCard.tsx
+++ b/quotevote-frontend/src/components/Post/PostCard.tsx
@@ -208,7 +208,7 @@ function PostCardComponent({
     e.stopPropagation()
     const uname = creator?.username
     if (!uname) return
-    if (guestGuard()) router.push(`/dashboard/profile/${uname}`)
+    router.push(`/dashboard/profile/${uname}`)
   }
 
   const username = creator?.username || 'Anonymous'

--- a/quotevote-frontend/src/components/Profile/ProfileHeader.tsx
+++ b/quotevote-frontend/src/components/Profile/ProfileHeader.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { ProfileBadge, ProfileBadgeContainer } from './ProfileBadge';
 import { cn } from '@/lib/utils';
+import useGuestGuard from '@/hooks/useGuestGuard';
 import { useProfileBackground } from '@/hooks/useProfileBackground';
 import {
   getProfileBackgroundStyle,
@@ -64,6 +65,7 @@ export function ProfileHeader({ profileUser }: ProfileHeaderProps) {
   const { color: profileBgColor, pattern: profileBgPattern } = useProfileBackground();
   const loggedInUserIdString = typeof loggedInUserId === 'string' ? loggedInUserId : String(loggedInUserId || '');
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
+  const ensureAuth = useGuestGuard();
 
   const {
     username,
@@ -132,6 +134,8 @@ export function ProfileHeader({ profileUser }: ProfileHeaderProps) {
   const room = !chatLoading && data?.messageRoom;
 
   const handleMessageUser = async () => {
+    if (!ensureAuth()) return;
+
     if (isBlocked) {
       const isBlocker = blockingStatus === 'blocker';
       const message = isBlocker

--- a/quotevote-frontend/src/components/RequestInviteDialog.tsx
+++ b/quotevote-frontend/src/components/RequestInviteDialog.tsx
@@ -2,9 +2,9 @@
 
 /**
  * RequestInviteDialog Component
- * 
- * Dialog component for requesting platform access via email invitation.
- * Migrated from Material UI to shadcn/ui components.
+ *
+ * Auth gate modal for guests: request invite, login with password, or learn more.
+ * Viewing is public; participation requires an account.
  */
 
 import { useState, useEffect, useRef } from 'react';
@@ -12,6 +12,7 @@ import { useApolloClient, useMutation } from '@apollo/client/react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
 
 import {
   Dialog,
@@ -27,25 +28,39 @@ import { Label } from '@/components/ui/label';
 import { REQUEST_USER_ACCESS_MUTATION } from '@/graphql/mutations';
 import { GET_CHECK_DUPLICATE_EMAIL } from '@/graphql/queries';
 import { requestAccessEmailSchema } from '@/lib/validation/requestAccessSchema';
+import { loginUser } from '@/lib/auth';
+import { useAppStore } from '@/store/useAppStore';
 import type { RequestInviteDialogProps } from '@/types/components';
 
-export function RequestInviteDialog({ open, onClose }: RequestInviteDialogProps) {
+type PanelView = 'invite' | 'login';
+
+export function RequestInviteDialog({ open, onClose, view = 'invite' }: RequestInviteDialogProps) {
+  const [panel, setPanel] = useState<PanelView>(view);
   const [email, setEmail] = useState('');
   const [error, setError] = useState('');
   const [submitted, setSubmitted] = useState(false);
+  const [loginUsername, setLoginUsername] = useState('');
+  const [loginPassword, setLoginPassword] = useState('');
+  const [loginLoading, setLoginLoading] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  
+  const setUserData = useAppStore((s) => s.setUserData);
+
   const client = useApolloClient();
   const [requestUserAccess, { loading }] = useMutation(
     REQUEST_USER_ACCESS_MUTATION
   );
 
-  const handleSubmit = async () => {
+  useEffect(() => {
+    if (open) {
+      setPanel(view);
+    }
+  }, [open, view]);
+
+  const handleInviteSubmit = async () => {
     setError('');
 
-    // Validate email using Zod schema
     const validationResult = requestAccessEmailSchema.safeParse({ email });
 
     if (!validationResult.success) {
@@ -56,7 +71,6 @@ export function RequestInviteDialog({ open, onClose }: RequestInviteDialogProps)
     }
 
     try {
-      // Check for duplicate email
       const checkDuplicate = await client.query({
         query: GET_CHECK_DUPLICATE_EMAIL,
         variables: { email },
@@ -74,28 +88,49 @@ export function RequestInviteDialog({ open, onClose }: RequestInviteDialogProps)
         return;
       }
 
-      // Submit request
       await requestUserAccess({
         variables: { requestUserAccessInput: { email } },
       });
-      
+
       setSubmitted(true);
       toast.success('Request submitted successfully!');
-      
-      // Auto-close after 3 seconds with cleanup
+
       timeoutRef.current = setTimeout(() => {
         handleClose();
       }, 3000);
     } catch (err) {
-      const error = err as Error;
+      const submitError = err as Error;
       setError('An unexpected error occurred. Please try again later.');
       toast.error('Failed to submit request');
-      console.error(error);
+      console.error(submitError);
+    }
+  };
+
+  const handleLoginSubmit = async () => {
+    setError('');
+    if (!loginUsername.trim() || !loginPassword) {
+      setError('Username and password are required.');
+      return;
+    }
+
+    setLoginLoading(true);
+    try {
+      const result = await loginUser(loginUsername.trim(), loginPassword);
+      if (result.success && result.data) {
+        setUserData(result.data.user as Record<string, unknown>);
+        toast.success('Welcome back!');
+        handleClose();
+        return;
+      }
+      setError(result.error || 'Login failed. Please try again.');
+    } catch {
+      setError('Connection failed. Please try again.');
+    } finally {
+      setLoginLoading(false);
     }
   };
 
   const handleClose = () => {
-    // Clear timeout if it exists
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
@@ -103,10 +138,12 @@ export function RequestInviteDialog({ open, onClose }: RequestInviteDialogProps)
     setEmail('');
     setError('');
     setSubmitted(false);
+    setLoginUsername('');
+    setLoginPassword('');
+    setPanel('invite');
     onClose();
   };
 
-  // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
       if (timeoutRef.current) {
@@ -115,9 +152,8 @@ export function RequestInviteDialog({ open, onClose }: RequestInviteDialogProps)
     };
   }, []);
 
-  // Get current URL path to pass as redirect parameter (including hash)
   const currentPath = pathname + (searchParams.toString() ? `?${searchParams.toString()}` : '');
-  const loginUrl = `/login?redirect=${encodeURIComponent(currentPath)}`;
+  const loginPageUrl = `/auths/login?callbackUrl=${encodeURIComponent(currentPath)}`;
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
@@ -143,62 +179,138 @@ export function RequestInviteDialog({ open, onClose }: RequestInviteDialogProps)
               </DialogTitle>
             </DialogHeader>
 
-            <div className="space-y-2">
-              <Label htmlFor="email" className="sr-only">
-                Email Address
-              </Label>
-              <div className="relative">
-                <div className="absolute inset-0 bg-gradient-to-br from-gray-50 to-gray-100 rounded-lg border-2 border-gray-200 transition-all duration-300 focus-within:border-[#52b274] focus-within:shadow-[0_0_0_4px_rgba(82,178,116,0.1)] focus-within:bg-gradient-to-br focus-within:from-white focus-within:to-gray-50" />
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="Enter Your Email Address"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
-                  className="relative bg-transparent border-none outline-none w-full text-base sm:text-lg text-foreground font-medium placeholder:text-muted-foreground focus:ring-0 focus-visible:ring-0"
-                />
-              </div>
+            <div className="flex rounded-lg border border-border p-1 gap-1">
+              <button
+                type="button"
+                onClick={() => { setPanel('invite'); setError(''); }}
+                className={`flex-1 rounded-md py-2 text-sm font-medium transition-colors ${
+                  panel === 'invite'
+                    ? 'bg-[#52b274] text-white'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Request invite
+              </button>
+              <button
+                type="button"
+                onClick={() => { setPanel('login'); setError(''); }}
+                className={`flex-1 rounded-md py-2 text-sm font-medium transition-colors ${
+                  panel === 'login'
+                    ? 'bg-[#52b274] text-white'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Log in
+              </button>
             </div>
 
-            {error && (
-              <div className="bg-red-50 border border-red-200 rounded-lg p-3 sm:p-4 text-center">
-                <p className="text-red-800 text-sm sm:text-[0.95rem] font-medium m-0">
-                  {error}
+            {panel === 'invite' ? (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="invite-email" className="sr-only">
+                    Email Address
+                  </Label>
+                  <Input
+                    id="invite-email"
+                    type="email"
+                    placeholder="Enter your email address"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && handleInviteSubmit()}
+                  />
+                </div>
+
+                <div className="text-center py-1">
+                  <Link
+                    href="/auths/request-access#mission"
+                    className="text-[#52b274] no-underline text-sm font-medium hover:underline"
+                  >
+                    Learn more about our mission
+                  </Link>
+                </div>
+
+                <Button
+                  onClick={handleInviteSubmit}
+                  disabled={loading}
+                  className="w-full bg-[#52b274] text-white hover:bg-[#4a9e63]"
+                >
+                  {loading ? 'Submitting...' : 'Request Invite'}
+                </Button>
+              </>
+            ) : (
+              <>
+                <div className="space-y-3">
+                  <div className="space-y-2">
+                    <Label htmlFor="login-username">Username or email</Label>
+                    <Input
+                      id="login-username"
+                      autoComplete="username"
+                      value={loginUsername}
+                      onChange={(e) => setLoginUsername(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="login-password">Password</Label>
+                    <Input
+                      id="login-password"
+                      type="password"
+                      autoComplete="current-password"
+                      value={loginPassword}
+                      onChange={(e) => setLoginPassword(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && handleLoginSubmit()}
+                    />
+                  </div>
+                </div>
+
+                <Button
+                  onClick={handleLoginSubmit}
+                  disabled={loginLoading}
+                  className="w-full bg-[#52b274] text-white hover:bg-[#4a9e63]"
+                >
+                  {loginLoading ? (
+                    <>
+                      <Loader2 className="mr-2 size-4 animate-spin" />
+                      Signing in...
+                    </>
+                  ) : (
+                    'Sign in'
+                  )}
+                </Button>
+
+                <p className="text-center text-xs text-muted-foreground">
+                  Need a password reset or magic link?{' '}
+                  <Link href="/auths/forgot-password" className="text-[#52b274] font-medium hover:underline">
+                    Forgot password
+                  </Link>
                 </p>
+              </>
+            )}
+
+            {error && (
+              <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-center">
+                <p className="text-red-800 text-sm font-medium m-0">{error}</p>
               </div>
             )}
 
-            <div className="text-center py-2">
-              <Link
-                href="/auth/request-access#mission"
-                className="text-[#52b274] no-underline text-sm sm:text-[0.95rem] font-medium transition-colors duration-300 hover:text-[#4a9f63] hover:underline"
-              >
-                Learn more about our mission here
-              </Link>
-            </div>
-
-            <Button
-              onClick={handleSubmit}
-              disabled={loading}
-              className="w-full bg-[#52b274] text-white hover:bg-[#4a9f63] rounded-lg py-3 px-6 text-base font-medium transition-colors duration-300"
-            >
-              {loading ? 'Submitting...' : 'Request Invite'}
-            </Button>
-
-            <p className="text-center text-sm text-gray-600 mt-4">
-              Already have an account?{' '}
-              <Link
-                href={loginUrl}
-                className="text-[#52b274] no-underline font-medium transition-colors duration-300 hover:underline"
-              >
-                Login
-              </Link>
-            </p>
+            {panel === 'invite' && (
+              <p className="text-center text-sm text-gray-600">
+                Already have an account?{' '}
+                <button
+                  type="button"
+                  onClick={() => { setPanel('login'); setError(''); }}
+                  className="text-[#52b274] font-medium hover:underline bg-transparent border-0 cursor-pointer p-0"
+                >
+                  Log in
+                </button>
+                {' '}or{' '}
+                <Link href={loginPageUrl} className="text-[#52b274] font-medium hover:underline">
+                  open full login page
+                </Link>
+              </p>
+            )}
           </div>
         )}
       </DialogContent>
     </Dialog>
   );
 }
-

--- a/quotevote-frontend/src/components/SearchContainer/SearchGuestSections.tsx
+++ b/quotevote-frontend/src/components/SearchContainer/SearchGuestSections.tsx
@@ -105,7 +105,7 @@ export default function SearchGuestSections() {
                 only takes a moment to get started.
               </p>
               <Button
-                onClick={openAuthModal}
+                onClick={() => openAuthModal()}
                 size="lg"
                 className="gap-2"
               >

--- a/quotevote-frontend/src/context/AuthModalContext.tsx
+++ b/quotevote-frontend/src/context/AuthModalContext.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { createContext, useState, useContext } from 'react'
+import { createContext, useState, useContext, useCallback } from 'react'
 import type {
   AuthModalContextValue,
   AuthModalProviderProps,
+  AuthModalView,
 } from '@/types/context'
 
 const AuthModalContext = createContext<AuthModalContextValue | undefined>(
@@ -11,16 +12,25 @@ const AuthModalContext = createContext<AuthModalContextValue | undefined>(
 )
 
 /**
- * Provider for global invite modal state management
+ * Provider for global auth / request-invite modal state
  */
 export function AuthModalProvider({ children }: AuthModalProviderProps) {
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [modalView, setModalView] = useState<AuthModalView>('invite')
 
-  const openAuthModal = () => setIsModalOpen(true)
-  const closeAuthModal = () => setIsModalOpen(false)
+  const openAuthModal = useCallback((options?: { view?: AuthModalView }) => {
+    setModalView(options?.view ?? 'invite')
+    setIsModalOpen(true)
+  }, [])
+
+  const closeAuthModal = useCallback(() => {
+    setIsModalOpen(false)
+    setModalView('invite')
+  }, [])
 
   const value: AuthModalContextValue = {
     isModalOpen,
+    modalView,
     openAuthModal,
     closeAuthModal,
   }
@@ -33,7 +43,7 @@ export function AuthModalProvider({ children }: AuthModalProviderProps) {
 }
 
 /**
- * Hook to access invite modal state and controls
+ * Hook to access auth modal state and controls
  * @throws {Error} When used outside AuthModalProvider
  */
 export const useAuthModal = (): AuthModalContextValue => {
@@ -43,4 +53,3 @@ export const useAuthModal = (): AuthModalContextValue => {
   }
   return context
 }
-

--- a/quotevote-frontend/src/hooks/useGuestGuard.ts
+++ b/quotevote-frontend/src/hooks/useGuestGuard.ts
@@ -11,7 +11,7 @@ export default function useGuestGuard() {
 
     return useCallback(() => {
         if (!isAuthenticated()) {
-            openAuthModal()
+            openAuthModal({ view: 'login' })
             return false
         }
         return true

--- a/quotevote-frontend/src/hooks/usePresenceHeartbeat.ts
+++ b/quotevote-frontend/src/hooks/usePresenceHeartbeat.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react'
 import { useMutation } from '@apollo/client/react'
 import { HEARTBEAT } from '@/graphql/mutations'
+import { isAuthenticated } from '@/lib/utils/auth'
 import type { UsePresenceHeartbeatReturn } from '@/types/hooks'
 
 /**
@@ -16,6 +17,10 @@ export const usePresenceHeartbeat = (interval: number = 45000): UsePresenceHeart
     const backoffMultiplier = 2
 
     useEffect(() => {
+        if (!isAuthenticated()) {
+            return
+        }
+
         const getRetryDelay = (attempt: number): number => {
             return Math.min(interval * Math.pow(backoffMultiplier, attempt), 300000)
         }

--- a/quotevote-frontend/src/lib/apollo/apollo-client.ts
+++ b/quotevote-frontend/src/lib/apollo/apollo-client.ts
@@ -11,6 +11,7 @@ import { env } from '@/config/env';
 import { getGraphqlWsServerUrl } from '@/lib/utils/getServerUrl';
 import { serializeObjectIds } from '@/lib/utils/objectIdSerializer';
 import { getToken, removeToken } from '@/lib/auth';
+import { triggerAuthGate } from '@/lib/auth-gate';
 
 /**
  * Get the GraphQL endpoint URL from validated environment configuration
@@ -191,7 +192,7 @@ function createErrorLink() {
         if (code === 'UNAUTHENTICATED') {
           if (typeof window !== 'undefined') {
             removeToken();
-            window.location.href = '/auths/login';
+            triggerAuthGate({ view: 'login' });
           }
           return;
         }

--- a/quotevote-frontend/src/lib/auth-gate.ts
+++ b/quotevote-frontend/src/lib/auth-gate.ts
@@ -1,0 +1,17 @@
+export type AuthGateView = 'invite' | 'login';
+
+export interface AuthGateOptions {
+  view?: AuthGateView;
+}
+
+type AuthGateHandler = (options?: AuthGateOptions) => void;
+
+let authGateHandler: AuthGateHandler | null = null;
+
+export function registerAuthGateHandler(handler: AuthGateHandler | null): void {
+  authGateHandler = handler;
+}
+
+export function triggerAuthGate(options?: AuthGateOptions): void {
+  authGateHandler?.(options);
+}

--- a/quotevote-frontend/src/lib/dashboard-routes.ts
+++ b/quotevote-frontend/src/lib/dashboard-routes.ts
@@ -1,0 +1,30 @@
+/**
+ * Dashboard route access rules for guest (logged-out) sessions.
+ * Read-only routes are browsable without auth; participation is gated client-side.
+ */
+
+const GUEST_READABLE_PREFIXES = ['/dashboard/explore', '/dashboard/post'] as const;
+
+const AUTH_REQUIRED_PREFIXES = [
+  '/dashboard/settings',
+  '/dashboard/notifications',
+  '/dashboard/manage-invites',
+  '/dashboard/control-panel',
+] as const;
+
+/** Public profile pages: /dashboard/profile/:username (not /dashboard/profile alone). */
+function isPublicProfileRoute(pathname: string): boolean {
+  return /^\/dashboard\/profile\/[^/]+/.test(pathname);
+}
+
+export function isGuestReadableDashboardRoute(pathname: string): boolean {
+  if (GUEST_READABLE_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))) {
+    return true;
+  }
+  return isPublicProfileRoute(pathname);
+}
+
+export function isAuthRequiredDashboardRoute(pathname: string): boolean {
+  if (pathname === '/dashboard/profile') return true;
+  return AUTH_REQUIRED_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}

--- a/quotevote-frontend/src/lib/utils/auth.ts
+++ b/quotevote-frontend/src/lib/utils/auth.ts
@@ -1,5 +1,6 @@
 import { jwtDecode } from 'jwt-decode'
 import { DecodedToken } from '@/types/store'
+import { triggerAuthGate } from '@/lib/auth-gate'
 
 export function isAuthenticated(): boolean {
   const token = localStorage.getItem('token')
@@ -19,9 +20,7 @@ export function isAuthenticated(): boolean {
 export function requireAuth<Args extends unknown[], R>(action: (...args: Args) => R) {
   return (...args: Args): R | void => {
     if (!isAuthenticated()) {
-      window.location.assign(
-        `https://quote.vote/invite?from=${window.location.pathname}`,
-      )
+      triggerAuthGate({ view: 'login' })
       return
     }
     return action(...args)

--- a/quotevote-frontend/src/types/components.ts
+++ b/quotevote-frontend/src/types/components.ts
@@ -735,6 +735,10 @@ export interface RequestInviteDialogProps {
    * Callback function called when dialog should close
    */
   onClose: () => void;
+  /**
+   * Which panel to show when the dialog opens
+   */
+  view?: 'invite' | 'login';
 }
 
 export interface CardDetails {

--- a/quotevote-frontend/src/types/context.ts
+++ b/quotevote-frontend/src/types/context.ts
@@ -26,11 +26,17 @@ export interface Theme {
 }
 
 /**
+ * Auth modal view modes
+ */
+export type AuthModalView = 'invite' | 'login'
+
+/**
  * AuthModal context value interface
  */
 export interface AuthModalContextValue {
   isModalOpen: boolean
-  openAuthModal: () => void
+  modalView: AuthModalView
+  openAuthModal: (options?: { view?: AuthModalView }) => void
   closeAuthModal: () => void
 }
 


### PR DESCRIPTION
## Summary
- Replace hard redirects on auth-gated actions with a shared auth gate that opens `RequestInviteDialog` (login + request invite tabs) while keeping the user on the current page
- Mount `AuthGateDialog` globally; wire `useGuestGuard`, dashboard layout actions, Apollo `UNAUTHENTICATED` handling, and profile Message button to the modal flow
- Preserve `callbackUrl` on login so users can resume after authenticating

**Depends on:** #389 (RC1-003 guest read access) — merge RC1-003 first; this PR stacks on those commits until then.

## Test plan
- [ ] Logged out on `/dashboard/explore`: click Create / Messages / Notifications → modal opens, no redirect
- [ ] Logged out on a post: vote / comment / bookmark → modal opens
- [ ] Logged out on public profile: Message → modal opens
- [ ] Modal login tab → successful login returns to originating route via `callbackUrl`
- [ ] `pnpm test -- src/__tests__/components/RequestInviteDialog.test.tsx src/__tests__/context/AuthModalContext.test.tsx src/__tests__/components/Profile/ProfileHeaderMessage.test.tsx src/__tests__/utils/auth.test.ts` passes


Made with [Cursor](https://cursor.com)