### PR TITLE
fix(RC1-030): prevent highlighted text from expanding on popup hover

### DIFF
--- a/quotevote-frontend/src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
@@ -65,8 +65,12 @@ describe('SelectionPopover', () => {
     expect(screen.queryByText('Test content')).not.toBeInTheDocument()
   })
 
-  it('calls onDeselect when selection is cleared', () => {
+  it('calls onDeselect when selection is cleared', async () => {
     const onDeselect = jest.fn()
+
+    // Override getSelection to return null (cleared)
+    global.window.getSelection = jest.fn(() => null)
+
     render(
       <SelectionPopover
         {...defaultProps}
@@ -75,14 +79,13 @@ describe('SelectionPopover', () => {
       />,
     )
 
-    // Simulate clearing selection
-    const selection = window.getSelection()
-    if (selection) {
-      selection.removeAllRanges()
-    }
+    // Trigger a pointermove so selectionChange runs with no active selection
+    await act(async () => {
+      const target = document.querySelector('[data-selectable]')
+      if (target) target.dispatchEvent(new Event('pointermove'))
+    })
 
-    // The component should handle this internally
-    expect(onDeselect).toBeDefined()
+    expect(onDeselect).toHaveBeenCalled()
   })
 
   it('applies custom topOffset', () => {
@@ -114,7 +117,7 @@ describe('SelectionPopover', () => {
     expect(popover).toHaveStyle({ zIndex: '999' })
   })
 
-  it('handles selection change events', async () => {
+  it('calls onSelect when a valid selection exists on pointermove', async () => {
     const onSelect = jest.fn()
     const onDeselect = jest.fn()
 
@@ -127,20 +130,18 @@ describe('SelectionPopover', () => {
       />,
     )
 
-    // Simulate selection change
     await act(async () => {
-      const event = new Event('pointermove')
       const target = document.querySelector('[data-selectable]')
-      if (target) {
-        target.dispatchEvent(event)
-      }
+      if (target) target.dispatchEvent(new Event('pointermove'))
     })
 
-    // onSelect should be called when selection exists
-    expect(onSelect).toBeDefined()
+    // With the mock selection (rangeCount=1, not collapsed, width > 0), onSelect must fire
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onDeselect).not.toHaveBeenCalled()
   })
 
-  it('handles mobile selection events', async () => {
+  it('starts interval polling for selection on selectstart (mobile)', async () => {
+    jest.useFakeTimers()
     const onSelect = jest.fn()
 
     render(
@@ -151,17 +152,19 @@ describe('SelectionPopover', () => {
       />,
     )
 
-    // Simulate mobile selection start
+    // Trigger mobile selectstart to start the 100ms polling interval
     await act(async () => {
       const target = document.querySelector('[data-selectable]')
-      if (target) {
-        const event = new Event('selectstart')
-        target.dispatchEvent(event)
-      }
+      if (target) target.dispatchEvent(new Event('selectstart'))
     })
 
-    // Should handle mobile selection
-    expect(onSelect).toBeDefined()
+    // Advance past one polling tick — selection mock is valid so onSelect fires
+    await act(async () => {
+      jest.advanceTimersByTime(150)
+    })
+
+    expect(onSelect).toHaveBeenCalled()
+    jest.useRealTimers()
   })
 
   it('clears selection when showPopover becomes false', () => {
@@ -284,10 +287,10 @@ describe('SelectionPopover', () => {
     expect(screen.getByText('Test content')).toBeInTheDocument()
   })
 
-  it('handles collapsed selection', () => {
+  it('calls onDeselect when selection is collapsed', async () => {
     const onDeselect = jest.fn()
 
-    // Mock collapsed selection
+    // Override with a collapsed (zero-width) selection
     global.window.getSelection = jest.fn(() => {
       const mockRange = {
         getBoundingClientRect: () => ({
@@ -320,8 +323,13 @@ describe('SelectionPopover', () => {
       />,
     )
 
-    // Should handle collapsed selection
-    expect(onDeselect).toBeDefined()
+    // Trigger a selectionChange via pointermove with a collapsed selection
+    await act(async () => {
+      const target = document.querySelector('[data-selectable]')
+      if (target) target.dispatchEvent(new Event('pointermove'))
+    })
+
+    expect(onDeselect).toHaveBeenCalled()
   })
 
   it('cleans up interval on unmount', async () => {

--- a/quotevote-frontend/src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
@@ -189,7 +189,7 @@ describe('SelectionPopover', () => {
     expect(screen.queryByText('Test content')).not.toBeInTheDocument()
   })
 
-  it('handles mouse enter to expand selection', async () => {
+  it('does not alter selection or call onSelect when mouse enters the popover', async () => {
     const onSelect = jest.fn()
 
     render(
@@ -207,8 +207,7 @@ describe('SelectionPopover', () => {
       })
     }
 
-    // Should expand selection on mouse enter
-    expect(onSelect).toBeDefined()
+    expect(onSelect).not.toHaveBeenCalled()
   })
 
   it('computes popover position correctly for desktop', () => {

--- a/quotevote-frontend/src/components/VotingComponents/SelectionPopover.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/SelectionPopover.tsx
@@ -121,21 +121,6 @@ export default function SelectionPopover({
     }, 100)
   }, [selectionChange])
 
-  const handleMouseEnter = useCallback(() => {
-    const selection = window.getSelection()
-    if (selection && selection.rangeCount > 0) {
-      const range = selection.getRangeAt(0)
-      // Expand to word boundary - use alternative method for Range
-      try {
-        range.setStart(range.startContainer, Math.max(0, range.startOffset - 1))
-        range.setEnd(range.endContainer, range.endOffset + 1)
-      } catch {
-        // If expansion fails, use selection as-is
-      }
-      onSelect(selection)
-    }
-  }, [onSelect])
-
   useEffect(() => {
     if (showPopover === false) {
       clearSelection()
@@ -185,7 +170,6 @@ export default function SelectionPopover({
         zIndex: 50,
         ...style,
       }}
-      onMouseEnter={handleMouseEnter}
     >
       {showPopover && children}
     </div>


### PR DESCRIPTION
<!DOCTYPE html><h2 cid="n179" mdtype="heading" class="md-end-block md-heading md-focus" style="box-sizing: border-box; white-space: pre-wrap; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.75em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.225; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain md-expand" style="box-sizing: border-box;">PR — RC1-030: Prevent highlighted text from expanding on popup hover</span></h2><p cid="n181" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="strong" class="md-pair-s" style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Branch:</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">bugfix/issue-382-hover-selection</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> → </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">main</code></span><span md-inline="softbreak" class="md-softbreak" style="box-sizing: border-box;">
</span><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Closes:</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> #382</span><span md-inline="softbreak" class="md-softbreak" style="box-sizing: border-box;">
</span><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Labels:</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">bug</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">rc1</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">highlight-popup</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">frontend</code></span></p><div tabindex="-1" cid="n182" mdtype="hr" class="md-hr md-end-block" style="box-sizing: border-box; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><hr style="box-sizing: content-box; height: 2px; margin: 16px 0px; border: 0px none; padding: 0px; background-color: rgb(231, 231, 231); overflow: hidden;"></div><h3 cid="n183" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; white-space: pre-wrap; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.5em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.43; cursor: text; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Problem</span></h3><p cid="n184" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">When a user highlighted text on a post and then hovered their cursor over the popup controls, the highlighted range expanded unexpectedly. This was caused by a </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">handleMouseEnter</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> callback attached to </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">onMouseEnter</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> on the </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">SelectionPopover</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> div that </span><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">directly mutated the active </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">Range</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> object</span></strong></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> every time the mouse entered the popup:</span></p><pre class="md-fences md-end-block ty-contain-cm modeLoaded" spellcheck="false" lang="ts" cid="n185" mdtype="fences" style="box-sizing: border-box; overflow: visible; font-family: var(--monospace); font-size: 0.9em; display: block; break-inside: avoid; text-align: left; white-space: pre; background-image: inherit; background-position: inherit; background-size: inherit; background-repeat: inherit; background-attachment: inherit; background-origin: inherit; background-clip: inherit; background-color: rgb(248, 248, 248); position: relative; border: 1px solid rgb(231, 234, 237); border-radius: 3px; padding: 8px 4px 6px; margin-bottom: 15px; margin-top: 15px; width: inherit; color: rgb(51, 51, 51); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"><span class="cm-keyword" style="box-sizing: border-box; color: rgb(119, 0, 136);">const</span> <span class="cm-def" style="box-sizing: border-box; color: rgb(0, 0, 255);">handleMouseEnter</span> <span class="cm-operator" style="box-sizing: border-box; color: rgb(152, 26, 26);">=</span> <span class="cm-variable" style="box-sizing: border-box; color: rgb(0, 0, 0);">useCallback</span>(() <span class="cm-operator" style="box-sizing: border-box; color: rgb(152, 26, 26);">=&gt;</span> {</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;<span class="cm-keyword" style="box-sizing: border-box; color: rgb(119, 0, 136);">const</span> <span class="cm-def" style="box-sizing: border-box; color: rgb(0, 0, 255);">selection</span> <span class="cm-operator" style="box-sizing: border-box; color: rgb(152, 26, 26);">=</span> <span class="cm-variable" style="box-sizing: border-box; color: rgb(0, 0, 0);">window</span>.<span class="cm-property" style="box-sizing: border-box; color: rgb(0, 0, 0);">getSelection</span>()</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;<span class="cm-keyword" style="box-sizing: border-box; color: rgb(119, 0, 136);">if</span> (<span class="cm-variable-2" style="box-sizing: border-box; color: rgb(0, 85, 170);">selection</span> <span class="cm-operator" style="box-sizing: border-box; color: rgb(152, 26, 26);">&amp;&amp;</span> <span class="cm-variable-2" style="box-sizing: border-box; color: rgb(0, 85, 170);">selection</span>.<span class="cm-property" style="box-sizing: border-box; color: rgb(0, 0, 0);">rangeCount</span> <span class="cm-operator" style="box-sizing: border-box; color: rgb(152, 26, 26);">&gt;</span> <span class="cm-number" style="box-sizing: border-box; color: rgb(17, 102, 68);">0</span>) {</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp; &nbsp;<span class="cm-keyword" style="box-sizing: border-box; color: rgb(119, 0, 136);">const</span> <span class="cm-def" style="box-sizing: border-box; color: rgb(0, 0, 255);">range</span> <span class="cm-operator" style="box-sizing: border-box; color: rgb(152, 26, 26);">=</span> <span class="cm-variable-2" style="box-sizing: border-box; color: rgb(0, 85, 170);">selection</span>.<span class="cm-property" style="box-sizing: border-box; color: rgb(0, 0, 0);">getRangeAt</span>(<span class="cm-number" style="box-sizing: border-box; color: rgb(17, 102, 68);">0</span>)</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp; &nbsp;<span class="cm-variable-2" style="box-sizing: border-box; color: rgb(0, 85, 170);">range</span>.<span class="cm-property" style="box-sizing: border-box; color: rgb(0, 0, 0);">setStart</span>(<span class="cm-variable-2" style="box-sizing: border-box; color: rgb(0, 85, 170);">range</span>.<span class="cm-property" style="box-sizing: border-box; color: rgb(0, 0, 0);">startContainer</span>, <span class="cm-variable" style="box-sizing: border-box; color: rgb(0, 0, 0);">Math</span>.<span class="cm-property" style="box-sizing: border-box; color: rgb(0, 0, 0);">max</span>(<span class="cm-number" style="box-sizing: border-box; color: rgb(17, 102, 68);">0</span>, <span class="cm-variable-2" style="box-sizing: border-box; color: rgb(0, 85, 170);">range</span>.<span class="cm-property" style="box-sizing: border-box; color: rgb(0, 0, 0);">startOffset</span> <span class="cm-operator" style="box-sizing: border-box; color: rgb(152, 26, 26);">-</span> <span class="cm-number" style="box-sizing: border-box; color: rgb(17, 102, 68);">1</span>))</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp; &nbsp;<span class="cm-variable-2" style="box-sizing: border-box; color: rgb(0, 85, 170);">range</span>.<span class="cm-property" style="box-sizing: border-box; color: rgb(0, 0, 0);">setEnd</span>(<span class="cm-variable-2" style="box-sizing: border-box; color: rgb(0, 85, 170);">range</span>.<span class="cm-property" style="box-sizing: border-box; color: rgb(0, 0, 0);">endContainer</span>, <span class="cm-variable-2" style="box-sizing: border-box; color: rgb(0, 85, 170);">range</span>.<span class="cm-property" style="box-sizing: border-box; color: rgb(0, 0, 0);">endOffset</span> <span class="cm-operator" style="box-sizing: border-box; color: rgb(152, 26, 26);">+</span> <span class="cm-number" style="box-sizing: border-box; color: rgb(17, 102, 68);">1</span>)</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp; &nbsp;<span class="cm-variable" style="box-sizing: border-box; color: rgb(0, 0, 0);">onSelect</span>(<span class="cm-variable-2" style="box-sizing: border-box; color: rgb(0, 85, 170);">selection</span>) <span class="cm-comment" style="box-sizing: border-box; color: rgb(170, 85, 0);">// fired spuriously on every hover</span></span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;">  }</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;">}, [<span class="cm-variable" style="box-sizing: border-box; color: rgb(0, 0, 0);">onSelect</span>])</span></pre><p cid="n186" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">This caused two visible symptoms:</span></p><ul class="ul-list" cid="n187" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="md-list-item" cid="n188" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n189" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">The highlighted text grew/shifted the moment the cursor touched the popup.</span></p></li><li class="md-list-item" cid="n190" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n191" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">onSelect</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> fired on every hover, triggering downstream state updates with an altered selection range.</span></p></li></ul><p cid="n192" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">There was also a pre-existing test — </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">'handles mouse enter to expand selection'</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> — that validated this buggy behavior with </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">expect(onSelect).toBeDefined()</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">, a no-op assertion that always passed regardless of whether the handler ran or not. Several other tests shared the same problem.</span></p><div tabindex="-1" cid="n193" mdtype="hr" class="md-hr md-end-block" style="box-sizing: border-box; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><hr style="box-sizing: content-box; height: 2px; margin: 16px 0px; border: 0px none; padding: 0px; background-color: rgb(231, 231, 231); overflow: hidden;"></div><h3 cid="n194" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; white-space: pre-wrap; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.5em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.43; cursor: text; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Fix</span></h3><p cid="n195" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">SelectionPopover.tsx</code></span></strong></span></p><ul class="ul-list" cid="n196" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="md-list-item" cid="n197" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n198" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Removed the </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">handleMouseEnter</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> callback entirely.</span></p></li><li class="md-list-item" cid="n199" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n200" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Removed </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">onMouseEnter={handleMouseEnter}</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> from the popup div.</span></p></li><li class="md-list-item" cid="n201" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n202" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Hovering the popup is now a complete no-op with respect to the active text selection.</span></p></li></ul><blockquote cid="n203" mdtype="blockquote" style="box-sizing: border-box; margin: 0.8em 0px; border-left: 4px solid rgb(223, 226, 229); padding: 0px 15px; color: rgb(119, 119, 119); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><p cid="n204" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0px; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">The positioning logic, mobile interval polling, </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">showPopover</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> clear-on-hide, and all other behaviors are unchanged.</span></p></blockquote><p cid="n205" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="strong" class="md-pair-s " style="box-sizing: border-box;"><strong style="box-sizing: border-box;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">SelectionPopover.test.tsx</code></span></strong></span></p><p cid="n206" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Replaced every </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">expect(fn).toBeDefined()</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> no-op with real behavioral assertions:</span></p><figure class="md-table-fig table-figure" cid="n207" mdtype="table" style="box-sizing: border-box; margin: 1.2em 0px; overflow-x: auto; max-width: calc(100% + 16px); padding: 0px; cursor: default; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
Old test name | New test name | Old assertion | New assertion
-- | -- | -- | --
handles mouse enter to expand selection | does not alter selection or call onSelect when mouse enters the popover | toBeDefined() | not.toHaveBeenCalled()
calls onDeselect when selection is cleared | same | toBeDefined() | dispatches pointermove with getSelection()=null → toHaveBeenCalled()
handles selection change events | calls onSelect when a valid selection exists on pointermove | toBeDefined() | toHaveBeenCalledTimes(1) + onDeselect not.toHaveBeenCalled()
handles mobile selection events | starts interval polling for selection on selectstart (mobile) | toBeDefined() | fake timers +150 ms past the 100 ms interval → toHaveBeenCalled()
handles collapsed selection | calls onDeselect when selection is collapsed | toBeDefined() | dispatches pointermove with zero-width range → toHaveBeenCalled()

</figure><div tabindex="-1" cid="n238" mdtype="hr" class="md-hr md-end-block" style="box-sizing: border-box; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><hr style="box-sizing: content-box; height: 2px; margin: 16px 0px; border: 0px none; padding: 0px; background-color: rgb(231, 231, 231); overflow: hidden;"></div><h3 cid="n239" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; white-space: pre-wrap; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.5em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.43; cursor: text; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Test results</span></h3><pre class="md-fences md-end-block ty-contain-cm modeLoaded" spellcheck="false" lang="" cid="n240" mdtype="fences" style="box-sizing: border-box; overflow: visible; font-family: var(--monospace); font-size: 0.9em; display: block; break-inside: avoid; text-align: left; white-space: pre; background-image: inherit; background-position: inherit; background-size: inherit; background-repeat: inherit; background-attachment: inherit; background-origin: inherit; background-clip: inherit; background-color: rgb(248, 248, 248); position: relative; border: 1px solid rgb(231, 234, 237); border-radius: 3px; padding: 8px 4px 6px; margin-bottom: 15px; margin-top: 15px; width: inherit; color: rgb(51, 51, 51); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;">PASS src/__tests__/components/VotingComponents/SelectionPopover.test.tsx</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;">  SelectionPopover</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ renders children when showPopover is true</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ does not render children when showPopover is false</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ calls onDeselect when selection is cleared</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ applies custom topOffset</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ renders above the post sticky action bar (z-index &gt; 10) by default</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ applies custom styles</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ calls onSelect when a valid selection exists on pointermove</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ starts interval polling for selection on selectstart (mobile)</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ clears selection when showPopover becomes false</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ does not alter selection or call onSelect when mouse enters the popover</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ computes popover position correctly for desktop</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ computes popover position correctly for tablet</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ computes popover position correctly for mobile</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ handles missing selectable element gracefully</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ calls onDeselect when selection is collapsed</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"> &nbsp;  ✓ cleans up interval on unmount</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"><span cm-text="" cm-zwsp="" style="box-sizing: border-box;">​</span></span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;">Tests: 16 passed, 16 total</span></pre><div tabindex="-1" cid="n241" mdtype="hr" class="md-hr md-end-block" style="box-sizing: border-box; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><hr style="box-sizing: content-box; height: 2px; margin: 16px 0px; border: 0px none; padding: 0px; background-color: rgb(231, 231, 231); overflow: hidden;"></div><h3 cid="n242" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; white-space: pre-wrap; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.5em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.43; cursor: text; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Acceptance criteria</span></h3><ul class="ul-list" cid="n243" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="md-list-item task-list-item  md-task-list-item task-list-done " cid="n244" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative; list-style-type: none; padding-left: 0px;"><input type="checkbox" checked="" style="box-sizing: border-box; color: var(--text-color); font-style: inherit; font-variant: inherit; font-weight: inherit; font-stretch: inherit; font-size: inherit; line-height: normal; font-family: inherit; font-optical-sizing: inherit; font-size-adjust: inherit; font-kerning: inherit; font-feature-settings: inherit; font-variation-settings: inherit; margin: calc(1em - 10px) 0px 0px -1.3em; background-color: var(--bg-color); padding: 0px; border: none; position: absolute; top: 0px; left: 0px; cursor: pointer; width: inherit; height: inherit;"> <span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Hovering the popup does not alter the selected text range or layout</span></li><li class="md-list-item task-list-item  md-task-list-item task-list-done " cid="n246" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative; list-style-type: none; padding-left: 0px;"><input type="checkbox" checked="" style="box-sizing: border-box; color: var(--text-color); font-style: inherit; font-variant: inherit; font-weight: inherit; font-stretch: inherit; font-size: inherit; line-height: normal; font-family: inherit; font-optical-sizing: inherit; font-size-adjust: inherit; font-kerning: inherit; font-feature-settings: inherit; font-variation-settings: inherit; margin: calc(1em - 10px) 0px 0px -1.3em; background-color: var(--bg-color); padding: 0px; border: none; position: absolute; top: 0px; left: 0px; cursor: pointer; width: inherit; height: inherit;"> <span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">onSelect</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> is not called spuriously on popup hover</span></li><li class="md-list-item task-list-item  md-task-list-item task-list-done " cid="n248" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative; list-style-type: none; padding-left: 0px;"><input type="checkbox" checked="" style="box-sizing: border-box; color: var(--text-color); font-style: inherit; font-variant: inherit; font-weight: inherit; font-stretch: inherit; font-size: inherit; line-height: normal; font-family: inherit; font-optical-sizing: inherit; font-size-adjust: inherit; font-kerning: inherit; font-feature-settings: inherit; font-variation-settings: inherit; margin: calc(1em - 10px) 0px 0px -1.3em; background-color: var(--bg-color); padding: 0px; border: none; position: absolute; top: 0px; left: 0px; cursor: pointer; width: inherit; height: inherit;"> <span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">onDeselect</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> is called when the selection is cleared or collapses to zero width</span></li><li class="md-list-item task-list-item  md-task-list-item task-list-done " cid="n250" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative; list-style-type: none; padding-left: 0px;"><input type="checkbox" checked="" style="box-sizing: border-box; color: var(--text-color); font-style: inherit; font-variant: inherit; font-weight: inherit; font-stretch: inherit; font-size: inherit; line-height: normal; font-family: inherit; font-optical-sizing: inherit; font-size-adjust: inherit; font-kerning: inherit; font-feature-settings: inherit; font-variation-settings: inherit; margin: calc(1em - 10px) 0px 0px -1.3em; background-color: var(--bg-color); padding: 0px; border: none; position: absolute; top: 0px; left: 0px; cursor: pointer; width: inherit; height: inherit;"> <span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Mobile interval polling fires </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">onSelect</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> correctly after </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">selectstart</code></span></li><li class="md-list-item task-list-item  md-task-list-item task-list-done " cid="n252" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative; list-style-type: none; padding-left: 0px;"><input type="checkbox" checked="" style="box-sizing: border-box; color: var(--text-color); font-style: inherit; font-variant: inherit; font-weight: inherit; font-stretch: inherit; font-size: inherit; line-height: normal; font-family: inherit; font-optical-sizing: inherit; font-size-adjust: inherit; font-kerning: inherit; font-feature-settings: inherit; font-variation-settings: inherit; margin: calc(1em - 10px) 0px 0px -1.3em; background-color: var(--bg-color); padding: 0px; border: none; position: absolute; top: 0px; left: 0px; cursor: pointer; width: inherit; height: inherit;"> <span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Behavior is consistent across desktop and mobile views</span></li><li class="md-list-item task-list-item md-task-list-item task-list-done md-focus-container" cid="n254" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative; list-style-type: none; padding-left: 0px;"><input type="checkbox" checked="" style="box-sizing: border-box; color: var(--text-color); font-style: inherit; font-variant: inherit; font-weight: inherit; font-stretch: inherit; font-size: inherit; line-height: normal; font-family: inherit; font-optical-sizing: inherit; font-size-adjust: inherit; font-kerning: inherit; font-feature-settings: inherit; font-variation-settings: inherit; margin: calc(1em - 10px) 0px 0px -1.3em; background-color: var(--bg-color); padding: 0px; border: none; position: absolute; top: 0px; left: 0px; cursor: pointer; width: inherit; height: inherit;"> <span md-inline="plain" class="md-plain md-expand" style="box-sizing: border-box;">No regressions in adjacent workflows</span></li></ul>