### PR TITLE
fix(chat): rename "Group Chat" label to "Discussion" in discussion surfaces (RC1-025)

### DIFF
--- a/quotevote-frontend/src/components/Chat/ChatList.tsx
+++ b/quotevote-frontend/src/components/Chat/ChatList.tsx
@@ -108,7 +108,7 @@ const ChatList: React.FC<ChatListProps> = ({ search = '', filterType }) => {
       };
     } else {
       return {
-        name: room.title || 'Group Chat',
+        name: room.title || 'Discussion',
         avatar: resolveAvatar(room.avatar),
         subtitle: `${room.users?.length || 0} members`,
         isGroup: true,
@@ -209,4 +209,3 @@ const ChatList: React.FC<ChatListProps> = ({ search = '', filterType }) => {
 };
 
 export default ChatList;
-

--- a/quotevote-frontend/src/components/Chat/MessageBox.tsx
+++ b/quotevote-frontend/src/components/Chat/MessageBox.tsx
@@ -152,7 +152,7 @@ function Header({ room }: HeaderProps) {
               {title || 'Chat'}
             </div>
             <div className="mt-0.5 text-[0.8125rem] text-muted-foreground">
-              {isUserRoom ? 'Direct Message' : 'Group Chat'}
+              {isUserRoom ? 'Direct Message' : 'Discussion'}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Updates user-facing chat copy from **"Group Chat"** to **"Discussion"** in frontend discussion chat contexts to align with product language.

Branch: fix-RC1-025-rename-group-chat → main
Closes: https://github.com/QuoteVote/quotevote-next/issues/377
Labels: bug rc1 chat copy frontend

## Changes
- Replaced user-facing `"Group Chat"` label with `"Discussion"` in relevant discussion chat UI surfaces.
- Kept internal identifiers and non-user-facing names unchanged.

## Why
This aligns chat terminology with the expected product language for RC1-025.

## Scope
- Frontend chat copy only (no behavior or logic changes).

## Testing
- Manually verified discussion chat UI shows **"Discussion"**.
- Searched UI-facing frontend copy for remaining **"Group Chat"** references.