### PR TITLE
fix: remove duplicate inline GraphQL SDL type defs in server.ts

### DIFF
--- a/quotevote-backend/app/server.ts
+++ b/quotevote-backend/app/server.ts
@@ -64,53 +64,6 @@ async function startServer() {
           heartbeat: HeartbeatResponse
       }
 
-      type Post {
-        _id: String
-        userId: String
-        groupId: String
-        title: String
-        text: String
-        citationUrl: String
-        url: String
-        deleted: Boolean
-        upvotes: Int
-        downvotes: Int
-        featuredSlot: Int
-        enable_voting: Boolean
-        dayPoints: Int
-        pointTimestamp: String
-        votedBy: [String]
-        bookmarkedBy: [String]
-        approvedBy: [String]
-        rejectedBy: [String]
-        reportedBy: [String]
-        created: String
-        creator: PostCreator
-      }
-
-      type PostCreator {
-        _id: String
-        name: String
-        username: String
-        avatar: String
-      }
-
-      type Pagination {
-        total_count: Int
-        limit: Int
-        offset: Int
-      }
-
-      type Posts {
-        entities: [Post]
-        pagination: Pagination
-      }
-
-      type HeartbeatResponse {
-        success: Boolean!
-        timestamp: String!
-      }
-
       type SolidConnectionStatus {
         connected: Boolean
         webId: String


### PR DESCRIPTION
## Summary

Fixes #403

`pnpm dev` crashed immediately after connecting to MongoDB with:

```
Error: Unable to merge GraphQL type "Post": Field "created" already defined with a different type. Declared as "Date", but you tried to override with "String"
```

This PR removes five stale inline SDL type definitions (`Post`, `PostCreator`, `Pagination`, `Posts`, `HeartbeatResponse`) from `app/server.ts` that were left over from before the GraphQL schema migration.

## Root cause

These five types were already migrated to the programmatic `GraphQLObjectType` API in `app/data/types/` (e.g. `PostType` in `app/data/types/Post.ts`), and are included in the `domainTypes` array (`app/data/types/index.ts`), which is flattened into `domainTypeDefs` and prepended to the schema in `server.ts`.

The old inline SDL block for `Post` in `server.ts` still declared `created: String`, while the migrated `PostType` declares `created: DateScalar`. Since `@graphql-tools/merge` only tolerates re-declaring a type when the fields match exactly, the conflicting `created` field type caused `makeExecutableSchema` to throw on every server start.

The other four types were also already covered by `domainTypeDefs`:
- `Pagination` → `PaginationType` (`app/data/types/Pagination.ts`)
- `Posts` → `PostsType` (`app/data/types/Posts.ts`)
- `HeartbeatResponse` → `HeartbeatResponseType` (`app/data/types/Presence.ts`)
- `PostCreator` → no longer needed; the migrated `PostType.creator` field now resolves to the full `UserType` rather than a separate slimmed-down type

## Changes

- Removed the inline `type Post`, `type PostCreator`, `type Pagination`, `type Posts`, and `type HeartbeatResponse` SDL blocks from the `typeDefs` template string in `app/server.ts`.
- No other changes. `Query`, `Mutation`, and the Solid-related types in `server.ts` are untouched.

## Before / After

**Before** — `pnpm dev` on `main`:

```
PS> pnpm dev
$ ts-node-dev --respawn --transpile-only app/server.ts
[INFO] ts-node-dev ver. 2.0.0 (using ts-node ver. 10.9.2, typescript ver. 5.9.3)
warn: NOTICE: process.env.JWT_SECRET is not defined. Using development fallback secret.
[dotenv@17.2.3] injecting env (8) from .env
✅ Connected to MongoDB
info: [Presence Cleanup] Started presence cleanup job
Error: Unable to merge GraphQL type "Post": Field "created" already defined with a different type. Declared as "Date", but you tried to override with "String"
    at mergeType (.../node_modules/.pnpm/@graphql-tools+merge@9.1.6_graphql@16.12.0/.../type.js:26:19)
    at makeExecutableSchema (.../makeExecutableSchema.js:72:58)
    at new ApolloServer (.../ApolloServer.ts:263:37)
    at startServer (app/server.ts:46:18)
```

**After** — `pnpm dev` with this fix applied:

```
PS> pnpm dev
$ ts-node-dev --respawn --transpile-only app/server.ts
[INFO] 17:53:56 ts-node-dev ver. 2.0.0 (using ts-node ver. 10.9.2, typescript ver. 5.9.3)
2026-06-28 17:53:58 warn: NOTICE: process.env.JWT_SECRET is not defined. Using development fallback secret.
[dotenv@17.2.3] injecting env (8) from .env -- tip: ⚙️  suppress all logs with { quiet: true }
✅ Connected to MongoDB
2026-06-28 17:53:59 info: [Presence Cleanup] Started presence cleanup job
🚀 Server ready at http://localhost:4000/graphql
```

Server now starts cleanly and stays up, instead of crashing right after connecting to MongoDB.

## Testing

Per the backend README's contribution checklist, ran the following from `quotevote-backend`:

- ✅ `pnpm dev` — server now starts cleanly and listens at `http://localhost:4000/graphql` (previously crashed before binding the port)
- ✅ `pnpm test` — 88/88 suites, 729/729 tests passing
- ✅ `pnpm type-check` — no errors
- ✅ `pnpm lint` — no errors
- ⚠️ `pnpm format:check` — fails on 199 files repo-wide; confirmed via `git stash` that this is **pre-existing on `main`** and unrelated to this change. Left untouched to keep this diff scoped to the actual bug fix; happy to follow up separately if a repo-wide Prettier pass is wanted.

Also manually verified via GraphQL Sandbox that `featuredPosts` still returns a valid (schema-conformant) response post-fix, with `creator` resolving correctly through `UserType`.

## Notes for reviewers

This is a pure deletion — no behavior change, no new types added. Confirmed each removed type already has an equivalent in `app/data/types/` before removing its inline counterpart.