### PR TITLE
fix: Discussion post title should navigate to post page [RC1-024]

### DIFF
--- a/quotevote-frontend/src/__tests__/components/Chat/ChatList.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Chat/ChatList.test.tsx
@@ -15,6 +15,7 @@
 
 import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils'
 import ChatList from '@/components/Chat/ChatList'
+import { toAppPostUrl } from '@/lib/utils/sanitizeUrl'
 import { useAppStore } from '@/store'
 import { GET_CHAT_ROOMS } from '@/graphql/queries'
 
@@ -75,7 +76,11 @@ const groupRoom = {
   messageType: 'POST',
   users: ['user1', 'user2', 'user3'],
   created: new Date(Date.now() - 120_000).toISOString(),
-  postDetails: { _id: 'post1', title: 'Interesting Quote', text: 'Some post text here.' },
+  postDetails: {
+    title: 'Interesting Quote',
+    text: 'Some post text here.',
+    url: '/post/general/interesting-quote/post1',
+  },
   avatar: null,
 }
 
@@ -207,10 +212,33 @@ describe('ChatList', () => {
       expect(screen.getByText('Jane Doe')).toBeInTheDocument()
     })
 
-    const roomButton = screen.getByText('Jane Doe').closest('button')!
+    const roomButton = screen.getByTestId('discussion-thread')
     fireEvent.click(roomButton)
 
     expect(mockSetSelectedChatRoom).toHaveBeenCalledWith('room-dm-1')
+  })
+
+  it('renders POST room title as post link in the list view', async () => {
+    render(<ChatList filterType="groups" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Interesting Quote')).toBeInTheDocument()
+    })
+
+    const postLink = screen.getByRole('link', { name: 'Interesting Quote' })
+    expect(postLink).toHaveAttribute('href', toAppPostUrl('/post/general/interesting-quote/post1'))
+  })
+
+  it('does not select chat room when clicking the post title link', async () => {
+    render(<ChatList filterType="groups" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Interesting Quote')).toBeInTheDocument()
+    })
+
+    const postLink = screen.getByRole('link', { name: 'Interesting Quote' })
+    fireEvent.click(postLink)
+    expect(mockSetSelectedChatRoom).not.toHaveBeenCalled()
   })
 
   // ── Selected room highlight ──────────────────────────────────────────────
@@ -228,7 +256,7 @@ describe('ChatList', () => {
     render(<ChatList filterType="chats" />)
 
     await waitFor(() => {
-      const roomButton = screen.getByText('Jane Doe').closest('button')
+      const roomButton = screen.getByTestId('discussion-thread')
       expect(roomButton?.className).toContain('border-[#52b274]')
     })
   })

--- a/quotevote-frontend/src/components/Chat/ChatList.tsx
+++ b/quotevote-frontend/src/components/Chat/ChatList.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useEffect } from 'react';
+import Link from 'next/link';
 import { useQuery } from '@apollo/client/react';
 import { MessageCircle, Users2 } from 'lucide-react';
 
 import { GET_CHAT_ROOMS } from '@/graphql/queries';
+import { toAppPostUrl } from '@/lib/utils/sanitizeUrl';
 import { useAppStore } from '@/store';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { DisplayAvatar } from '@/components/DisplayAvatar';
@@ -145,6 +147,10 @@ const ChatList: React.FC<ChatListProps> = ({ search = '', filterType }) => {
         {sortedRooms.map((room) => {
           const displayInfo = getRoomDisplayInfo(room);
           const isSelected = typeof selectedRoomId === 'string' && selectedRoomId === room._id;
+          const postHref =
+            room.messageType === 'POST' && room.postDetails?.url
+              ? toAppPostUrl(room.postDetails.url)
+              : null;
 
           const isDm = room.messageType === 'USER' && (room.users?.length ?? 0) === 2;
 
@@ -170,9 +176,24 @@ const ChatList: React.FC<ChatListProps> = ({ search = '', filterType }) => {
 
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
-                    <span className="truncate text-sm font-semibold text-foreground">
-                      {displayInfo.name}
-                    </span>
+                    {postHref ? (
+                      <Link
+                        href={postHref}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                        }}
+                        onKeyDown={(e) => {
+                          e.stopPropagation();
+                        }}
+                        className="truncate text-sm font-semibold text-foreground hover:underline"
+                      >
+                        {displayInfo.name}
+                      </Link>
+                    ) : (
+                      <span className="truncate text-sm font-semibold text-foreground">
+                        {displayInfo.name}
+                      </span>
+                    )}
                     <span
                       className={
                         'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ' +

--- a/quotevote-frontend/src/graphql/queries.ts
+++ b/quotevote-frontend/src/graphql/queries.ts
@@ -612,6 +612,7 @@ export const GET_CHAT_ROOMS = gql`
       postDetails {
         title
         text
+        url
       }
     }
   }

--- a/quotevote-frontend/src/types/chat.ts
+++ b/quotevote-frontend/src/types/chat.ts
@@ -94,6 +94,7 @@ export interface ChatRoom {
         _id?: string
         title?: string | null
         text?: string | null
+        url?: string | null
     } | null
 }
 


### PR DESCRIPTION
**Closes:** #376   
**Labels:** `bug` `rc1` `chat` `discussion` `routing`

---

### Summary
Clicking a post title in the Discussions chat should navigate to the related post page.

### Acceptance Criteria

- Update discussion title component to render a link.
- Ensure post ID/slug is available in discussion data.
- Prevent nested click conflicts with chat controls.
- Add regression coverage.

### Test Results
 PASS  src/__tests__/components/Chat/ChatList.test.tsx
  ChatList
    ✓ renders loading spinner when loading and no cached data (11 ms)
    ✓ renders direct message rooms when filterType is "chats" (7 ms)
    ✓ shows DM badge label for USER rooms (4 ms)
    ✓ renders group rooms when filterType is "groups" (2 ms)
    ✓ shows Group badge label for POST rooms (4 ms)
    ✓ filters rooms by search query (case-insensitive) (3 ms)
    ✓ shows empty state when search matches nothing (2 ms)
    ✓ calls setSelectedChatRoom with room._id when a room is clicked (4 ms)
    ✓ renders POST room title as post link in the list view (29 ms)
    ✓ does not select chat room when clicking the post title link (6 ms)
    ✓ applies selected styling to the currently active room (5 ms)
    ✓ renders unread count badge when a room has unread messages (2 ms)
    ✓ renders "99+" badge when unread count exceeds 99 (2 ms)
    ✓ does not render unread badge when unreadMessages is 0 (3 ms)
    ✓ shows "No chats yet" heading when there are no chats (2 ms)
    ✓ shows "No groups yet" heading when there are no groups (2 ms)
    ✓ renders an avatar image when the room has an avatar URL (3 ms)
    ✓ renders a fallback icon when the room has no avatar (2 ms)
    ✓ calls useQuery with GET_CHAT_ROOMS (2 ms)

Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total