### PR TITLE
Bugfix/issue 384 viewport clamping

### DIFF
--- a/quotevote-frontend/src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
@@ -189,7 +189,7 @@ describe('SelectionPopover', () => {
     expect(screen.queryByText('Test content')).not.toBeInTheDocument()
   })
 
-  it('handles mouse enter to expand selection', async () => {
+  it('does not alter selection or call onSelect when mouse enters the popover', async () => {
     const onSelect = jest.fn()
 
     render(
@@ -207,8 +207,8 @@ describe('SelectionPopover', () => {
       })
     }
 
-    // Should expand selection on mouse enter
-    expect(onSelect).toBeDefined()
+    // Hovering over the popup must NOT call onSelect or expand the selection
+    expect(onSelect).not.toHaveBeenCalled()
   })
 
   it('computes popover position correctly for desktop', () => {

--- a/quotevote-frontend/src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
@@ -86,31 +86,31 @@ describe('SelectionPopover', () => {
   })
 
   it('applies custom topOffset', () => {
-    const { container } = render(
+    render(
       <SelectionPopover {...defaultProps} showPopover={true} topOffset={50} />,
     )
-    const popover = container.querySelector('#selectionPopover')
+    const popover = document.querySelector('#selectionPopover')
     expect(popover).toBeInTheDocument()
   })
 
   it('renders above the post sticky action bar (z-index > 10) by default', () => {
-    const { container } = render(
+    render(
       <SelectionPopover {...defaultProps} showPopover={true} />,
     )
-    const popover = container.querySelector('#selectionPopover') as HTMLElement
+    const popover = document.querySelector('#selectionPopover') as HTMLElement
     expect(Number(popover.style.zIndex)).toBeGreaterThan(10)
   })
 
   it('applies custom styles', () => {
     const customStyle = { zIndex: 999 }
-    const { container } = render(
+    render(
       <SelectionPopover
         {...defaultProps}
         showPopover={true}
         style={customStyle}
       />,
     )
-    const popover = container.querySelector('#selectionPopover') as HTMLElement
+    const popover = document.querySelector('#selectionPopover') as HTMLElement
     expect(popover).toHaveStyle({ zIndex: '999' })
   })
 

--- a/quotevote-frontend/src/components/VotingComponents/SelectionPopover.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/SelectionPopover.tsx
@@ -116,21 +116,6 @@ export default function SelectionPopover({
     }, 100)
   }, [selectionChange])
 
-  const handleMouseEnter = useCallback(() => {
-    const selection = window.getSelection()
-    if (selection && selection.rangeCount > 0) {
-      const range = selection.getRangeAt(0)
-      // Expand to word boundary - use alternative method for Range
-      try {
-        range.setStart(range.startContainer, Math.max(0, range.startOffset - 1))
-        range.setEnd(range.endContainer, range.endOffset + 1)
-      } catch {
-        // If expansion fails, use selection as-is
-      }
-      onSelect(selection)
-    }
-  }, [onSelect])
-
   useEffect(() => {
     if (showPopover === false) {
       clearSelection()
@@ -200,7 +185,6 @@ export default function SelectionPopover({
         zIndex: 50,
         ...style,
       }}
-      onMouseEnter={handleMouseEnter}
     >
       {showPopover && children}
     </div>,

--- a/quotevote-frontend/src/components/VotingComponents/SelectionPopover.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/SelectionPopover.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState, useCallback } from 'react'
+import { createPortal } from 'react-dom'
 import type { SelectionPopoverProps } from '@/types/voting'
 
 /**
@@ -15,13 +16,18 @@ export default function SelectionPopover({
   style,
   children,
 }: SelectionPopoverProps) {
+  const [mounted, setMounted] = useState(false)
   const [popoverBox, setPopoverBox] = useState({
     top: 0,
     left: 0,
-    right: 0,
   })
   const popoverRef = useRef<HTMLDivElement>(null)
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true)
+  }, [])
 
   const selectionExists = useCallback(() => {
     const selection = window.getSelection()
@@ -55,44 +61,33 @@ export default function SelectionPopover({
     if (!popoverElement) return
 
     const popoverBoxRect = popoverElement.getBoundingClientRect()
-    const halfWindowWidth = window.innerWidth / 2
-    const targetElement = document.querySelector('[data-selectable]')
-    if (!targetElement) return
+    const popoverWidth = popoverBoxRect.width || 285
+    const popoverHeight = popoverBoxRect.height || 48
 
-    const targetBox = targetElement.getBoundingClientRect()
+    // Clamp horizontally within viewport
+    const margin = 10
+    const viewportLeft = selectionBox.left + selectionBox.width / 2 - popoverWidth / 2
+    const clampedViewportLeft = Math.max(
+      margin,
+      Math.min(window.innerWidth - popoverWidth - margin, viewportLeft)
+    )
+    const pageLeft = clampedViewportLeft + window.scrollX
 
-    const popupH = popoverBoxRect.height || 48
-    const popupW = popoverBoxRect.width || 285
-
-    if (window.innerWidth > 960) {
-      // Desktop: popup above the selection, horizontally centred over it
-      setPopoverBox({
-        top: selectionBox.top - popupH - 8 - targetBox.top,
-        left:
-          selectionBox.left - targetBox.left +
-          selectionBox.width / 2 -
-          popupW / 2,
-        right: 0,
-      })
-    } else if (
-      window.innerWidth > 500 &&
-      window.innerWidth <= 960 &&
-      selectionBox.x > halfWindowWidth
-    ) {
-      // Tablet, right-side selection: popup below, right-aligned
-      setPopoverBox({
-        top: selectionBox.bottom - targetBox.top + 8,
-        right: window.innerWidth - selectionBox.x + popupW,
-        left: 0,
-      })
+    // Determine vertical position: top or bottom
+    const spaceAtTop = selectionBox.top
+    let pageTop: number
+    if (spaceAtTop < popoverHeight + topOffset + 10) {
+      // Position below the selection
+      pageTop = selectionBox.bottom + window.scrollY + topOffset
     } else {
-      // Mobile: popup below the selection, left-aligned
-      setPopoverBox({
-        top: selectionBox.bottom - targetBox.top + 8,
-        left: 0,
-        right: 0,
-      })
+      // Position above the selection
+      pageTop = selectionBox.top + window.scrollY - popoverHeight - topOffset
     }
+
+    setPopoverBox({
+      top: pageTop,
+      left: pageLeft,
+    })
   }, [topOffset, selectionExists])
 
   const selectionChange = useCallback(() => {
@@ -159,6 +154,25 @@ export default function SelectionPopover({
   }, [handleMobileSelection, handleRemoveInterval, selectionChange])
 
   useEffect(() => {
+    if (showPopover) {
+      // Run on next frames to handle potential layout adjustments and avoid cascading renders lint rule
+      const rafId1 = requestAnimationFrame(computePopoverBox)
+      const rafId2 = requestAnimationFrame(() => requestAnimationFrame(computePopoverBox))
+
+      window.addEventListener('resize', computePopoverBox)
+      window.addEventListener('scroll', computePopoverBox, { passive: true })
+
+      return () => {
+        cancelAnimationFrame(rafId1)
+        cancelAnimationFrame(rafId2)
+        window.removeEventListener('resize', computePopoverBox)
+        window.removeEventListener('scroll', computePopoverBox)
+      }
+    }
+    return undefined
+  }, [showPopover, computePopoverBox])
+
+  useEffect(() => {
     return () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current)
@@ -166,10 +180,12 @@ export default function SelectionPopover({
     }
   }, [])
 
+  if (!mounted) return null
+
   const visibility = showPopover ? 'visible' : 'hidden'
   const display = showPopover ? 'inline-block' : 'none'
 
-  return (
+  return createPortal(
     <div
       id="selectionPopover"
       ref={popoverRef}
@@ -178,8 +194,7 @@ export default function SelectionPopover({
         display,
         position: 'absolute',
         top: popoverBox.top,
-        left: popoverBox.left || undefined,
-        right: popoverBox.right || undefined,
+        left: popoverBox.left,
         // Must sit above the post's sticky action bar (Disagree/Support,
         // z-10 in Post.tsx) so the selection interaction isn't hidden behind it.
         zIndex: 50,
@@ -188,7 +203,8 @@ export default function SelectionPopover({
       onMouseEnter={handleMouseEnter}
     >
       {showPopover && children}
-    </div>
+    </div>,
+    document.body
   )
 }
 


### PR DESCRIPTION
## PR — RC1-032: Render highlight popup in portal and clamp within viewport

**Branch:** `bugfix/issue-384-viewport-clamping` → `main`
**Closes:** #384
**Labels:** `bug` `rc1` `highlight-popup` `layout` `frontend`

---

### Problem

The highlight popup was rendered as a regular child element inside `SelectionPopover`'s DOM parent. This caused two distinct bugs:

**1. Overflow clipping**
Any ancestor with `overflow: hidden` (present in multiple layout containers) clipped the popup at the parent's edge. Selecting text near a container boundary made the popup appear cut off or invisible.

**2. No viewport clamping**
The old `computePopoverBox` positioned the popup relative to the `[data-selectable]` element's bounding box without checking viewport edges. Selecting text near the left or right edge caused the popup to render partially or fully off-screen.

The old positioning used three separate layout branches (desktop / tablet right-side / mobile) with coordinates relative to the parent container, all of which could still overflow the viewport:

```ts
// Old: position relative to parent container — could overflow viewport
setPopoverBox({
  top: selectionBox.top - popupH - 8 - targetBox.top,
  left: selectionBox.left - targetBox.left + selectionBox.width / 2 - popupW / 2,
  right: 0,
})
```

There was also a `handleMouseEnter` callback (introduced in the same branch) that mutated the live selection range on hover — a regression against the no-regressions acceptance criterion.

---

### Fix

**`SelectionPopover.tsx`** — four concrete changes:

**1. SSR guard (`mounted` state)**

Added a `mounted` state flag set in a `useEffect`. The component returns `null` on the server to avoid `document` access during SSR:

```ts
const [mounted, setMounted] = useState(false)
useEffect(() => { setMounted(true) }, [])
if (!mounted) return null
```

**2. Portal rendering**

The popup div is now rendered via `createPortal(…, document.body)`, escaping all ancestor overflow constraints. It overlays the full page regardless of the DOM hierarchy:

```ts
return createPortal(
  <div id="selectionPopover" ref={popoverRef} style={...}>,
  document.body
)
```

**3. Unified viewport-aware positioning with horizontal clamping and vertical flip**

Replaced the three-branch layout with a single algorithm that works at all viewport widths:

```ts
// Horizontal: centre over selection, clamp within [10px, viewport - popupWidth - 10px]
const viewportLeft = selectionBox.left + selectionBox.width / 2 - popoverWidth / 2
const clampedViewportLeft = Math.max(
  margin,
  Math.min(window.innerWidth - popoverWidth - margin, viewportLeft)
)
const pageLeft = clampedViewportLeft + window.scrollX

// Vertical: flip below the selection when there is not enough space above
if (selectionBox.top < popoverHeight + topOffset + 10) {
  pageTop = selectionBox.bottom + window.scrollY + topOffset  // below
} else {
  pageTop = selectionBox.top + window.scrollY - popoverHeight - topOffset  // above
}
```

Coordinates are now in page-absolute space (`viewport coord + scrollX/Y`) so the absolutely-positioned portal element tracks the selection correctly even on scrolled pages.

**4. Resize and scroll recalculation**

While the popup is visible, `computePopoverBox` is re-run via `requestAnimationFrame` on the next two frames (to allow the portal to paint and report its measured size), and on every `resize` and passive `scroll` event:

```ts
useEffect(() => {
  if (showPopover) {
    const rafId1 = requestAnimationFrame(computePopoverBox)
    const rafId2 = requestAnimationFrame(() => requestAnimationFrame(computePopoverBox))
    window.addEventListener('resize', computePopoverBox)
    window.addEventListener('scroll', computePopoverBox, { passive: true })
    return () => {
      cancelAnimationFrame(rafId1)
      cancelAnimationFrame(rafId2)
      window.removeEventListener('resize', computePopoverBox)
      window.removeEventListener('scroll', computePopoverBox)
    }
  }
}, [showPopover, computePopoverBox])
```

**5. Removed `handleMouseEnter`**

Removed the `handleMouseEnter` callback and `onMouseEnter` prop that were introduced in the first commit on this branch. The callback mutated the active `Range` on hover, which is the root cause of #382 and a direct regression against this issue's acceptance criterion.

**`SelectionPopover.test.tsx`** — two targeted changes:

- `container.querySelector('#selectionPopover')` → `document.querySelector('#selectionPopover')` throughout, because the popup now renders into `document.body` via the portal and is not a child of the React test container.
- Replaced `'handles mouse enter to expand selection'` (which asserted the buggy behavior with `toBeDefined()`) with `'does not alter selection or call onSelect when mouse enters the popover'` asserting `expect(onSelect).not.toHaveBeenCalled()`.

---

### Test results

```
PASS src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
  SelectionPopover
    ✓ renders children when showPopover is true
    ✓ does not render children when showPopover is false
    ✓ calls onDeselect when selection is cleared
    ✓ applies custom topOffset
    ✓ renders above the post sticky action bar (z-index > 10) by default
    ✓ applies custom styles
    ✓ handles selection change events
    ✓ handles mobile selection events
    ✓ clears selection when showPopover becomes false
    ✓ does not alter selection or call onSelect when mouse enters the popover
    ✓ computes popover position correctly for desktop
    ✓ computes popover position correctly for tablet
    ✓ computes popover position correctly for mobile
    ✓ handles missing selectable element gracefully
    ✓ handles collapsed selection
    ✓ cleans up interval on unmount

Tests: 16 passed, 16 total
```

---

### Acceptance criteria

- [x] Popup is positioned and clamped within viewport bounds at all screen widths
- [x] Popup never clips against a parent container — rendered via `document.body` portal
- [x] Popup flips below the selection when space above is insufficient
- [x] Popup coordinates stay correct on scrolled pages (`scrollX` / `scrollY` offsets applied)
- [x] Position recalculates on `resize` and `scroll` while visible
- [x] SSR-safe — returns `null` until mounted on the client
- [x] Hovering the popup does not alter the active selection (no regression from #382)
- [x] No regressions in adjacent workflows