### PR TITLE
Fix highlight popup comment input focus and empty send behavior (#381) 

### DIFF
--- a/quotevote-frontend/src/__tests__/components/VotingComponents/VotingPopup.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/VotingPopup.test.tsx
@@ -257,8 +257,8 @@ describe('VotingPopup', () => {
     const input = screen.getByPlaceholderText('Type comment here')
     fireEvent.change(input, { target: { value: 'Test comment' } })
 
-    // Press Enter - component uses onKeyPress
-    fireEvent.keyPress(input, { key: 'Enter', code: 'Enter', charCode: 13, keyCode: 13 })
+    // Press Enter - component uses onKeyDown
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', charCode: 13, keyCode: 13 })
 
     await waitFor(() => {
       expect(onAddComment).toHaveBeenCalledWith('Test comment', true)
@@ -302,6 +302,60 @@ describe('VotingPopup', () => {
 
     await waitFor(() => {
       expect(onAddComment).toHaveBeenCalledWith('Test comment', false)
+    })
+  })
+
+  it('shows validation error when submitting an empty comment', async () => {
+    const onAddComment = jest.fn()
+    render(<VotingPopup {...defaultProps} onAddComment={onAddComment} />)
+
+    const commentButton = screen
+      .getByTestId('comment-icon')
+      .closest('button')
+    if (commentButton) {
+      fireEvent.click(commentButton)
+    }
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Type comment here')).toBeInTheDocument()
+    })
+
+    const sendButton = screen.getByText('Send')
+    fireEvent.click(sendButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Please enter a comment')).toBeInTheDocument()
+    })
+    expect(onAddComment).not.toHaveBeenCalled()
+  })
+
+  it('clears validation error when user types', async () => {
+    const onAddComment = jest.fn()
+    render(<VotingPopup {...defaultProps} onAddComment={onAddComment} />)
+
+    const commentButton = screen
+      .getByTestId('comment-icon')
+      .closest('button')
+    if (commentButton) {
+      fireEvent.click(commentButton)
+    }
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Type comment here')).toBeInTheDocument()
+    })
+
+    const sendButton = screen.getByText('Send')
+    fireEvent.click(sendButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Please enter a comment')).toBeInTheDocument()
+    })
+
+    const input = screen.getByPlaceholderText('Type comment here')
+    fireEvent.change(input, { target: { value: 'New comment' } })
+
+    await waitFor(() => {
+      expect(screen.queryByText('Please enter a comment')).not.toBeInTheDocument()
     })
   })
 

--- a/quotevote-frontend/src/components/Post/Post.tsx
+++ b/quotevote-frontend/src/components/Post/Post.tsx
@@ -196,11 +196,15 @@ export default function Post({
 
   const handleAddComment = async (comment: string, commentWithQuote = false) => {
     if (!ensureAuth()) return
+    if (!comment.trim()) {
+      toast.error('Please enter a comment')
+      return
+    }
     try {
       await addComment({
         variables: {
           comment: {
-            userId: user._id, content: comment,
+            userId: user._id, content: comment.trim(),
             startWordIndex: selectedText.startIndex, endWordIndex: selectedText.endIndex,
             postId: _id, url: post.url,
             quote: commentWithQuote ? selectedText.text : '',

--- a/quotevote-frontend/src/components/VotingComponents/VotingPopup.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/VotingPopup.tsx
@@ -37,6 +37,7 @@ export default function VotingPopup({
     type: '',
   })
   const [comment, setComment] = useState('')
+  const [validationError, setValidationError] = useState('')
   const [checkWindowWidth, setCheckWindowWidth] = useState(() => {
     if (typeof window !== 'undefined') {
       return window.innerWidth >= 400
@@ -58,6 +59,13 @@ export default function VotingPopup({
       window.removeEventListener('resize', handleWindowSizeChange)
     }
   }, [handleWindowSizeChange])
+
+  const handleSetExpand = useCallback((newExpand: { open: boolean; type: string }) => {
+    if (!newExpand.open || newExpand.type !== 'comment') {
+      setValidationError('')
+    }
+    setExpand(newExpand)
+  }, [])
 
   const voteOptions: VoteOption[] = (() => {
     if (expand.type === 'up') {
@@ -87,27 +95,41 @@ export default function VotingPopup({
         return // Don't allow voting if user has already voted
       }
       onVote({ type: expand.type as VoteType, tags })
-      setExpand({ open: false, type: '' })
+      handleSetExpand({ open: false, type: '' })
     },
-    [hasVoted, expand.type, onVote],
+    [hasVoted, expand.type, onVote, handleSetExpand],
   )
 
   const handleAddComment = useCallback(() => {
+    if (!comment.trim()) {
+      setValidationError('Please enter a comment')
+      return
+    }
     const withQuote = !isEmpty(selectedText.text)
-    onAddComment(comment, withQuote)
+    onAddComment(comment.trim(), withQuote)
     setComment('')
-    setExpand({ open: false, type: '' })
-  }, [comment, selectedText.text, onAddComment])
+    handleSetExpand({ open: false, type: '' })
+  }, [comment, selectedText.text, onAddComment, handleSetExpand])
 
   const handleAddQuote = useCallback(() => {
     onAddQuote()
-    setExpand({ open: false, type: '' })
-  }, [onAddQuote])
+    handleSetExpand({ open: false, type: '' })
+  }, [onAddQuote, handleSetExpand])
 
   useEffect(() => {
     const selectionPopover = document.querySelector('#popButtons')
     if (selectionPopover) {
       const handleMouseDown = (e: Event) => {
+        const target = e.target as HTMLElement
+        if (
+          target &&
+          (target.tagName === 'INPUT' ||
+            target.tagName === 'TEXTAREA' ||
+            target.isContentEditable ||
+            target.closest('input, textarea'))
+        ) {
+          return
+        }
         e.preventDefault()
       }
       selectionPopover.addEventListener('mousedown', handleMouseDown)
@@ -121,15 +143,6 @@ export default function VotingPopup({
   }, [])
 
   const isComment = expand.type === 'comment'
-  let inputValue = comment
-
-  if (!isComment) {
-    if (expand.type === 'up') {
-      inputValue = '#true | #agree | #like'
-    } else if (expand.type === 'down') {
-      inputValue = '#false | #disagree | #dislike'
-    }
-  }
 
   const voteTooltipText = hasVoted
     ? `You have already ${userVoteType === 'up' ? 'upvoted' : 'downvoted'} this post`
@@ -190,7 +203,7 @@ export default function VotingPopup({
                 aria-label="Upvote"
                 onClick={() => {
                   if (!hasVoted) {
-                    setExpand({
+                    handleSetExpand({
                       open: expand.type !== 'up' || !expand.open,
                       type: 'up',
                     })
@@ -246,7 +259,7 @@ export default function VotingPopup({
                 aria-label="Downvote"
                 onClick={() => {
                   if (!hasVoted) {
-                    setExpand({
+                    handleSetExpand({
                       open: expand.type !== 'down' || !expand.open,
                       type: 'down',
                     })
@@ -270,7 +283,7 @@ export default function VotingPopup({
               size="icon"
               aria-label="Comment"
               onClick={() =>
-                setExpand({
+                handleSetExpand({
                   open: expand.type !== 'comment' || !expand.open,
                   type: 'comment',
                 })
@@ -293,7 +306,7 @@ export default function VotingPopup({
               aria-label="Quote"
               onClick={() => {
                 const newQuote = expand.type !== 'quote'
-                setExpand({ open: false, type: newQuote ? 'quote' : '' })
+                handleSetExpand({ open: false, type: newQuote ? 'quote' : '' })
                 if (newQuote) {
                   handleAddQuote()
                 }
@@ -321,25 +334,40 @@ export default function VotingPopup({
         }}
       >
         {isComment ? (
-          <div className="flex items-center gap-2">
-            <Input
-              placeholder="Type comment here"
-              value={inputValue}
-              onChange={(e) => setComment(e.target.value)}
-              className="flex-1 text-[#3c4858cc] pb-1"
-              onKeyPress={(event) => {
-                if (event.key === 'Enter') {
-                  handleAddComment()
-                }
-              }}
-            />
-            <Button
-              onClick={handleAddComment}
-              className="bg-[#52b274] text-white hover:bg-[#52b274]/90"
-              size="sm"
-            >
-              Send
-            </Button>
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center gap-2">
+              <Input
+                placeholder="Type comment here"
+                value={comment}
+                onChange={(e) => {
+                  setComment(e.target.value)
+                  if (validationError) {
+                    setValidationError('')
+                  }
+                }}
+                className={cn(
+                  'flex-1 text-[#3c4858cc] pb-1',
+                  validationError && 'border-destructive focus-visible:ring-destructive',
+                )}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && !event.shiftKey) {
+                    event.preventDefault()
+                    handleAddComment()
+                  }
+                }}
+                autoFocus
+              />
+              <Button
+                onClick={handleAddComment}
+                className="bg-[#52b274] text-white hover:bg-[#52b274]/90"
+                size="sm"
+              >
+                Send
+              </Button>
+            </div>
+            {validationError && (
+              <p className="text-xs text-destructive m-0 px-1">{validationError}</p>
+            )}
           </div>
         ) : (
           <div className="flex flex-col items-center gap-2">


### PR DESCRIPTION
# Fix highlight popup comment input focus and empty send behavior (#381)

## 📋 Summary

This pull request resolves **Issue #381 (RC1-029)** by fixing input responsiveness and state handling within the text highlight popup (`VotingPopup`). Previously, clicking into the comment input box was unresponsive due to aggressive `e.preventDefault()` calls, and submitting empty comments resulted in failing GraphQL requests and generic error toasts.

This update restores natural browser focus/cursor behavior, implements clean controlled React state handling without ESLint side-effect warnings, and adds clear inline validation for empty comment submissions.

---

## 🛠️ Key Changes

### 1. Fixed Input Focus & Cursor Placement ([[VotingPopup.tsx](file:///home/ximarelli/Projects/quotevote-next/quotevote-frontend/src/components/VotingComponents/VotingPopup.tsx#L105-L122)](file:///home/ximarelli/Projects/quotevote-next/quotevote-frontend/src/components/VotingComponents/VotingPopup.tsx#L105-L122))

- **Problem**: A `mousedown` event listener attached to `#popButtons` unconditionally called `e.preventDefault()` to prevent text selection from clearing. This inadvertently prevented the browser from focusing interactive form elements or placing the text cursor inside `<Input />`.
- **Fix**: Updated `handleMouseDown` to check if the click target is an `<input>`, `<textarea>`, or contenteditable element before invoking `e.preventDefault()`.
- **UX Enhancement**: Added `autoFocus` to the comment `<Input />` component so the input field receives immediate focus when the user clicks the comment icon.

### 2. Cleaned Up Controlled State & Fixed ESLint Error ([[VotingPopup.tsx](file:///home/ximarelli/Projects/quotevote-next/quotevote-frontend/src/components/VotingComponents/VotingPopup.tsx#L63-L115)](file:///home/ximarelli/Projects/quotevote-next/quotevote-frontend/src/components/VotingComponents/VotingPopup.tsx#L63-L115))

- **Problem**: Legacy code attempted to assign tag strings to `inputValue` when not in comment mode, creating confusing state handling. Furthermore, resetting validation errors inside `useEffect` triggered React 19 / ESLint cascading render warnings (`react-hooks/set-state-in-effect`).
- **Fix**: Removed dead tag assignment logic to guarantee `<Input />` is cleanly controlled via the `comment` state string. Replaced direct `setExpand` calls with an event-driven `handleSetExpand` wrapper that cleanly clears validation errors during user interactions without triggering side effects.

### 3. Inline & Toast Validation for Empty Submissions ([[VotingPopup.tsx](file:///home/ximarelli/Projects/quotevote-next/quotevote-frontend/src/components/VotingComponents/VotingPopup.tsx#L101-L109)](file:///home/ximarelli/Projects/quotevote-next/quotevote-frontend/src/components/VotingComponents/VotingPopup.tsx#L101-L109) & [[Post.tsx](file:///home/ximarelli/Projects/quotevote-next/quotevote-frontend/src/components/Post/Post.tsx#L198-L205)](file:///home/ximarelli/Projects/quotevote-next/quotevote-frontend/src/components/Post/Post.tsx#L198-L205))

- **Problem**: Pressing Enter or clicking **Send** with an empty or whitespace-only string fired `onAddComment`, triggering a GraphQL mutation that failed on the backend and threw a generic `Error: ...` toast.
- **Fix**: 
  - Added inline validation in `VotingPopup`: Submitting an empty comment is now blocked and displays a clean inline error message (`"Please enter a comment"`) directly below the input field. Typing any text automatically clears the error state.
  - Added a safeguard check in `Post.tsx` (`handleAddComment`) so any empty submission attempts trigger a clean validation toast rather than an API error.

---

## 🧪 Test Coverage & Verification

### Automated Tests

- Updated [[VotingPopup.test.tsx](file:///home/ximarelli/Projects/quotevote-next/quotevote-frontend/src/__tests__/components/VotingComponents/VotingPopup.test.tsx#L307-L360)](file:///home/ximarelli/Projects/quotevote-next/quotevote-frontend/src/__tests__/components/VotingComponents/VotingPopup.test.tsx#L307-L360) with new unit tests:
  - `shows validation error when submitting an empty comment`: Confirms that empty submissions display inline validation and do NOT invoke `onAddComment`.
  - `clears validation error when user types`: Confirms that typing into the input field clears active validation errors.
  - Upgraded Enter key submission tests to use standard `onKeyDown` event handling.
- **Verification Results**:
  - `pnpm test VotingPopup` — **19/19 tests passing**
  - `pnpm test Post` — **11/11 tests passing**
  - `pnpm lint` — **0 errors**

### How to Test Locally

1. Highlight any text within a post to open the floating selection toolbar.
2. Click the **Comment** icon. Verify the input field automatically gains focus and allows immediate typing.
3. Without typing anything (or entering only spaces), press **Enter** or click **Send**.
4. Confirm that submission is blocked and the inline error message `"Please enter a comment"` appears in red below the input box.
5. Start typing a comment. Confirm the red inline error message immediately disappears.
6. Click **Send** (or press Enter). Confirm the comment submits successfully without errors.

---

## 🔗 Related Issues

- Closes #381
- RC1-029