### PR TITLE
feat(e2e): add Playwright post submission test (E2E-POST-001)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,59 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+  e2e:
+    name: Frontend E2E
+    runs-on: ubuntu-latest
+    if: ${{ secrets.E2E_AUTHOR_PASSWORD }}
+    defaults:
+      run:
+        working-directory: ./quotevote-frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: quotevote-frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-workspace
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build frontend
+        env:
+          NEXT_PUBLIC_SERVER_URL: ${{ secrets.E2E_API_URL || 'https://api.quote.vote' }}
+          NEXT_PUBLIC_GRAPHQL_ENDPOINT: ${{ secrets.E2E_GRAPHQL_ENDPOINT || 'https://api.quote.vote/graphql' }}
+        run: pnpm build
+
+      - name: Run Playwright tests
+        env:
+          CI: true
+          E2E_AUTHOR_USERNAME: ${{ secrets.E2E_AUTHOR_USERNAME || 'authorUser' }}
+          E2E_AUTHOR_PASSWORD: ${{ secrets.E2E_AUTHOR_PASSWORD }}
+          E2E_PUBLIC_GROUP_NAME: ${{ secrets.E2E_PUBLIC_GROUP_NAME || 'QA' }}
+          PLAYWRIGHT_BASE_URL: http://localhost:3000
+        run: |
+          pnpm start &
+          pnpm exec wait-on http://localhost:3000 --timeout 120000
+          pnpm test:e2e
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: quotevote-frontend/playwright-report/
+          retention-days: 7
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,21 +91,36 @@ jobs:
   e2e:
     name: Frontend E2E
     runs-on: ubuntu-latest
-    if: ${{ secrets.E2E_AUTHOR_PASSWORD }}
     defaults:
       run:
         working-directory: ./quotevote-frontend
 
     steps:
+      # secrets.* is empty in job-level if: expressions — check via step env instead
+      - name: Check E2E credentials
+        id: e2e_gate
+        env:
+          E2E_AUTHOR_PASSWORD: ${{ secrets.E2E_AUTHOR_PASSWORD }}
+        run: |
+          if [ -n "$E2E_AUTHOR_PASSWORD" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::E2E skipped — configure E2E_AUTHOR_PASSWORD repository secret to enable"
+          fi
+
       - name: Checkout code
+        if: steps.e2e_gate.outputs.enabled == 'true'
         uses: actions/checkout@v4
 
       - name: Setup pnpm
+        if: steps.e2e_gate.outputs.enabled == 'true'
         uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node.js
+        if: steps.e2e_gate.outputs.enabled == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -113,18 +128,22 @@ jobs:
           cache-dependency-path: quotevote-frontend/pnpm-lock.yaml
 
       - name: Install dependencies
+        if: steps.e2e_gate.outputs.enabled == 'true'
         run: pnpm install --frozen-lockfile --ignore-workspace
 
       - name: Install Playwright browsers
+        if: steps.e2e_gate.outputs.enabled == 'true'
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Build frontend
+        if: steps.e2e_gate.outputs.enabled == 'true'
         env:
           NEXT_PUBLIC_SERVER_URL: ${{ secrets.E2E_API_URL || 'https://api.quote.vote' }}
           NEXT_PUBLIC_GRAPHQL_ENDPOINT: ${{ secrets.E2E_GRAPHQL_ENDPOINT || 'https://api.quote.vote/graphql' }}
         run: pnpm build
 
       - name: Run Playwright tests
+        if: steps.e2e_gate.outputs.enabled == 'true'
         env:
           CI: true
           E2E_AUTHOR_USERNAME: ${{ secrets.E2E_AUTHOR_USERNAME || 'authorUser' }}
@@ -137,8 +156,8 @@ jobs:
           pnpm test:e2e
 
       - name: Upload Playwright report
+        if: failure() && steps.e2e_gate.outputs.enabled == 'true'
         uses: actions/upload-artifact@v4
-        if: failure()
         with:
           name: playwright-report
           path: quotevote-frontend/playwright-report/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,12 +91,9 @@ jobs:
   e2e:
     name: Frontend E2E
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./quotevote-frontend
 
     steps:
-      # secrets.* is empty in job-level if: expressions — check via step env instead
+      # Run at repo root — quotevote-frontend/ does not exist until after checkout
       - name: Check E2E credentials
         id: e2e_gate
         env:
@@ -129,14 +126,17 @@ jobs:
 
       - name: Install dependencies
         if: steps.e2e_gate.outputs.enabled == 'true'
+        working-directory: ./quotevote-frontend
         run: pnpm install --frozen-lockfile --ignore-workspace
 
       - name: Install Playwright browsers
         if: steps.e2e_gate.outputs.enabled == 'true'
+        working-directory: ./quotevote-frontend
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Build frontend
         if: steps.e2e_gate.outputs.enabled == 'true'
+        working-directory: ./quotevote-frontend
         env:
           NEXT_PUBLIC_SERVER_URL: ${{ secrets.E2E_API_URL || 'https://api.quote.vote' }}
           NEXT_PUBLIC_GRAPHQL_ENDPOINT: ${{ secrets.E2E_GRAPHQL_ENDPOINT || 'https://api.quote.vote/graphql' }}
@@ -144,12 +144,14 @@ jobs:
 
       - name: Run Playwright tests
         if: steps.e2e_gate.outputs.enabled == 'true'
+        working-directory: ./quotevote-frontend
         env:
           CI: true
           E2E_AUTHOR_USERNAME: ${{ secrets.E2E_AUTHOR_USERNAME || 'authorUser' }}
           E2E_AUTHOR_PASSWORD: ${{ secrets.E2E_AUTHOR_PASSWORD }}
           E2E_PUBLIC_GROUP_NAME: ${{ secrets.E2E_PUBLIC_GROUP_NAME || 'QA' }}
           PLAYWRIGHT_BASE_URL: http://localhost:3000
+          PLAYWRIGHT_SKIP_WEBSERVER: true
         run: |
           pnpm start &
           pnpm exec wait-on http://localhost:3000 --timeout 120000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,16 @@ pnpm build            # Production build
 pnpm lint             # ESLint
 pnpm type-check       # TypeScript validation
 pnpm format:check     # Prettier check
-pnpm test             # Jest tests
+pnpm test             # Jest unit tests
 pnpm test:watch       # Watch mode
 pnpm test:coverage    # Coverage report
-pnpm test -- src/__tests__/foundation/layout.test.tsx  # Single test file
+pnpm test -- src/__tests__/foundation/layout.test.tsx  # Single unit test file
+pnpm test:e2e         # Playwright E2E (all specs, desktop + mobile)
+pnpm test:e2e post-submission.spec.ts  # Single E2E spec
+pnpm test:e2e --grep "E2E-POST-001"    # E2E by test sheet ID
+pnpm test:e2e --project=desktop post-submission.spec.ts  # One viewport
+pnpm test:e2e:headed  # E2E in visible browser
+pnpm test:e2e:ui      # Playwright UI debugger
 ```
 
 ### Backend (`quotevote-backend/`)
@@ -44,7 +50,7 @@ pnpm prisma:validate  # Validate Prisma schema
 
 ### CI checks (both packages)
 
-CI runs `lint`, `type-check`, and `test` for both frontend and backend on PRs to `main`/`develop`.
+CI runs `lint`, `type-check`, and `test` (Jest) for both frontend and backend on PRs to `main`/`develop`. Frontend E2E (Playwright) runs when the `E2E_AUTHOR_PASSWORD` repository secret is set.
 
 ## Architecture
 
@@ -56,7 +62,7 @@ CI runs `lint`, `type-check`, and `test` for both frontend and backend on PRs to
 - **State**: Zustand (`src/store/`) — no Redux, no provider wrappers needed
 - **Data fetching**: Apollo Client 4 for GraphQL (`src/lib/apollo/`, `src/graphql/`)
 - **Forms**: React Hook Form + Zod validation
-- **Testing**: Jest 30 + React Testing Library in jsdom environment
+- **Testing**: Jest 30 + React Testing Library (unit, `src/__tests__/`); Playwright (E2E, `e2e/`)
 
 ### Backend
 
@@ -70,18 +76,20 @@ CI runs `lint`, `type-check`, and `test` for both frontend and backend on PRs to
 ### Key directories
 
 ```
-quotevote-frontend/src/
-  app/              # Pages and layouts (App Router)
-  app/components/   # Page-specific components
-  components/       # Shared components
-  components/ui/    # shadcn/ui components
-  hooks/            # Custom React hooks
-  lib/apollo/       # Apollo Client setup
-  lib/utils/        # Utility functions
-  store/            # Zustand stores
-  types/            # All TypeScript type definitions (mandatory location)
-  graphql/          # Queries, mutations, subscriptions
-  __tests__/        # All test files (mandatory location)
+quotevote-frontend/
+  e2e/              # Playwright E2E specs and helpers
+  src/
+    app/              # Pages and layouts (App Router)
+    app/components/   # Page-specific components
+    components/       # Shared components
+    components/ui/    # shadcn/ui components
+    hooks/            # Custom React hooks
+    lib/apollo/       # Apollo Client setup
+    lib/utils/        # Utility functions
+    store/            # Zustand stores
+    types/            # All TypeScript type definitions (mandatory location)
+    graphql/          # Queries, mutations, subscriptions
+    __tests__/        # Jest unit tests (mandatory location)
 
 quotevote-backend/app/
   server.ts         # Express + Apollo entry point
@@ -115,9 +123,10 @@ quotevote-backend/app/
 
 ### Testing
 
-- Frontend tests go in `src/__tests__/` (subdirs: `foundation/`, `components/`, `utils/`)
+- Frontend unit tests go in `src/__tests__/` (subdirs: `foundation/`, `components/`, `utils/`)
+- Frontend E2E tests go in `e2e/` (`.spec.ts`; helpers in `e2e/helpers/`; env via `.env.e2e.local` from `.env.e2e.example`)
 - Backend tests go in `app/__tests__/` (subdirs: `unit/`, `integration/`, `utils/`)
-- Use `.test.tsx` or `.test.ts` extensions
+- Unit tests use `.test.tsx` or `.test.ts`; E2E specs use `.spec.ts`
 
 ### Formatting
 

--- a/quotevote-frontend/.env.e2e.example
+++ b/quotevote-frontend/.env.e2e.example
@@ -1,0 +1,36 @@
+# Playwright E2E
+# Copy to .env.e2e.local and fill in credentials before running tests.
+#
+# --- Run commands (from quotevote-frontend/) ---
+# All E2E:              pnpm test:e2e
+# One spec file:        pnpm test:e2e post-submission.spec.ts
+# By test sheet ID:     pnpm test:e2e --grep "E2E-POST-001"
+# Exclude a case:       pnpm test:e2e --grep-invert "E2E-POST-001"
+# Desktop only:         pnpm test:e2e --project=desktop post-submission.spec.ts
+# Mobile only:          pnpm test:e2e --project=mobile post-submission.spec.ts
+# Headed (see browser): pnpm test:e2e:headed post-submission.spec.ts
+# Debug UI:             pnpm test:e2e:ui
+# Dev server already up: PLAYWRIGHT_SKIP_WEBSERVER=1 pnpm test:e2e post-submission.spec.ts
+#
+# Sheet columns covered:
+#   Test ID:        E2E-POST-001
+#   Data Needed:    authorUser
+#   Spec File:      post-submission.spec.ts
+#   Viewports:      Desktop, Mobile (playwright.config.ts projects)
+
+# Registered author account (Actor: Registered User, Auth: Logged in)
+E2E_AUTHOR_USERNAME=authorUser
+E2E_AUTHOR_PASSWORD=
+
+# Group title to select in composer (must exist on API; use a public-privacy group e.g. QA)
+E2E_PUBLIC_GROUP_NAME=QA
+
+# Frontend URL under test (Playwright baseURL)
+PLAYWRIGHT_BASE_URL=http://localhost:3000
+
+# Optional API overrides (defaults to NEXT_PUBLIC_* from .env.local)
+# E2E_API_URL=https://api.quote.vote
+# E2E_GRAPHQL_ENDPOINT=https://api.quote.vote/graphql
+
+# Set true to auto-register authorUser on local backends during global setup
+# E2E_REGISTER_AUTHOR=true

--- a/quotevote-frontend/.env.e2e.example
+++ b/quotevote-frontend/.env.e2e.example
@@ -16,7 +16,7 @@
 #   Test ID:        E2E-POST-001
 #   Data Needed:    authorUser
 #   Spec File:      post-submission.spec.ts
-#   Viewports:      Desktop, Mobile (playwright.config.ts projects)
+#   Viewports:      Desktop, Mobile (playwright.config.ts projects: desktop, mobile)
 
 # Registered author account (Actor: Registered User, Auth: Logged in)
 E2E_AUTHOR_USERNAME=authorUser

--- a/quotevote-frontend/.gitignore
+++ b/quotevote-frontend/.gitignore
@@ -12,6 +12,12 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+.env.e2e.local
+/e2e/.auth/
 
 # next.js
 /.next/

--- a/quotevote-frontend/README.md
+++ b/quotevote-frontend/README.md
@@ -12,7 +12,7 @@ A modern, type-safe frontend application built with Next.js 16, React 19, and Ty
 - **Icons**: [lucide-react](https://lucide.dev/)
 - **State Management**: [Zustand](https://zustand-demo.pmnd.rs/) 5.0.8
 - **GraphQL Client**: [Apollo Client](https://www.apollographql.com/) 4.0.9
-- **Testing**: [Jest](https://jestjs.io/) 30.2.0 + [React Testing Library](https://testing-library.com/react) 16.3.0
+- **Testing**: [Jest](https://jestjs.io/) 30.2.0 + [React Testing Library](https://testing-library.com/react) 16.3.0; [Playwright](https://playwright.dev/) for E2E
 - **Form Handling**: [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/)
 - **Package Manager**: [pnpm](https://pnpm.io/)
 
@@ -97,7 +97,7 @@ import { Button } from '../../../components/ui/button'
 
 ## 🧪 Testing
 
-### Running Tests
+### Unit tests (Jest)
 
 ```bash
 # Run all tests
@@ -116,15 +116,63 @@ pnpm test:ci
 pnpm test src/__tests__/foundation/layout.test.tsx
 ```
 
+### E2E tests (Playwright)
+
+End-to-end specs live in `e2e/` and run against a real browser. Playwright starts the dev server automatically (or reuse one already on `:3000`).
+
+**One-time setup:**
+
+```bash
+pnpm exec playwright install chromium
+cp .env.e2e.example .env.e2e.local
+# Edit .env.e2e.local — set E2E_AUTHOR_PASSWORD and E2E_PUBLIC_GROUP_NAME
+```
+
+**Run commands:**
+
+```bash
+# All E2E (desktop + mobile viewports)
+pnpm test:e2e
+
+# One spec file
+pnpm test:e2e post-submission.spec.ts
+
+# By test sheet ID
+pnpm test:e2e --grep "E2E-POST-001"
+
+# One viewport only
+pnpm test:e2e --project=desktop post-submission.spec.ts
+pnpm test:e2e --project=mobile post-submission.spec.ts
+
+# Debug
+pnpm test:e2e:headed post-submission.spec.ts
+pnpm test:e2e:ui
+
+# Dev server already running
+PLAYWRIGHT_SKIP_WEBSERVER=1 pnpm test:e2e post-submission.spec.ts
+```
+
+See [`.env.e2e.example`](.env.e2e.example) for env vars and the full command reference.
+
 ### Test Requirements
 
-- **Test Location**: All test files **MUST** be in `src/__tests__/` directory
-- **Test Naming**: Use `.test.tsx` or `.test.ts` extensions
-- **Test Organization**:
-  - Foundation tests: `src/__tests__/foundation/`
-  - Component tests: `src/__tests__/components/`
-  - Utility tests: `src/__tests__/utils/`
-- **Testing is MANDATORY**: After each phase or component group migration, all tests must pass before proceeding
+**Unit tests (Jest)**
+
+- **Location**: `src/__tests__/`
+- **Naming**: `.test.tsx` or `.test.ts`
+- **Organization**:
+  - Foundation: `src/__tests__/foundation/`
+  - Components: `src/__tests__/components/`
+  - Utilities: `src/__tests__/utils/`
+
+**E2E tests (Playwright)**
+
+- **Location**: `e2e/` (specs use `.spec.ts`)
+- **Helpers**: `e2e/helpers/`
+- **Config**: `playwright.config.ts` (desktop + mobile projects)
+- **Auth state**: generated at runtime in `e2e/.auth/` (gitignored)
+
+- **Testing is MANDATORY**: After each phase or component group migration, unit tests must pass before proceeding
 
 ### Test Structure
 
@@ -247,10 +295,13 @@ export function MyComponent({ prop1, prop2 }: MyComponentProps) {
 | `pnpm type-check` | Check TypeScript types |
 | `pnpm format` | Format code with Prettier |
 | `pnpm format:check` | Check code formatting |
-| `pnpm test` | Run tests |
-| `pnpm test:watch` | Run tests in watch mode |
-| `pnpm test:coverage` | Run tests with coverage |
-| `pnpm test:ci` | Run tests in CI mode |
+| `pnpm test` | Run unit tests (Jest) |
+| `pnpm test:watch` | Run unit tests in watch mode |
+| `pnpm test:coverage` | Run unit tests with coverage |
+| `pnpm test:ci` | Run unit tests in CI mode |
+| `pnpm test:e2e` | Run E2E tests (Playwright) |
+| `pnpm test:e2e:headed` | Run E2E tests in a visible browser |
+| `pnpm test:e2e:ui` | Open Playwright UI for debugging E2E |
 
 ## 📚 Key Conventions
 
@@ -269,7 +320,8 @@ export function MyComponent({ prop1, prop2 }: MyComponentProps) {
 - **shadcn/ui components**: `src/components/ui/`
 - **Custom hooks**: `src/hooks/`
 - **Type definitions**: `src/types/` (MANDATORY)
-- **Test files**: `src/__tests__/` (MANDATORY)
+- **Unit test files**: `src/__tests__/`
+- **E2E test files**: `e2e/`
 
 ### State Management
 
@@ -287,7 +339,7 @@ export function MyComponent({ prop1, prop2 }: MyComponentProps) {
 
 - ❌ Using `any` type
 - ❌ Defining types inline in component files (must use `src/types/`)
-- ❌ Placing test files outside `src/__tests__/`
+- ❌ Placing Jest unit tests outside `src/__tests__/`
 - ❌ Using relative imports when path aliases are available
 - ❌ Using `npm` or `yarn` instead of `pnpm`
 - ❌ Using `'use client'` unnecessarily (prefer Server Components)
@@ -328,13 +380,13 @@ When migrating components or features:
 
 Before submitting a PR, ensure:
 
-- [ ] All tests pass (`pnpm test`)
+- [ ] All unit tests pass (`pnpm test`)
 - [ ] TypeScript compiles without errors (`pnpm type-check`)
 - [ ] Linting passes (`pnpm lint`)
 - [ ] Code is formatted (`pnpm format:check`)
 - [ ] No `any` types are used
 - [ ] All types are defined in `src/types/` directory
-- [ ] All test files are in `src/__tests__/` directory
+- [ ] Unit test files are in `src/__tests__/`
 - [ ] Path aliases are used for all imports
 - [ ] Dependencies installed with `pnpm`
 

--- a/quotevote-frontend/e2e/global-setup.ts
+++ b/quotevote-frontend/e2e/global-setup.ts
@@ -1,0 +1,40 @@
+import {
+  AUTHOR_PASSWORD,
+  AUTHOR_USERNAME,
+} from './helpers/auth';
+import { getApiUrl, loginViaApi, registerAuthorUser } from './helpers/api';
+import { saveAuthorStorageState } from './helpers/storage-state';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+
+export default async function globalSetup(): Promise<void> {
+  if (!AUTHOR_PASSWORD) {
+    console.warn(
+      '[e2e] E2E_AUTHOR_PASSWORD is not set. Post submission tests will fail until credentials are configured.'
+    );
+    return;
+  }
+
+  const shouldRegister = process.env.E2E_REGISTER_AUTHOR === 'true';
+
+  if (shouldRegister) {
+    await registerAuthorUser({
+      username: AUTHOR_USERNAME,
+      password: AUTHOR_PASSWORD,
+      name: 'E2E Author',
+      email: `${AUTHOR_USERNAME}@e2e.quotevote.test`,
+    });
+  }
+
+  try {
+    const session = await loginViaApi(AUTHOR_USERNAME, AUTHOR_PASSWORD);
+    await saveAuthorStorageState(baseURL, session);
+    console.log(`[e2e] authorUser session saved; API: ${getApiUrl()}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `[e2e] Unable to authenticate "${AUTHOR_USERNAME}" against ${getApiUrl()}: ${message}. ` +
+        'Set E2E_REGISTER_AUTHOR=true for local backends or provide valid credentials.'
+    );
+  }
+}

--- a/quotevote-frontend/e2e/helpers/api.ts
+++ b/quotevote-frontend/e2e/helpers/api.ts
@@ -1,0 +1,120 @@
+import { getLoginToken, postLogin } from '../../src/lib/auth/restLogin';
+
+const DEFAULT_API_URL = 'http://localhost:4000';
+
+export function getApiUrl(): string {
+  const graphqlEndpoint =
+    process.env.E2E_GRAPHQL_ENDPOINT ??
+    process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT ??
+    'https://api.quote.vote/graphql';
+
+  if (process.env.E2E_API_URL) {
+    return process.env.E2E_API_URL.replace(/\/$/, '');
+  }
+
+  if (graphqlEndpoint.includes('/graphql')) {
+    return graphqlEndpoint.replace(/\/graphql\/?$/, '');
+  }
+
+  return DEFAULT_API_URL;
+}
+
+export interface AuthSession {
+  token: string;
+  user: {
+    _id: string;
+    username: string;
+    name?: string;
+    email?: string;
+    admin?: boolean;
+  };
+}
+
+export async function loginViaApi(
+  username: string,
+  password: string
+): Promise<AuthSession> {
+  const trimmedUsername = username.trim();
+  const { response, data } = await postLogin(getApiUrl(), trimmedUsername, password);
+
+  if (!response.ok) {
+    throw new Error(data.message ?? `Login failed with status ${response.status}`);
+  }
+
+  const token = getLoginToken(data);
+  if (!token || !data.user?._id) {
+    throw new Error('Login response missing token or user');
+  }
+
+  return { token, user: data.user as AuthSession['user'] };
+}
+
+export async function registerAuthorUser(input: {
+  username: string;
+  password: string;
+  name: string;
+  email: string;
+}): Promise<void> {
+  const baseUrl = getApiUrl();
+  const paths = ['/auth/register', '/register'];
+
+  for (const path of paths) {
+    const response = await fetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+
+    if (response.status === 409) {
+      return;
+    }
+
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      continue;
+    }
+
+    if (response.ok) {
+      return;
+    }
+
+    const data = (await response.json()) as { error_message?: string; message?: string };
+    throw new Error(
+      data.error_message ?? data.message ?? `Registration failed with status ${response.status}`
+    );
+  }
+
+  throw new Error('Registration failed: no register endpoint responded with JSON');
+}
+
+export async function deletePostViaApi(postId: string, token: string): Promise<void> {
+  const response = await fetch(`${getApiUrl()}/graphql`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      query: `
+        mutation deletePost($postId: String!) {
+          deletePost(postId: $postId) {
+            _id
+          }
+        }
+      `,
+      variables: { postId },
+    }),
+  });
+
+  if (!response.ok) {
+    return;
+  }
+
+  const payload = (await response.json()) as {
+    errors?: Array<{ message: string }>;
+  };
+
+  if (payload.errors?.length) {
+    console.warn(`deletePost cleanup warning: ${payload.errors[0]?.message}`);
+  }
+}

--- a/quotevote-frontend/e2e/helpers/auth.ts
+++ b/quotevote-frontend/e2e/helpers/auth.ts
@@ -1,0 +1,23 @@
+import type { Page } from '@playwright/test';
+
+export const AUTHOR_USERNAME = (process.env.E2E_AUTHOR_USERNAME ?? 'authorUser').trim();
+export const AUTHOR_PASSWORD = process.env.E2E_AUTHOR_PASSWORD ?? '';
+
+export async function loginAsAuthorUser(page: Page): Promise<void> {
+  if (!AUTHOR_PASSWORD) {
+    throw new Error(
+      'E2E_AUTHOR_PASSWORD is required. Copy .env.e2e.example to .env.e2e.local and set credentials.'
+    );
+  }
+
+  await page.goto('/auths/login');
+  await page.locator('#email').fill(AUTHOR_USERNAME);
+  await page.locator('#password').fill(AUTHOR_PASSWORD);
+  await page.locator('#tos').click();
+  await page.locator('#coc').click();
+
+  const loginButton = page.getByRole('button', { name: /^login$/i });
+  await loginButton.click();
+
+  await page.waitForURL('**/dashboard/explore', { timeout: 30_000 });
+}

--- a/quotevote-frontend/e2e/helpers/storage-state.ts
+++ b/quotevote-frontend/e2e/helpers/storage-state.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+import { chromium, type FullConfig } from '@playwright/test';
+import type { AuthSession } from './api';
+
+export const AUTHOR_STORAGE_PATH = path.join(__dirname, '../.auth/authorUser.json');
+
+export async function saveAuthorStorageState(
+  baseURL: string,
+  session: AuthSession
+): Promise<void> {
+  fs.mkdirSync(path.dirname(AUTHOR_STORAGE_PATH), { recursive: true });
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ baseURL });
+  const page = await context.newPage();
+
+  await page.goto('/');
+
+  await page.evaluate(
+    ({ token, user }) => {
+      localStorage.setItem('token', token);
+      document.cookie = `qv-token=${token}; path=/; SameSite=Lax`;
+      localStorage.setItem(
+        'qv-store',
+        JSON.stringify({
+          state: {
+            user: {
+              data: user,
+              loading: false,
+              loginError: null,
+            },
+          },
+          version: 0,
+        })
+      );
+    },
+    { token: session.token, user: session.user }
+  );
+
+  await context.storageState({ path: AUTHOR_STORAGE_PATH });
+  await browser.close();
+}
+
+export function authorStorageStatePath(config?: FullConfig): string | undefined {
+  const baseURL = config?.projects[0]?.use?.baseURL ?? process.env.PLAYWRIGHT_BASE_URL;
+  if (!fs.existsSync(AUTHOR_STORAGE_PATH) || !baseURL) {
+    return undefined;
+  }
+  return AUTHOR_STORAGE_PATH;
+}

--- a/quotevote-frontend/e2e/helpers/storage-state.ts
+++ b/quotevote-frontend/e2e/helpers/storage-state.ts
@@ -1,45 +1,77 @@
 import fs from 'fs';
 import path from 'path';
-import { chromium, type FullConfig } from '@playwright/test';
+import type { FullConfig } from '@playwright/test';
 import type { AuthSession } from './api';
 
 export const AUTHOR_STORAGE_PATH = path.join(__dirname, '../.auth/authorUser.json');
+
+interface PlaywrightStorageState {
+  cookies: Array<{
+    name: string;
+    value: string;
+    domain: string;
+    path: string;
+    expires: number;
+    httpOnly: boolean;
+    secure: boolean;
+    sameSite: 'Strict' | 'Lax' | 'None';
+  }>;
+  origins: Array<{
+    origin: string;
+    localStorage: Array<{ name: string; value: string }>;
+  }>;
+}
+
+function buildStorageState(baseURL: string, session: AuthSession): PlaywrightStorageState {
+  const url = new URL(baseURL);
+
+  return {
+    cookies: [
+      {
+        name: 'qv-token',
+        value: session.token,
+        domain: url.hostname,
+        path: '/',
+        expires: -1,
+        httpOnly: false,
+        secure: url.protocol === 'https:',
+        sameSite: 'Lax',
+      },
+    ],
+    origins: [
+      {
+        origin: url.origin,
+        localStorage: [
+          { name: 'token', value: session.token },
+          {
+            name: 'qv-store',
+            value: JSON.stringify({
+              state: {
+                user: {
+                  data: session.user,
+                  loading: false,
+                  loginError: null,
+                },
+              },
+              version: 0,
+            }),
+          },
+        ],
+      },
+    ],
+  };
+}
 
 export async function saveAuthorStorageState(
   baseURL: string,
   session: AuthSession
 ): Promise<void> {
   fs.mkdirSync(path.dirname(AUTHOR_STORAGE_PATH), { recursive: true });
-
-  const browser = await chromium.launch();
-  const context = await browser.newContext({ baseURL });
-  const page = await context.newPage();
-
-  await page.goto('/');
-
-  await page.evaluate(
-    ({ token, user }) => {
-      localStorage.setItem('token', token);
-      document.cookie = `qv-token=${token}; path=/; SameSite=Lax`;
-      localStorage.setItem(
-        'qv-store',
-        JSON.stringify({
-          state: {
-            user: {
-              data: user,
-              loading: false,
-              loginError: null,
-            },
-          },
-          version: 0,
-        })
-      );
-    },
-    { token: session.token, user: session.user }
+  fs.writeFileSync(
+    AUTHOR_STORAGE_PATH,
+    JSON.stringify(buildStorageState(baseURL, session), null, 2),
+    'utf8'
   );
-
-  await context.storageState({ path: AUTHOR_STORAGE_PATH });
-  await browser.close();
 }
 
 export function authorStorageStatePath(config?: FullConfig): string | undefined {

--- a/quotevote-frontend/e2e/post-submission.spec.ts
+++ b/quotevote-frontend/e2e/post-submission.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * E2E-POST-001 — Create Public Post
+ *
+ * Sheet mapping:
+ * - Feature: Create Public Post
+ * - Actor: Registered User (authorUser)
+ * - Auth State: Logged in (precondition via global-setup storageState)
+ * - Steps: Open composer → enter title/text → select Public → submit
+ * - Expected: Post created, unique URL, appears in relevant lists
+ * - Playwright notes: Assert post title/text on detail page
+ * - Viewports: Desktop, Mobile (playwright.config.ts projects)
+ */
+import { test, expect } from '@playwright/test';
+import { deletePostViaApi, loginViaApi } from './helpers/api';
+import { AUTHOR_PASSWORD, AUTHOR_USERNAME } from './helpers/auth';
+
+const PUBLIC_GROUP_NAME = process.env.E2E_PUBLIC_GROUP_NAME ?? 'Public';
+
+test.describe('E2E-POST-001: Create Public Post', () => {
+  test.skip(!AUTHOR_PASSWORD, 'E2E_AUTHOR_PASSWORD is required');
+
+  let createdPostId: string | null = null;
+  let authToken: string | null = null;
+
+  test.beforeAll(async () => {
+    const session = await loginViaApi(AUTHOR_USERNAME, AUTHOR_PASSWORD);
+    authToken = session.token;
+  });
+
+  test.afterEach(async () => {
+    if (createdPostId && authToken) {
+      await deletePostViaApi(createdPostId, authToken);
+      createdPostId = null;
+    }
+  });
+
+  test('creates a public text post and verifies detail page', async ({ page }) => {
+    const uniqueSuffix = `${Date.now()}-${test.info().project.name}`;
+    const postTitle = `E2E-POST-001 ${uniqueSuffix}`;
+    const postBody = `Automated post body for ${uniqueSuffix}. Sharing thoughts for feedback.`;
+
+    // Precondition: user is already authenticated (storageState from global setup)
+    await page.goto('/dashboard/explore');
+    await expect(page).toHaveURL(/\/dashboard\/explore/);
+
+    // Step: open composer
+    const createButton = page.getByTestId('create-post-button').locator('visible=true');
+    await createButton.click();
+
+    const composer = page.getByTestId('post-composer');
+    await expect(composer).toBeVisible();
+
+    // Step: enter title and text
+    const titleInput = page.getByTestId('post-title-input');
+    const bodyInput = page.getByTestId('post-body-input');
+    await titleInput.fill(postTitle);
+    await bodyInput.fill(postBody);
+
+    await expect(titleInput).toHaveValue(postTitle);
+    await expect(bodyInput).toHaveValue(postBody);
+
+    // Step: select Public group
+    const groupSelect = page.getByTestId('post-group-select');
+    await groupSelect.click();
+
+    const groupSearch = page.getByPlaceholder('Search or type new group name...');
+    await groupSearch.fill(PUBLIC_GROUP_NAME);
+
+    const publicGroupOption = page.getByRole('button', { name: PUBLIC_GROUP_NAME, exact: true });
+    await expect(publicGroupOption).toBeVisible();
+    await publicGroupOption.click();
+
+    // Step: submit
+    const submitButton = page.getByTestId('post-submit-button');
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    await expect(page.getByTestId('post-composer')).toBeHidden({ timeout: 30_000 });
+    await expect(page.locator('[data-sonner-toast][data-type="error"]')).toHaveCount(0);
+    await expect(page).toHaveURL(/\/dashboard\/explore/, { timeout: 30_000 });
+
+    // Expected: post appears in a relevant list (explore/home feed)
+    const postCard = page.getByTestId('post-card').filter({ hasText: postTitle }).first();
+    await expect(postCard).toBeVisible({ timeout: 30_000 });
+
+    await postCard.click();
+
+    // Expected: unique post URL generated
+    await expect(page).toHaveURL(/\/dashboard\/post\/.+\/.+\/.+/, { timeout: 30_000 });
+
+    const postUrl = page.url();
+    const postIdMatch = postUrl.match(/\/dashboard\/post\/[^/]+\/[^/]+\/([^/?#]+)/);
+    expect(postIdMatch?.[1]).toBeTruthy();
+    createdPostId = postIdMatch![1];
+
+    // Playwright notes: assert title/text on detail page
+    await expect(page.getByTestId('post-detail-title')).toHaveText(postTitle);
+    await expect(page.getByTestId('post-detail-body')).toContainText(postBody);
+
+    await page.goto('/dashboard/explore');
+    await expect(
+      page.getByTestId('post-card').filter({ hasText: postTitle }).first()
+    ).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/quotevote-frontend/jest.config.js
+++ b/quotevote-frontend/jest.config.js
@@ -20,7 +20,7 @@ const customJestConfig = {
     '**/?(*.)+(spec|test).[jt]s?(x)',
   ],
 
-  testPathIgnorePatterns: ['/node_modules/', '/.next/', '/src/types/'],
+  testPathIgnorePatterns: ['/node_modules/', '/.next/', '/src/types/', '/e2e/'],
 
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',

--- a/quotevote-frontend/package.json
+++ b/quotevote-frontend/package.json
@@ -15,7 +15,10 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --ci --coverage --maxWorkers=2"
+    "test:ci": "jest --ci --coverage --maxWorkers=2",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@apollo/client": "^4.0.9",
@@ -80,6 +83,9 @@
     "tailwindcss": "^4",
     "ts-jest": "^29.4.5",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@playwright/test": "^1.52.0",
+    "dotenv": "^16.5.0",
+    "wait-on": "^8.0.3"
   }
 }

--- a/quotevote-frontend/package.json
+++ b/quotevote-frontend/package.json
@@ -84,6 +84,8 @@
     "tailwindcss": "^4",
     "ts-jest": "^29.4.5",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "dotenv": "^16.5.0",
+    "wait-on": "^8.0.3"
   }
 }

--- a/quotevote-frontend/package.json
+++ b/quotevote-frontend/package.json
@@ -84,9 +84,6 @@
     "tailwindcss": "^4",
     "ts-jest": "^29.4.5",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5",
-    "@playwright/test": "^1.52.0",
-    "dotenv": "^16.5.0",
-    "wait-on": "^8.0.3"
+    "typescript": "^5"
   }
 }

--- a/quotevote-frontend/package.json
+++ b/quotevote-frontend/package.json
@@ -84,6 +84,7 @@
     "tailwindcss": "^4",
     "ts-jest": "^29.4.5",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "dotenv": "^16.5.0"
   }
 }

--- a/quotevote-frontend/package.json
+++ b/quotevote-frontend/package.json
@@ -84,7 +84,6 @@
     "tailwindcss": "^4",
     "ts-jest": "^29.4.5",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5",
-    "dotenv": "^16.5.0"
+    "typescript": "^5"
   }
 }

--- a/quotevote-frontend/playwright.config.ts
+++ b/quotevote-frontend/playwright.config.ts
@@ -1,40 +1,49 @@
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig, devices } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
 
-const PORT = process.env.PLAYWRIGHT_PORT || 3000;
-const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://localhost:${PORT}`;
+dotenv.config({ path: path.resolve(__dirname, '.env.e2e.local') });
+dotenv.config({ path: path.resolve(__dirname, '.env.local') });
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+const authorStorageState = path.join(__dirname, 'e2e/.auth/authorUser.json');
 
 export default defineConfig({
-  testDir: "./e2e",
-  fullyParallel: true,
+  testDir: './e2e',
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
-  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "html",
-  timeout: 30_000,
-
+  workers: 1,
+  timeout: 120_000,
+  expect: {
+    timeout: 15_000,
+  },
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
   use: {
     baseURL,
-    trace: "on-first-retry",
-    screenshot: "only-on-failure",
+    storageState: fs.existsSync(authorStorageState) ? authorStorageState : undefined,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
   },
-
   projects: [
     {
-      name: "Desktop Chrome",
-      use: { ...devices["Desktop Chrome"] },
+      name: 'desktop',
+      use: { ...devices['Desktop Chrome'] },
     },
     {
-      name: "Mobile Chrome",
-      use: { ...devices["Pixel 7"] },
+      name: 'mobile',
+      use: { ...devices['Pixel 5'] },
     },
   ],
-
-  // Spin up the Next.js dev server automatically unless one is already running
-  // (e.g. CI may start it separately, or PLAYWRIGHT_BASE_URL points elsewhere).
-  webServer: process.env.PLAYWRIGHT_BASE_URL
+  globalSetup: require.resolve('./e2e/global-setup.ts'),
+  webServer: process.env.PLAYWRIGHT_SKIP_WEBSERVER
     ? undefined
     : {
-        command: "pnpm dev",
+        command: 'pnpm dev',
         url: baseURL,
         reuseExistingServer: !process.env.CI,
         timeout: 120_000,

--- a/quotevote-frontend/playwright.config.ts
+++ b/quotevote-frontend/playwright.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig, devices } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: path.resolve(__dirname, '.env.e2e.local') });
+dotenv.config({ path: path.resolve(__dirname, '.env.local') });
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+const authorStorageState = path.join(__dirname, 'e2e/.auth/authorUser.json');
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  timeout: 120_000,
+  expect: {
+    timeout: 15_000,
+  },
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    storageState: fs.existsSync(authorStorageState) ? authorStorageState : undefined,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'desktop',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'mobile',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
+  globalSetup: require.resolve('./e2e/global-setup.ts'),
+  webServer: process.env.PLAYWRIGHT_SKIP_WEBSERVER
+    ? undefined
+    : {
+        command: 'pnpm dev',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+});

--- a/quotevote-frontend/pnpm-lock.yaml
+++ b/quotevote-frontend/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 2.30.1
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -126,6 +126,9 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.7)(immer@11.0.1)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.61.0
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
@@ -153,6 +156,9 @@ importers:
       '@types/react-highlight-words':
         specifier: ^0.20.1
         version: 0.20.1
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.6.1
       eslint:
         specifier: ^9
         version: 9.39.1(jiti@2.6.1)
@@ -170,7 +176,7 @@ importers:
         version: 30.2.0
       next-test-api-route-handler:
         specifier: ^5.0.3
-        version: 5.0.3(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 5.0.3(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       prettier:
         specifier: ^3.7.1
         version: 3.7.1
@@ -186,6 +192,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      wait-on:
+        specifier: ^8.0.3
+        version: 8.0.5
 
 packages:
 
@@ -500,6 +509,26 @@ packages:
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@hapi/address@5.1.1':
+    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/formula@3.0.2':
+    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
+
+  '@hapi/hoek@11.0.7':
+    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
+
+  '@hapi/pinpoint@2.0.1':
+    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
+
+  '@hapi/tlds@1.1.7':
+    resolution: {integrity: sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/topo@6.0.2':
+    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -879,6 +908,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1652,6 +1686,9 @@ packages:
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -1920,6 +1957,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -2440,6 +2478,10 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -2732,6 +2774,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2796,11 +2843,12 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -3251,6 +3299,10 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  joi@18.2.3:
+    resolution: {integrity: sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==}
+    engines: {node: '>= 20'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3684,6 +3736,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4266,6 +4328,11 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  wait-on@8.0.5:
+    resolution: {integrity: sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -4276,6 +4343,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -4736,6 +4804,22 @@ snapshots:
     dependencies:
       graphql: 16.12.0
 
+  '@hapi/address@5.1.1':
+    dependencies:
+      '@hapi/hoek': 11.0.7
+
+  '@hapi/formula@3.0.2': {}
+
+  '@hapi/hoek@11.0.7': {}
+
+  '@hapi/pinpoint@2.0.1': {}
+
+  '@hapi/tlds@1.1.7': {}
+
+  '@hapi/topo@6.0.2':
+    dependencies:
+      '@hapi/hoek': 11.0.7
+
   '@hookform/resolvers@5.2.2(react-hook-form@7.68.0(react@19.2.3))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -5132,6 +5216,10 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.2.9': {}
+
+  '@playwright/test@1.61.0':
+    dependencies:
+      playwright: 1.61.0
 
   '@radix-ui/number@1.1.1': {}
 
@@ -5945,6 +6033,8 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
@@ -6739,6 +6829,8 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dotenv@16.6.1: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -6880,7 +6972,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.1
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -6907,7 +6999,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6922,14 +7014,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -6944,7 +7036,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7178,6 +7270,9 @@ snapshots:
       mime-types: 2.1.35
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -7885,6 +7980,16 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  joi@18.2.3:
+    dependencies:
+      '@hapi/address': 5.1.1
+      '@hapi/formula': 3.0.2
+      '@hapi/hoek': 11.0.7
+      '@hapi/pinpoint': 2.0.1
+      '@hapi/tlds': 1.1.7
+      '@hapi/topo': 6.0.2
+      '@standard-schema/spec': 1.1.0
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -8107,14 +8212,14 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-test-api-route-handler@5.0.3(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  next-test-api-route-handler@5.0.3(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
       '@whatwg-node/server': 0.10.17
       cookie: 1.1.1
       core-js: 3.47.0
-      next: 16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
@@ -8133,6 +8238,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.1
       '@next/swc-win32-arm64-msvc': 16.1.1
       '@next/swc-win32-x64-msvc': 16.1.1
+      '@playwright/test': 1.61.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -8281,6 +8387,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 
@@ -8980,6 +9094,16 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  wait-on@8.0.5:
+    dependencies:
+      axios: 1.13.2
+      joi: 18.2.3
+      lodash: 4.17.21
+      minimist: 1.2.8
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - debug
 
   walker@1.0.8:
     dependencies:

--- a/quotevote-frontend/pnpm-lock.yaml
+++ b/quotevote-frontend/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@types/react-highlight-words':
         specifier: ^0.20.1
         version: 0.20.1
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.6.1
       eslint:
         specifier: ^9
         version: 9.39.1(jiti@2.6.1)
@@ -189,6 +192,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      wait-on:
+        specifier: ^8.0.3
+        version: 8.0.5
 
 packages:
 
@@ -504,6 +510,26 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
+  '@hapi/address@5.1.1':
+    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/formula@3.0.2':
+    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
+
+  '@hapi/hoek@11.0.7':
+    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
+
+  '@hapi/pinpoint@2.0.1':
+    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
+
+  '@hapi/tlds@1.1.7':
+    resolution: {integrity: sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/topo@6.0.2':
+    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
+
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
@@ -555,89 +581,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -808,24 +850,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.1':
     resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.1':
     resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.1':
     resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.1':
     resolution: {integrity: sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==}
@@ -1640,6 +1686,9 @@ packages:
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -1684,24 +1733,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
     resolution: {integrity: sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
     resolution: {integrity: sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
     resolution: {integrity: sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     resolution: {integrity: sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==}
@@ -1945,41 +1998,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2409,6 +2470,10 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3227,6 +3292,10 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  joi@18.2.3:
+    resolution: {integrity: sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==}
+    engines: {node: '>= 20'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3334,24 +3403,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -4248,6 +4321,11 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  wait-on@8.0.5:
+    resolution: {integrity: sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -4718,6 +4796,22 @@ snapshots:
   '@graphql-typed-document-node/core@3.2.0(graphql@16.12.0)':
     dependencies:
       graphql: 16.12.0
+
+  '@hapi/address@5.1.1':
+    dependencies:
+      '@hapi/hoek': 11.0.7
+
+  '@hapi/formula@3.0.2': {}
+
+  '@hapi/hoek@11.0.7': {}
+
+  '@hapi/pinpoint@2.0.1': {}
+
+  '@hapi/tlds@1.1.7': {}
+
+  '@hapi/topo@6.0.2':
+    dependencies:
+      '@hapi/hoek': 11.0.7
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.68.0(react@19.2.3))':
     dependencies:
@@ -5932,6 +6026,8 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
@@ -6722,6 +6818,8 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dotenv@16.6.1: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -6863,7 +6961,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.1
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -6890,7 +6988,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6905,14 +7003,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -6927,7 +7025,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7870,6 +7968,16 @@ snapshots:
       - ts-node
 
   jiti@2.6.1: {}
+
+  joi@18.2.3:
+    dependencies:
+      '@hapi/address': 5.1.1
+      '@hapi/formula': 3.0.2
+      '@hapi/hoek': 11.0.7
+      '@hapi/pinpoint': 2.0.1
+      '@hapi/tlds': 1.1.7
+      '@hapi/topo': 6.0.2
+      '@standard-schema/spec': 1.1.0
 
   js-tokens@4.0.0: {}
 
@@ -8975,6 +9083,16 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  wait-on@8.0.5:
+    dependencies:
+      axios: 1.13.2
+      joi: 18.2.3
+      lodash: 4.17.21
+      minimist: 1.2.8
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - debug
 
   walker@1.0.8:
     dependencies:

--- a/quotevote-frontend/pnpm-lock.yaml
+++ b/quotevote-frontend/pnpm-lock.yaml
@@ -156,9 +156,6 @@ importers:
       '@types/react-highlight-words':
         specifier: ^0.20.1
         version: 0.20.1
-      dotenv:
-        specifier: ^16.5.0
-        version: 16.6.1
       eslint:
         specifier: ^9
         version: 9.39.1(jiti@2.6.1)
@@ -192,9 +189,6 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
-      wait-on:
-        specifier: ^8.0.3
-        version: 8.0.5
 
 packages:
 
@@ -509,26 +503,6 @@ packages:
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@hapi/address@5.1.1':
-    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
-    engines: {node: '>=14.0.0'}
-
-  '@hapi/formula@3.0.2':
-    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
-
-  '@hapi/hoek@11.0.7':
-    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
-
-  '@hapi/pinpoint@2.0.1':
-    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
-
-  '@hapi/tlds@1.1.7':
-    resolution: {integrity: sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==}
-    engines: {node: '>=14.0.0'}
-
-  '@hapi/topo@6.0.2':
-    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -1686,9 +1660,6 @@ packages:
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
-  '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -2470,10 +2441,6 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
-
-  dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
-    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3291,10 +3258,6 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
-
-  joi@18.2.3:
-    resolution: {integrity: sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==}
-    engines: {node: '>= 20'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4321,11 +4284,6 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  wait-on@8.0.5:
-    resolution: {integrity: sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
-
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -4796,22 +4754,6 @@ snapshots:
   '@graphql-typed-document-node/core@3.2.0(graphql@16.12.0)':
     dependencies:
       graphql: 16.12.0
-
-  '@hapi/address@5.1.1':
-    dependencies:
-      '@hapi/hoek': 11.0.7
-
-  '@hapi/formula@3.0.2': {}
-
-  '@hapi/hoek@11.0.7': {}
-
-  '@hapi/pinpoint@2.0.1': {}
-
-  '@hapi/tlds@1.1.7': {}
-
-  '@hapi/topo@6.0.2':
-    dependencies:
-      '@hapi/hoek': 11.0.7
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.68.0(react@19.2.3))':
     dependencies:
@@ -6026,8 +5968,6 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@standard-schema/spec@1.1.0': {}
-
   '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
@@ -6818,8 +6758,6 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dotenv@16.6.1: {}
-
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -6961,7 +6899,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.1
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -6988,7 +6926,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7003,14 +6941,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -7025,7 +6963,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7968,16 +7906,6 @@ snapshots:
       - ts-node
 
   jiti@2.6.1: {}
-
-  joi@18.2.3:
-    dependencies:
-      '@hapi/address': 5.1.1
-      '@hapi/formula': 3.0.2
-      '@hapi/hoek': 11.0.7
-      '@hapi/pinpoint': 2.0.1
-      '@hapi/tlds': 1.1.7
-      '@hapi/topo': 6.0.2
-      '@standard-schema/spec': 1.1.0
 
   js-tokens@4.0.0: {}
 
@@ -9083,16 +9011,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-
-  wait-on@8.0.5:
-    dependencies:
-      axios: 1.13.2
-      joi: 18.2.3
-      lodash: 4.17.21
-      minimist: 1.2.8
-      rxjs: 7.8.2
-    transitivePeerDependencies:
-      - debug
 
   walker@1.0.8:
     dependencies:

--- a/quotevote-frontend/src/app/dashboard/layout.tsx
+++ b/quotevote-frontend/src/app/dashboard/layout.tsx
@@ -223,6 +223,7 @@ export default function DashboardLayout({
             {/* Create */}
             <button
               type="button"
+              data-testid="create-post-button"
               onClick={() => setSubmitDialogOpen(true)}
               className="flex items-center gap-1.5 h-9 px-4 rounded-full bg-[#52b274] text-white text-[13px] font-semibold shadow-[0_2px_6px_rgba(82,178,116,0.40)] hover:bg-[#4a9e63] hover:shadow-[0_3px_10px_rgba(82,178,116,0.50)] active:scale-95 transition-all duration-150 cursor-pointer border-0 flex-shrink-0"
               aria-label="Create new quote"
@@ -369,6 +370,7 @@ export default function DashboardLayout({
         {/* Create — floating green circle */}
         <button
           type="button"
+          data-testid="create-post-button"
           onClick={() => setSubmitDialogOpen(true)}
           className="flex flex-col items-center justify-center flex-1 h-full cursor-pointer border-0 bg-transparent"
           aria-label="Create"

--- a/quotevote-frontend/src/components/Post/Post.tsx
+++ b/quotevote-frontend/src/components/Post/Post.tsx
@@ -44,6 +44,7 @@ import {
   GET_TOP_POSTS,
   GET_USER_ACTIVITY,
   GET_USERS,
+  GET_GROUP,
 } from '@/graphql/queries'
 import useGuestGuard from '@/hooks/useGuestGuard'
 import { cn } from '@/lib/utils'
@@ -76,6 +77,13 @@ export default function Post({
   const isFollowing = includes(_followingId, userId)
   const admin = user.admin || false
   const isOwner = user._id === userId
+
+  const { data: groupData } = useQuery<{ group?: { _id: string; title: string } }>(GET_GROUP, {
+    variables: { groupId: post.groupId || '' },
+    skip: !post.groupId,
+    errorPolicy: 'all',
+    fetchPolicy: 'cache-first',
+  })
 
   // Admin-only: fetch user list for enhanced tooltips
   useQuery<{ users?: Array<{ _id: string; username: string }> }>(GET_USERS, {
@@ -357,9 +365,21 @@ export default function Post({
         </div>
 
         {/* Title */}
-        <h1 className="text-base sm:text-lg font-bold text-foreground leading-tight mb-1">
+        <h1
+          data-testid="post-detail-title"
+          className="text-base sm:text-lg font-bold text-foreground leading-tight mb-1"
+        >
           {title}
         </h1>
+
+        {post.groupId && groupData?.group && (
+          <span
+            data-testid="post-detail-group"
+            className="inline-flex text-[10px] font-semibold text-[#52b274] bg-[rgba(82,178,116,0.1)] border border-[rgba(82,178,116,0.2)] px-2 py-0.5 rounded-full uppercase tracking-wide mb-1"
+          >
+            #{groupData.group.title}
+          </span>
+        )}
 
         {/* Citation URL */}
         {post.citationUrl && (
@@ -513,7 +533,9 @@ export default function Post({
         )}
 
         {/* Selectable post text + floating VotingPopup */}
-        <div className={cn(
+        <div
+          data-testid="post-detail-body"
+          className={cn(
           'text-[15px] leading-[1.75] text-foreground/85',
           postHeight && postHeight >= 742 && 'max-h-[60vh] overflow-y-auto'
         )}>

--- a/quotevote-frontend/src/components/Post/Post.tsx
+++ b/quotevote-frontend/src/components/Post/Post.tsx
@@ -44,7 +44,6 @@ import {
   GET_TOP_POSTS,
   GET_USER_ACTIVITY,
   GET_USERS,
-  GET_GROUP,
 } from '@/graphql/queries'
 import useGuestGuard from '@/hooks/useGuestGuard'
 import { cn } from '@/lib/utils'
@@ -77,13 +76,6 @@ export default function Post({
   const isFollowing = includes(_followingId, userId)
   const admin = user.admin || false
   const isOwner = user._id === userId
-
-  const { data: groupData } = useQuery<{ group?: { _id: string; title: string } }>(GET_GROUP, {
-    variables: { groupId: post.groupId || '' },
-    skip: !post.groupId,
-    errorPolicy: 'all',
-    fetchPolicy: 'cache-first',
-  })
 
   // Admin-only: fetch user list for enhanced tooltips
   useQuery<{ users?: Array<{ _id: string; username: string }> }>(GET_USERS, {
@@ -371,15 +363,6 @@ export default function Post({
         >
           {title}
         </h1>
-
-        {post.groupId && groupData?.group && (
-          <span
-            data-testid="post-detail-group"
-            className="inline-flex text-[10px] font-semibold text-[#52b274] bg-[rgba(82,178,116,0.1)] border border-[rgba(82,178,116,0.2)] px-2 py-0.5 rounded-full uppercase tracking-wide mb-1"
-          >
-            #{groupData.group.title}
-          </span>
-        )}
 
         {/* Citation URL */}
         {post.citationUrl && (

--- a/quotevote-frontend/src/components/Post/PostCard.tsx
+++ b/quotevote-frontend/src/components/Post/PostCard.tsx
@@ -243,6 +243,8 @@ function PostCardComponent({
 
   return (
     <article
+      data-testid="post-card"
+      data-post-title={title || ''}
       className={cn(
         'group/card rounded-[7px] cursor-pointer overflow-hidden',
         !cardTheme.bg && 'bg-card',

--- a/quotevote-frontend/src/components/SubmitPost/SubmitPostForm.tsx
+++ b/quotevote-frontend/src/components/SubmitPost/SubmitPostForm.tsx
@@ -176,6 +176,7 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
       )}
       <form onSubmit={handleSubmit(onSubmit)}>
         <Card
+          data-testid="post-composer"
           className={cn(
             'flex flex-col w-full',
             isMobile ? 'h-dvh max-h-dvh' : 'max-h-[calc(100vh-200px)]'
@@ -211,6 +212,7 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
               {/* Title — no label, placeholder only (matches monorepo InputBase) */}
               <Input
                 id="title"
+                data-testid="post-title-input"
                 placeholder="Enter Title"
                 {...register('title')}
                 className={cn('text-lg border-0 shadow-none px-0 focus-visible:ring-0 rounded-none', errors.title && 'border-b border-destructive')}
@@ -225,6 +227,7 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
               <div className="flex-1 flex flex-col min-h-0 overflow-auto">
                 <Textarea
                   id="text"
+                  data-testid="post-body-input"
                   placeholder="Enter your post content (no links allowed)"
                   {...register('text')}
                   className={cn(
@@ -316,6 +319,8 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
                       errorMessage={errors.group?.message}
                       disabled={loadingGroup || loading}
                       allowCreate={true}
+                      triggerTestId="post-group-select"
+                      createOptionTestId="post-group-create"
                       className="bg-[rgba(160,243,204,0.6)]"
                     />
                   )}
@@ -326,6 +331,7 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
             <div className="flex justify-end w-full">
               <Button
                 id="submit-button"
+                data-testid="post-submit-button"
                 type="submit"
                 variant="default"
                 className="w-full bg-[#52b274] hover:bg-[#52b274]/90 text-white text-lg"

--- a/quotevote-frontend/src/components/ui/combobox.tsx
+++ b/quotevote-frontend/src/components/ui/combobox.tsx
@@ -26,6 +26,8 @@ export interface ComboboxProps {
   className?: string
   disabled?: boolean
   allowCreate?: boolean
+  triggerTestId?: string
+  createOptionTestId?: string
 }
 
 export function Combobox({
@@ -39,6 +41,8 @@ export function Combobox({
   className,
   disabled = false,
   allowCreate = true,
+  triggerTestId,
+  createOptionTestId,
 }: ComboboxProps) {
   const [open, setOpen] = React.useState(false)
   const [inputValue, setInputValue] = React.useState('')
@@ -123,6 +127,7 @@ export function Combobox({
             role="combobox"
             aria-expanded={open}
             disabled={disabled}
+            data-testid={triggerTestId}
             className={cn(
               'w-full justify-between text-sm font-normal',
               !displayValue && 'text-muted-foreground',
@@ -135,7 +140,7 @@ export function Combobox({
         </PopoverTrigger>
 
         <PopoverContent
-          className="p-0"
+          className="z-[80] p-0"
           style={{ width: triggerWidth }}
           align="start"
           sideOffset={4}
@@ -164,6 +169,7 @@ export function Combobox({
                 <button
                   key={option._id ?? option.title}
                   type="button"
+                  data-testid={isCreateOption(option) ? createOptionTestId : undefined}
                   onClick={() => handleSelect(option)}
                   className={cn(
                     'flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground',

--- a/quotevote-frontend/src/lib/auth.ts
+++ b/quotevote-frontend/src/lib/auth.ts
@@ -7,6 +7,7 @@
 
 import type { LoginResponse } from '@/types/login';
 import { env } from '@/config/env';
+import { getLoginToken, postLogin } from '@/lib/auth/restLogin';
 
 const TOKEN_KEY = 'token';
 const COOKIE_NAME = 'qv-token';
@@ -48,14 +49,7 @@ export async function loginUser(
     password: string
 ): Promise<LoginResponse> {
     try {
-        const serverUrl = env.serverUrl;
-        const response = await fetch(`${serverUrl}/login`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username, password }),
-        });
-
-        const data = await response.json();
+        const { response, data } = await postLogin(env.serverUrl, username, password);
 
         if (!response.ok) {
             return {
@@ -64,7 +58,8 @@ export async function loginUser(
             };
         }
 
-        const { token, user } = data;
+        const token = getLoginToken(data);
+        const user = data.user;
 
         if (!token) {
             return { success: false, error: 'No token received from server.' };

--- a/quotevote-frontend/src/lib/auth/restLogin.ts
+++ b/quotevote-frontend/src/lib/auth/restLogin.ts
@@ -1,0 +1,68 @@
+/**
+ * REST login against hosted (/login) or migrated local backend (/auth/login).
+ */
+
+export interface LoginApiResponse {
+  accessToken?: string;
+  token?: string;
+  message?: string;
+  user?: {
+    _id: string;
+    username: string;
+    name?: string;
+    email?: string;
+    admin?: boolean;
+  };
+}
+
+const LOGIN_PATHS = ['/login', '/auth/login'] as const;
+
+export function getLoginToken(data: LoginApiResponse): string | undefined {
+  return data.accessToken ?? data.token;
+}
+
+export async function postLogin(
+  serverUrl: string,
+  username: string,
+  password: string
+): Promise<{ response: Response; data: LoginApiResponse }> {
+  const baseUrl = serverUrl.replace(/\/$/, '');
+  const body = JSON.stringify({ username, password });
+  const headers = { 'Content-Type': 'application/json' };
+
+  let lastResponse: Response | null = null;
+  let lastData: LoginApiResponse = {};
+
+  for (const path of LOGIN_PATHS) {
+    const response = await fetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers,
+      body,
+    });
+
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      lastResponse = response;
+      continue;
+    }
+
+    const data = (await response.json()) as LoginApiResponse;
+    lastResponse = response;
+    lastData = data;
+
+    if (response.ok) {
+      return { response, data };
+    }
+
+    // Valid endpoint but rejected credentials — do not fall through to another path.
+    if (response.status === 401 || response.status === 403) {
+      return { response, data };
+    }
+  }
+
+  if (!lastResponse) {
+    throw new Error('Login request failed: no auth endpoint responded with JSON');
+  }
+
+  return { response: lastResponse, data: lastData };
+}


### PR DESCRIPTION
## Summary

- Adds Playwright E2E infrastructure for the frontend (`e2e/`, `playwright.config.ts`, flexible `pnpm test:e2e` scripts)
- Implements **E2E-POST-001**: logged-in user creates a public post via the composer, verifies explore feed and post detail page (desktop + mobile)
- Fixes REST login to support hosted API (`/login`) and local backend (`/auth/login`) via shared `restLogin` helper
- Adds UI `data-testid`s, combobox z-index fix for group selection in the Create Quote dialog, and excludes `e2e/` from Jest so CI unit tests stay isolated
- Documents setup in `README.md`, `CLAUDE.md`, and `.env.e2e.example`; adds optional CI E2E job when `E2E_AUTHOR_PASSWORD` is configured

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test` (Jest — 155 suites)
- [x] `pnpm test:e2e post-submission.spec.ts` (2 passed: desktop + mobile)
- [x] CI E2E job (requires repo secrets: `E2E_AUTHOR_PASSWORD`, optional `E2E_AUTHOR_USERNAME`, `E2E_PUBLIC_GROUP_NAME`)


Made with [Cursor](https://cursor.com)