### PR TITLE
fix: ChatSearchInput auto clearing on non buddy mode [RC1-026]

### DIFF
--- a/quotevote-frontend/src/__tests__/components/Chat/ChatSearchInput.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Chat/ChatSearchInput.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen, waitFor } from "@/__tests__/utils/test-utils";
+import ChatSearchInput from "@/components/Chat/ChatSearchInput";
+
+describe("ChatSearchInput", () => {
+  it("does not clear search immediately in normal search mode", () => {
+    const setSearch = jest.fn();
+    const onAddBuddyModeChange = jest.fn();
+
+    render(
+      <ChatSearchInput
+        setSearch={setSearch}
+        addBuddyMode={false}
+        onAddBuddyModeChange={onAddBuddyModeChange}
+      />
+    );
+
+    const input = screen.getByLabelText("search conversations");
+    fireEvent.change(input, { target: { value: "test search" } });
+
+    expect(input).toHaveValue("test search");
+    expect(setSearch).toHaveBeenLastCalledWith("test search");
+  });
+
+  it("clears search when exiting add buddy mode", async () => {
+    const setSearch = jest.fn();
+    const onAddBuddyModeChange = jest.fn();
+
+    const { rerender } = render(
+      <ChatSearchInput
+        setSearch={setSearch}
+        addBuddyMode={true}
+        onAddBuddyModeChange={onAddBuddyModeChange}
+      />
+    );
+
+    const input = screen.getByLabelText("search users to add");
+    fireEvent.change(input, { target: { value: "alice" } });
+    expect(input).toHaveValue("alice");
+
+    rerender(
+      <ChatSearchInput
+        setSearch={setSearch}
+        addBuddyMode={false}
+        onAddBuddyModeChange={onAddBuddyModeChange}
+      />
+    );
+
+    await waitFor(() => {
+      expect(input).toHaveValue("");
+      expect(setSearch).toHaveBeenLastCalledWith("");
+    });
+  });
+});

--- a/quotevote-frontend/src/components/Chat/ChatSearchInput.tsx
+++ b/quotevote-frontend/src/components/Chat/ChatSearchInput.tsx
@@ -20,6 +20,7 @@ const ChatSearchInput: FC<ChatSearchInputProps> = ({
 }) => {
   const [searchValue, setSearchValue] = useState('');
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const previousAddBuddyMode = useRef(addBuddyMode);
 
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
     const searchKey = e.target.value;
@@ -58,10 +59,13 @@ const ChatSearchInput: FC<ChatSearchInputProps> = ({
     }
   };
 
-  // Clear search when addBuddyMode changes from outside (e.g., parent component)
-  // Only clear if we're exiting add mode and have a search value
+  // Track the previous mode so we only clear when addBuddyMode transitions
+  // from true to false via an external change.
   useEffect(() => {
-    if (!addBuddyMode && searchValue && onAddBuddyModeChange) {
+    const wasAddBuddyMode = previousAddBuddyMode.current;
+    previousAddBuddyMode.current = addBuddyMode;
+
+    if (wasAddBuddyMode !== addBuddyMode && !addBuddyMode && searchValue && onAddBuddyModeChange) {
       // Only clear if we're not in the middle of toggling (which is handled in toggleAddMode)
       // This handles the case where addBuddyMode is changed externally
       const timeoutId = setTimeout(() => {


### PR DESCRIPTION
RC1-026: Fix chat search input clearing during normal search**

**Branch:** `fix/chat-search-clear-guard` → `main`  
**Closes:** #378  
**Labels:** `bug` `rc1` `chat` `search` `frontend`

---

### Summary
Chat search input was clearing in normal search mode when anything is typed, which broke the ability to keep username/keyword queries in place. This fix makes the clear behavior happen only when leaving buddy-add mode.

### Problem
The search input was being cleared on initial render / non-buddy search mode instead of only when `addBuddyMode` actually changed. That made chat search behave inconsistently and interfered with searching by username or keyword.

### Fix
- Added `previousAddBuddyMode` to track the prior mode value.
- Only clear the search input when `addBuddyMode` transitions from `true` to `false`.
- Updated the comment to match the transition-based behavior.
- Added regression coverage for both normal search mode and exiting add buddy mode.

### Acceptance Criteria
- Search input remains stable in normal chat search mode.
- Search clears only when leaving add buddy mode.
- No regressions in adjacent chat workflows.

### Test Results
`pnpm test -- src/__tests__/components/Chat/ChatSearchInput.test.tsx --runInBand
```
src/__tests__/components/Chat/ChatSearchInput.test.tsx
  ChatSearchInput
    ✓ does not clear search immediately in normal search mode (26 ms)
    ✓ clears search when exiting add buddy mode (13 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```