### PR TITLE
feat(auth): implement E2E-AUTH-006 Eyebrow Email Gateway for Registered Users

### DIFF
--- a/quotevote-frontend/.gitignore
+++ b/quotevote-frontend/.gitignore
@@ -39,3 +39,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Playwright artifacts and reports
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/quotevote-frontend/e2e/auth.spec.ts
+++ b/quotevote-frontend/e2e/auth.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect, type Page } from "@playwright/test";
+import { registeredUser } from "./fixtures/registeredUser";
+
+/**
+ * E2E-AUTH-006: Eyebrow Email Gateway — Registered User
+ *
+ * A logged-out visitor enters an email belonging to an existing registered
+ * account into the top-of-page "eyebrow" email gateway. The gateway should
+ * recognize the account and offer magic link / password login options,
+ * without logging the user in.
+ *
+ * Out of scope (covered by other issues): completing magic link login,
+ * completing password login, invite request flow, pending invite state,
+ * approved invite onboarding, password reset, email delivery.
+ */
+
+/**
+ * Mocks the `/auth/check-email` endpoint so this spec doesn't depend on a
+ * real seeded database account or a backend implementation that doesn't
+ * exist yet (see e2e/fixtures/registeredUser.ts for context). Swap this for
+ * a real seeded fixture once the backend route ships.
+ */
+async function mockRegisteredEmailCheck(page: Page, email: string) {
+  // Match on path only — embedding '?'/'=' query-string characters directly
+  // in a glob pattern is fragile (Playwright parses the glob through `new
+  // URL()`, which has known quirks with '?'). Instead, match any request to
+  // the endpoint and verify the email query param inside the handler.
+  await page.route("**/auth/check-email**", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.searchParams.get("email") !== email) {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "registered" }),
+    });
+  });
+}
+
+test.describe("Eyebrow Email Gateway: Registered User (E2E-AUTH-006)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockRegisteredEmailCheck(page, registeredUser.email);
+  });
+
+  test("recognizes a registered email and offers login options", async ({ page }) => {
+    const errorToastLocator = page.locator('[data-sonner-toast][data-type="error"]');
+
+    await page.goto("/");
+
+    // 1. Eyebrow email field is visible to logged-out visitors
+    const form = page.getByTestId("eyebrow-email-form");
+    const emailInput = page.getByTestId("eyebrow-email-input");
+    const submitButton = page.getByTestId("eyebrow-email-submit");
+
+    await expect(form).toBeVisible();
+    await expect(emailInput).toBeVisible();
+
+    // Submit is disabled before a valid email is entered
+    await expect(submitButton).toBeDisabled();
+
+    // 2. Email input accepts a registered email address
+    await emailInput.fill(registeredUser.email);
+
+    // 3. Submit button becomes available once the email is valid
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    // 4. Registered-user state appears after submission
+    const registeredMessage = page.getByTestId("registered-user-message");
+    await expect(registeredMessage).toBeVisible();
+    await expect(registeredMessage).toContainText(/we recognize this email/i);
+
+    // 5. Magic link login option is visible
+    const magicLinkOption = page.getByTestId("magic-link-login-option");
+    await expect(magicLinkOption).toBeVisible();
+
+    // 6. Password login option is visible
+    const passwordOption = page.getByTestId("password-login-option");
+    await expect(passwordOption).toBeVisible();
+
+    // 7. User remains logged out — no session/auth cookie or token has
+    // been set, and the eyebrow gateway (which only renders for logged-out
+    // visitors) is still present underneath the modal.
+    const cookies = await page.context().cookies();
+    const hasAuthCookie = cookies.some((cookie) =>
+      /token|session|auth/i.test(cookie.name)
+    );
+    expect(hasAuthCookie).toBe(false);
+    await expect(form).toBeVisible();
+
+    // 8. No runtime error or generic error toast appears
+    await expect(errorToastLocator).toHaveCount(0);
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+    expect(pageErrors).toHaveLength(0);
+  });
+});

--- a/quotevote-frontend/e2e/fixtures/registeredUser.ts
+++ b/quotevote-frontend/e2e/fixtures/registeredUser.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared test fixtures for auth E2E specs.
+ *
+ * NOTE: The backend does not yet implement a real `/auth/check-email`
+ * endpoint (see quotevote-frontend/src/app/components/Eyebrow/Eyebrow.tsx,
+ * which calls it but has no corresponding server route). Until that route
+ * exists, these specs mock the network response for `/auth/check-email`
+ * rather than depending on a real seeded database record. Once the backend
+ * implements the endpoint, `registeredUser.email` should be updated to point
+ * at an actual seeded account and the mocked route in auth.spec.ts can be
+ * removed.
+ */
+
+export const registeredUser = {
+  email: "registered.user@quotevote.test",
+};

--- a/quotevote-frontend/jest.config.js
+++ b/quotevote-frontend/jest.config.js
@@ -20,7 +20,7 @@ const customJestConfig = {
     '**/?(*.)+(spec|test).[jt]s?(x)',
   ],
 
-  testPathIgnorePatterns: ['/node_modules/', '/.next/', '/src/types/'],
+  testPathIgnorePatterns: ['/node_modules/', '/.next/', '/src/types/', '/e2e/'],
 
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',

--- a/quotevote-frontend/package.json
+++ b/quotevote-frontend/package.json
@@ -15,7 +15,10 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:ci": "jest --ci --coverage --maxWorkers=2"
+    "test:ci": "jest --ci --coverage --maxWorkers=2",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@apollo/client": "^4.0.9",
@@ -59,6 +62,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/postcss": "^4",

--- a/quotevote-frontend/playwright.config.ts
+++ b/quotevote-frontend/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = process.env.PLAYWRIGHT_PORT || 3000;
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "html",
+  timeout: 30_000,
+
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "Desktop Chrome",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "Mobile Chrome",
+      use: { ...devices["Pixel 7"] },
+    },
+  ],
+
+  // Spin up the Next.js dev server automatically unless one is already running
+  // (e.g. CI may start it separately, or PLAYWRIGHT_BASE_URL points elsewhere).
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: "pnpm dev",
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+});

--- a/quotevote-frontend/pnpm-lock.yaml
+++ b/quotevote-frontend/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 2.30.1
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -126,6 +126,9 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.7)(immer@11.0.1)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
@@ -170,7 +173,7 @@ importers:
         version: 30.2.0
       next-test-api-route-handler:
         specifier: ^5.0.3
-        version: 5.0.3(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 5.0.3(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       prettier:
         specifier: ^3.7.1
         version: 3.7.1
@@ -879,6 +882,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1920,6 +1928,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -2212,10 +2221,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.8.31:
-    resolution: {integrity: sha512-a28v2eWrrRWPpJSzxc+mKwm0ZtVx/G8SepdQZDArnXYU/XS+IF6mp8aB/4E+hH1tyGCoDo3KlUCdlSxGDsRkAw==}
-    hasBin: true
-
   baseline-browser-mapping@2.9.13:
     resolution: {integrity: sha512-WhtvB2NG2wjr04+h77sg3klAIwrgOqnjS49GGudnUPGFFgg7G17y7Qecqp+2Dr5kUDxNRBca0SK7cG8JwzkWDQ==}
     hasBin: true
@@ -2268,9 +2273,6 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-
-  caniuse-lite@1.0.30001757:
-    resolution: {integrity: sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==}
 
   caniuse-lite@1.0.30001763:
     resolution: {integrity: sha512-mh/dGtq56uN98LlNX9qdbKnzINhX0QzhiWBFEkFfsFO4QyCvL8YegrJAazCwXIeqkIob8BlZPGM3xdnY+sgmvQ==}
@@ -2732,6 +2734,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2796,11 +2803,12 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -3685,6 +3693,16 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -4276,6 +4294,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -5132,6 +5151,10 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.2.9': {}
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6544,8 +6567,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.8.31: {}
-
   baseline-browser-mapping@2.9.13: {}
 
   brace-expansion@1.1.12:
@@ -6563,8 +6584,8 @@ snapshots:
 
   browserslist@4.28.0:
     dependencies:
-      baseline-browser-mapping: 2.8.31
-      caniuse-lite: 1.0.30001757
+      baseline-browser-mapping: 2.9.13
+      caniuse-lite: 1.0.30001763
       electron-to-chromium: 1.5.260
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.28.0)
@@ -6601,8 +6622,6 @@ snapshots:
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
-
-  caniuse-lite@1.0.30001757: {}
 
   caniuse-lite@1.0.30001763: {}
 
@@ -7178,6 +7197,9 @@ snapshots:
       mime-types: 2.1.35
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -8107,14 +8129,14 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-test-api-route-handler@5.0.3(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  next-test-api-route-handler@5.0.3(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
       '@whatwg-node/server': 0.10.17
       cookie: 1.1.1
       core-js: 3.47.0
-      next: 16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
@@ -8133,6 +8155,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.1
       '@next/swc-win32-arm64-msvc': 16.1.1
       '@next/swc-win32-x64-msvc': 16.1.1
+      '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -8281,6 +8304,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/quotevote-frontend/pnpm-workspace.yaml
+++ b/quotevote-frontend/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  core-js: true
+  sharp: true
+  unrs-resolver: true

--- a/quotevote-frontend/src/app/components/Eyebrow/Eyebrow.tsx
+++ b/quotevote-frontend/src/app/components/Eyebrow/Eyebrow.tsx
@@ -125,10 +125,15 @@ export function Eyebrow() {
         email={watch("email")}
       />
       <div className="relative bg-white z-40 shadow-sm border-b border-gray-200">
-        <div className="mx-auto px-6 pr-12 sm:pr-14 py-3 w-full flex flex-col sm:flex-row items-start justify-between gap-3">
+        <form
+          data-testid="eyebrow-email-form"
+          onSubmit={handleSubmit(handleContinue)}
+          className="mx-auto px-6 pr-12 sm:pr-14 py-3 w-full flex flex-col sm:flex-row items-start justify-between gap-3"
+        >
           <div className="flex flex-col gap-1.5 grow w-full">
             <Input
               id="email"
+              data-testid="eyebrow-email-input"
               type="email"
               placeholder="Enter your email"
               className="w-full"
@@ -149,14 +154,13 @@ export function Eyebrow() {
           </div>
 
           <Button
-            onClick={handleSubmit(handleContinue)}
+            data-testid="eyebrow-email-submit"
             disabled={!isValid || isLoading}
             type="submit"
             className="mx-auto w-full sm:w-fit"
           >
             Continue
           </Button>
-
           {errors.email && (
             <div className="min-h-4 text-[13px] block sm:hidden text-red-500">
               <span>{errors.email.message}</span>
@@ -167,7 +171,7 @@ export function Eyebrow() {
               <span>{feedback}</span>
             </div>
           )}
-        </div>
+        </form>
         <button
           type="button"
           onClick={() => setIsDismissed(true)}

--- a/quotevote-frontend/src/app/components/Eyebrow/LoginOptionsModal.tsx
+++ b/quotevote-frontend/src/app/components/Eyebrow/LoginOptionsModal.tsx
@@ -21,13 +21,15 @@ const LoginOptionsModal = ({ email, isOpen, onClose }: LoginOptionsModalProps) =
           e.preventDefault();
         }}
       >
-        <DialogHeader>
-          <DialogTitle>We recognize this email.</DialogTitle>
+       <DialogHeader>
+          <DialogTitle data-testid="registered-user-message">We recognize this email.</DialogTitle>
           <DialogDescription>Choose how you&apos;d like to log in</DialogDescription>
         </DialogHeader>
         <div className="grid gap-3">
-          <Button className="w-full">Send me a login link</Button>
-          <Button variant="outline" className="w-full">
+          <Button data-testid="magic-link-login-option" className="w-full">
+            Send me a login link
+          </Button>
+          <Button data-testid="password-login-option" variant="outline" className="w-full">
             Login with password
           </Button>
         </div>

--- a/quotevote-frontend/src/app/layout.tsx
+++ b/quotevote-frontend/src/app/layout.tsx
@@ -8,7 +8,7 @@ import { AuthModalProvider } from "@/context/AuthModalContext";
 import { AuthGateDialog } from "@/components/AuthGateDialog";
 import { ThemeContextProvider } from "@/context/ThemeContext";
 import { cn } from "@/lib/utils";
-// import { Eyebrow } from "./components/Eyebrow/Eyebrow";
+import { Eyebrow } from "./components/Eyebrow/Eyebrow";
 import "./globals.css";
 
 /**
@@ -69,7 +69,7 @@ export default function RootLayout({
           <ApolloProviderWrapper>
             <ThemeContextProvider>
               <AuthModalProvider>
-                {/* <Eyebrow /> */}
+                <Eyebrow />
                 {children}
                 <AuthGateDialog />
                 <Toaster position="top-right" richColors />


### PR DESCRIPTION
## Summary 
Fixes issue #398 
This PR introduces Playwright end-to-end testing for the eyebrow email gateway when accessed by a logged-out visitor using an existing registered user's email. It also resolves a blocking layout issue preventing the gateway from rendering.

## Changes Implemented
- **Fixes & Enhancements:**
  - Uncommmented and mounted the `<Eyebrow />` component within the root layout.
  - Refactored the email gateway submission from an unstable `div + onClick` setup to a semantic `<form onSubmit>`, resolving accessibility and enabling native Enter key form submission.
- **Testing Infrastructure:**
  - Initialized Playwright configuration (`playwright.config.ts`) targeting **Desktop Chrome** and **Mobile Chrome (Pixel 7)**.
  - Isolated the `e2e/` directory inside `jest.config.js` (`testPathIgnorePatterns`) so Jest doesn't inadvertently try to parse Playwright specs.
  - Added new execution script shortcuts to `package.json` (`pnpm test:e2e`, etc.).
- **Test Implementation:**
  - Added `e2e/auth.spec.ts` tracking all user flows and explicit criteria mentioned in the ticket.
  - Created network interception layer via `mockRegisteredEmailCheck()` to substitute for the pending backend endpoint `/auth/check-email`.
  - Provisioned the `registeredUser` account fixture.

## Verification Checklist
- [x] Full Jest unit suite passes locally (`154/155` units passing — the singular failure on `SettingsContent` is a pre-existing flake verified independent of this branch).
- [x] Playwright specs pass natively across both Desktop and Mobile configurations.
- [x] Code quality verified via `pnpm lint` and `pnpm type-check`.

## Notes for Reviewers
- The backend implementation for `/auth/check-email` hasn't shipped yet. The test safely mocks this interaction at the network layer. A tracking comment has been left inside `auth.spec.ts` indicating where to swap the mock for a real seeded DB record once available.
- The interaction states inside `LoginOptionsModal` are currently functional stubs—handling actual login completions is explicitly designated as out-of-scope for this specific issue.