### PR TITLE
test(e2e): E2E-POST-003 post submission validation

### DIFF
--- a/quotevote-frontend/e2e/helpers/post-composer.ts
+++ b/quotevote-frontend/e2e/helpers/post-composer.ts
@@ -1,0 +1,48 @@
+import { expect, type Page } from '@playwright/test';
+
+export const PUBLIC_GROUP_NAME = process.env.E2E_PUBLIC_GROUP_NAME ?? 'Public';
+
+export async function openPostComposer(page: Page): Promise<void> {
+  const createButton = page.getByTestId('create-post-button').locator('visible=true');
+  await createButton.click();
+
+  const composer = page.getByTestId('post-composer');
+  await expect(composer).toBeVisible();
+}
+
+export async function selectPostGroup(page: Page, groupName = PUBLIC_GROUP_NAME): Promise<void> {
+  await page.getByTestId('post-group-select').click();
+  await page.getByPlaceholder('Search or type new group name...').fill(groupName);
+  await page.getByRole('button', { name: groupName, exact: true }).click();
+}
+
+export async function assertComposerRemainsOpen(page: Page): Promise<void> {
+  await expect(page.getByTestId('post-composer')).toBeVisible();
+  await expect(page).not.toHaveURL(/\/dashboard\/post\/[^/]+\/[^/]+\/[^/?#]+/);
+  await expect(page.locator('[data-sonner-toast][data-type="success"]')).toHaveCount(0);
+}
+
+export async function assertPostTitleNotVisibleOnPage(
+  page: Page,
+  titleMarker: string
+): Promise<void> {
+  await expect(page.locator(`[data-post-title="${titleMarker}"]`)).toHaveCount(0);
+}
+
+export async function assertInvalidPostNotPublished(
+  page: Page,
+  titleMarker: string,
+  groupName = PUBLIC_GROUP_NAME
+): Promise<void> {
+  const surfaces = [
+    '/dashboard/explore',
+    '/dashboard/post',
+    '/dashboard/profile',
+    `/dashboard/explore?q=${encodeURIComponent(groupName)}`,
+  ];
+
+  for (const path of surfaces) {
+    await page.goto(path);
+    await assertPostTitleNotVisibleOnPage(page, titleMarker);
+  }
+}

--- a/quotevote-frontend/e2e/post-submission.spec.ts
+++ b/quotevote-frontend/e2e/post-submission.spec.ts
@@ -1,105 +1,95 @@
 /**
- * E2E-POST-001 — Create Public Post
+ * E2E-POST-003 — Post Validation
  *
  * Sheet mapping:
- * - Feature: Create Public Post
+ * - Feature Area: Post Submission
+ * - Scenario: Post Validation
+ * - Priority: P0
  * - Actor: Registered User (authorUser)
  * - Auth State: Logged in (precondition via global-setup storageState)
- * - Steps: Open composer → enter title/text → select Public → submit
- * - Expected: Post created, unique URL, appears in relevant lists
- * - Playwright notes: Assert post title/text on detail page
  * - Viewports: Desktop, Mobile (playwright.config.ts projects)
+ *
+ * Confirms required-field validation blocks submission, shows inline field errors
+ * for title, body, and group, keeps the user in the composer, and never creates
+ * an incomplete post.
  */
 import { test, expect } from '@playwright/test';
-import { deletePostViaApi, loginViaApi } from './helpers/api';
-import { AUTHOR_PASSWORD, AUTHOR_USERNAME } from './helpers/auth';
+import { AUTHOR_PASSWORD } from './helpers/auth';
+import {
+  assertComposerRemainsOpen,
+  assertInvalidPostNotPublished,
+  openPostComposer,
+  selectPostGroup,
+} from './helpers/post-composer';
 
-const PUBLIC_GROUP_NAME = process.env.E2E_PUBLIC_GROUP_NAME ?? 'Public';
-
-test.describe('E2E-POST-001: Create Public Post', () => {
+test.describe('E2E-POST-003: Post Validation', () => {
   test.skip(!AUTHOR_PASSWORD, 'E2E_AUTHOR_PASSWORD is required');
 
-  let createdPostId: string | null = null;
-  let authToken: string | null = null;
-
-  test.beforeAll(async () => {
-    const session = await loginViaApi(AUTHOR_USERNAME, AUTHOR_PASSWORD);
-    authToken = session.token;
-  });
-
-  test.afterEach(async () => {
-    if (createdPostId && authToken) {
-      await deletePostViaApi(createdPostId, authToken);
-      createdPostId = null;
-    }
-  });
-
-  test('creates a public text post and verifies detail page', async ({ page }) => {
+  test('blocks submission and shows inline validation for missing required fields', async ({
+    page,
+  }) => {
     const uniqueSuffix = `${Date.now()}-${test.info().project.name}`;
-    const postTitle = `E2E-POST-001 ${uniqueSuffix}`;
-    const postBody = `Automated post body for ${uniqueSuffix}. Sharing thoughts for feedback.`;
+    const attemptedTitle = `E2E-POST-003-title-${uniqueSuffix}`;
+    const attemptedBody = `E2E-POST-003-body-${uniqueSuffix}`;
 
-    // Precondition: user is already authenticated (storageState from global setup)
+    // Step 1: Log in as authorUser (precondition via global-setup storageState)
     await page.goto('/dashboard/explore');
     await expect(page).toHaveURL(/\/dashboard\/explore/);
 
-    // Step: open composer
-    const createButton = page.getByTestId('create-post-button').locator('visible=true');
-    await createButton.click();
-
+    // Step 2: Open the post composer
+    await openPostComposer(page);
     const composer = page.getByTestId('post-composer');
-    await expect(composer).toBeVisible();
 
-    // Step: enter title and text
-    const titleInput = page.getByTestId('post-title-input');
-    const bodyInput = page.getByTestId('post-body-input');
-    await titleInput.fill(postTitle);
-    await bodyInput.fill(postBody);
+    // Step 3: Attempt submit with empty title, body, and group
+    await page.getByTestId('post-submit-button').click();
 
-    await expect(titleInput).toHaveValue(postTitle);
-    await expect(bodyInput).toHaveValue(postBody);
+    await expect(page.getByTestId('post-title-error')).toBeVisible();
+    await expect(page.getByTestId('post-title-error')).toHaveText('Title is required');
+    await expect(page.getByTestId('post-body-error')).toBeVisible();
+    await expect(page.getByTestId('post-body-error')).toHaveText('Post content is required');
+    await expect(page.getByTestId('post-group-error')).toBeVisible();
+    await expect(page.getByTestId('post-group-error')).toHaveText('Please select or create a group');
+    await assertComposerRemainsOpen(page);
 
-    // Step: select Public group
-    const groupSelect = page.getByTestId('post-group-select');
-    await groupSelect.click();
+    // Step 4: Enter title and body but leave group unselected, then submit again
+    await page.getByTestId('post-title-input').fill(attemptedTitle);
+    await page.getByTestId('post-body-input').fill(attemptedBody);
+    await page.getByTestId('post-submit-button').click();
 
-    const groupSearch = page.getByPlaceholder('Search or type new group name...');
-    await groupSearch.fill(PUBLIC_GROUP_NAME);
+    await expect(page.getByTestId('post-group-error')).toBeVisible();
+    await expect(page.getByTestId('post-group-error')).toHaveText('Please select or create a group');
+    await expect(page.getByTestId('post-title-error')).toHaveCount(0);
+    await expect(page.getByTestId('post-body-error')).toHaveCount(0);
+    await assertComposerRemainsOpen(page);
 
-    const publicGroupOption = page.getByRole('button', { name: PUBLIC_GROUP_NAME, exact: true });
-    await expect(publicGroupOption).toBeVisible();
-    await publicGroupOption.click();
+    // Step 5: Select group but leave body empty, then submit again
+    await selectPostGroup(page);
+    await page.getByTestId('post-body-input').fill('');
+    await page.getByTestId('post-submit-button').click();
 
-    // Step: submit
-    const submitButton = page.getByTestId('post-submit-button');
-    await expect(submitButton).toBeEnabled();
-    await submitButton.click();
+    await expect(page.getByTestId('post-body-error')).toBeVisible();
+    await expect(page.getByTestId('post-body-error')).toHaveText('Post content is required');
+    await expect(page.getByTestId('post-title-error')).toHaveCount(0);
+    await expect(page.getByTestId('post-group-error')).toHaveCount(0);
+    await assertComposerRemainsOpen(page);
 
-    await expect(page.getByTestId('post-composer')).toBeHidden({ timeout: 30_000 });
+    // Step 6: Clear title, enter body text, then submit again
+    await page.getByTestId('post-title-input').fill('');
+    await page.getByTestId('post-body-input').fill(attemptedBody);
+    await page.getByTestId('post-submit-button').click();
+
+    await expect(page.getByTestId('post-title-error')).toBeVisible();
+    await expect(page.getByTestId('post-title-error')).toHaveText('Title is required');
+    await expect(page.getByTestId('post-body-error')).toHaveCount(0);
+    await expect(page.getByTestId('post-group-error')).toHaveCount(0);
+    await assertComposerRemainsOpen(page);
+
+    // Step 7: Confirm no post was created from any invalid submission attempt
+    await composer.getByRole('button').first().click();
+    await expect(composer).toBeHidden();
+    await assertInvalidPostNotPublished(page, attemptedTitle);
+
+    // Confirm no runtime error toast appears
     await expect(page.locator('[data-sonner-toast][data-type="error"]')).toHaveCount(0);
-    await expect(page).toHaveURL(/\/dashboard\/explore/, { timeout: 30_000 });
-
-    // Expected: post appears in a relevant list (explore/home feed)
-    const postCard = page.getByTestId('post-card').filter({ hasText: postTitle }).first();
-    await expect(postCard).toBeVisible({ timeout: 30_000 });
-
-    await postCard.click();
-
-    // Expected: unique post URL generated
-    await expect(page).toHaveURL(/\/dashboard\/post\/.+\/.+\/.+/, { timeout: 30_000 });
-
-    const postUrl = page.url();
-    const postIdMatch = postUrl.match(/\/dashboard\/post\/[^/]+\/[^/]+\/([^/?#]+)/);
-    expect(postIdMatch?.[1]).toBeTruthy();
-    createdPostId = postIdMatch![1];
-
-    // Playwright notes: assert title/text on detail page
-    await expect(page.getByTestId('post-detail-title')).toHaveText(postTitle);
-    await expect(page.getByTestId('post-detail-body')).toContainText(postBody);
-
-    await page.goto('/dashboard/explore');
-    await expect(
-      page.getByTestId('post-card').filter({ hasText: postTitle }).first()
-    ).toBeVisible({ timeout: 30_000 });
   });
 });

--- a/quotevote-frontend/e2e/post-submission.spec.ts
+++ b/quotevote-frontend/e2e/post-submission.spec.ts
@@ -1,26 +1,98 @@
 /**
- * E2E-POST-003 — Post Validation
+ * Post submission E2E specs (post-submission.spec.ts)
  *
- * Sheet mapping:
- * - Feature Area: Post Submission
- * - Scenario: Post Validation
- * - Priority: P0
- * - Actor: Registered User (authorUser)
- * - Auth State: Logged in (precondition via global-setup storageState)
- * - Viewports: Desktop, Mobile (playwright.config.ts projects)
+ * - E2E-POST-001: Create Public Post (happy path)
+ * - E2E-POST-003: Post Validation (required-field inline errors)
  *
- * Confirms required-field validation blocks submission, shows inline field errors
- * for title, body, and group, keeps the user in the composer, and never creates
- * an incomplete post.
+ * Actor: Registered User (authorUser)
+ * Auth State: Logged in (precondition via global-setup storageState)
+ * Viewports: Desktop, Mobile (playwright.config.ts projects)
  */
 import { test, expect } from '@playwright/test';
-import { AUTHOR_PASSWORD } from './helpers/auth';
+import { deletePostViaApi, loginViaApi } from './helpers/api';
+import { AUTHOR_PASSWORD, AUTHOR_USERNAME } from './helpers/auth';
 import {
   assertComposerRemainsOpen,
   assertInvalidPostNotPublished,
   openPostComposer,
   selectPostGroup,
 } from './helpers/post-composer';
+
+test.describe('E2E-POST-001: Create Public Post', () => {
+  test.skip(!AUTHOR_PASSWORD, 'E2E_AUTHOR_PASSWORD is required');
+
+  let createdPostId: string | null = null;
+  let authToken: string | null = null;
+
+  test.beforeAll(async () => {
+    const session = await loginViaApi(AUTHOR_USERNAME, AUTHOR_PASSWORD);
+    authToken = session.token;
+  });
+
+  test.afterEach(async () => {
+    if (createdPostId && authToken) {
+      await deletePostViaApi(createdPostId, authToken);
+      createdPostId = null;
+    }
+  });
+
+  test('creates a public text post and verifies detail page', async ({ page }) => {
+    const uniqueSuffix = `${Date.now()}-${test.info().project.name}`;
+    const postTitle = `E2E-POST-001 ${uniqueSuffix}`;
+    const postBody = `Automated post body for ${uniqueSuffix}. Sharing thoughts for feedback.`;
+
+    // Precondition: user is already authenticated (storageState from global setup)
+    await page.goto('/dashboard/explore');
+    await expect(page).toHaveURL(/\/dashboard\/explore/);
+
+    // Step: open composer
+    await openPostComposer(page);
+
+    // Step: enter title and text
+    const titleInput = page.getByTestId('post-title-input');
+    const bodyInput = page.getByTestId('post-body-input');
+    await titleInput.fill(postTitle);
+    await bodyInput.fill(postBody);
+
+    await expect(titleInput).toHaveValue(postTitle);
+    await expect(bodyInput).toHaveValue(postBody);
+
+    // Step: select Public group
+    await selectPostGroup(page);
+
+    // Step: submit
+    const submitButton = page.getByTestId('post-submit-button');
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    await expect(page.getByTestId('post-composer')).toBeHidden({ timeout: 30_000 });
+    await expect(page.locator('[data-sonner-toast][data-type="error"]')).toHaveCount(0);
+    await expect(page).toHaveURL(/\/dashboard\/explore/, { timeout: 30_000 });
+
+    // Expected: post appears in a relevant list (explore/home feed)
+    const postCard = page.getByTestId('post-card').filter({ hasText: postTitle }).first();
+    await expect(postCard).toBeVisible({ timeout: 30_000 });
+
+    await postCard.click();
+
+    // Expected: unique post URL generated
+    await expect(page).toHaveURL(/\/dashboard\/post\/.+\/.+\/.+/, { timeout: 30_000 });
+
+    const postUrl = page.url();
+    const postIdMatch = postUrl.match(/\/dashboard\/post\/[^/]+\/[^/]+\/([^/?#]+)/);
+    expect(postIdMatch?.[1]).toBeTruthy();
+    createdPostId = postIdMatch![1];
+
+    // Playwright notes: assert title/text on detail page
+    await expect(page.getByTestId('post-detail-title')).toHaveText(postTitle);
+    await expect(page.getByTestId('post-detail-body')).toContainText(postBody);
+
+    await page.goto('/dashboard/explore');
+    await expect(
+      page.getByTestId('post-card').filter({ hasText: postTitle }).first()
+    ).toBeVisible({ timeout: 30_000 });
+  });
+});
 
 test.describe('E2E-POST-003: Post Validation', () => {
   test.skip(!AUTHOR_PASSWORD, 'E2E_AUTHOR_PASSWORD is required');

--- a/quotevote-frontend/src/components/SubmitPost/SubmitPostForm.tsx
+++ b/quotevote-frontend/src/components/SubmitPost/SubmitPostForm.tsx
@@ -218,7 +218,9 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
                 className={cn('text-lg border-0 shadow-none px-0 focus-visible:ring-0 rounded-none', errors.title && 'border-b border-destructive')}
               />
               {errors.title && (
-                <p className="text-sm text-destructive mt-1">{errors.title.message}</p>
+                <p className="text-sm text-destructive mt-1" data-testid="post-title-error">
+                  {errors.title.message}
+                </p>
               )}
 
               <div className="border-t my-2" />
@@ -242,7 +244,12 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
                     className="flex items-center gap-2 bg-red-50 border border-red-400 rounded p-3 mt-2"
                   >
                     <AlertTriangle className="h-5 w-5 text-red-500 shrink-0" />
-                    <p className="text-sm text-red-600 font-medium">{errors.text.message}</p>
+                    <p
+                      className="text-sm text-red-600 font-medium"
+                      data-testid="post-body-error"
+                    >
+                      {errors.text.message}
+                    </p>
                   </div>
                 )}
               </div>
@@ -317,6 +324,7 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
                       label=""
                       error={!!errors.group}
                       errorMessage={errors.group?.message}
+                      errorTestId="post-group-error"
                       disabled={loadingGroup || loading}
                       allowCreate={true}
                       triggerTestId="post-group-select"

--- a/quotevote-frontend/src/components/ui/combobox.tsx
+++ b/quotevote-frontend/src/components/ui/combobox.tsx
@@ -28,6 +28,7 @@ export interface ComboboxProps {
   allowCreate?: boolean
   triggerTestId?: string
   createOptionTestId?: string
+  errorTestId?: string
 }
 
 export function Combobox({
@@ -43,6 +44,7 @@ export function Combobox({
   allowCreate = true,
   triggerTestId,
   createOptionTestId,
+  errorTestId,
 }: ComboboxProps) {
   const [open, setOpen] = React.useState(false)
   const [inputValue, setInputValue] = React.useState('')
@@ -201,7 +203,9 @@ export function Combobox({
       </Popover>
 
       {error && errorMessage && (
-        <p className="mt-1 text-sm text-destructive">{errorMessage}</p>
+        <p className="mt-1 text-sm text-destructive" data-testid={errorTestId}>
+          {errorMessage}
+        </p>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

- Adds **E2E-POST-003** Playwright coverage for post composer validation (P0)
- Asserts inline field-level errors for missing **title**, **body**, and **group** — not toast-only validation
- Adds stable `data-testid` selectors: `post-title-error`, `post-body-error`, `post-group-error`
- Introduces `e2e/helpers/post-composer.ts` for shared composer open/select/assert helpers

## Test coverage (E2E-POST-003)

| Step | Input state | Expected |
|------|-------------|----------|
| 1 | Empty title, body, group | All three inline errors |
| 2 | Title + body, no group | Group error only |
| 3 | Group + title, empty body | Body error only |
| 4 | Group + body, empty title | Title error only |

Also verifies:
- Composer stays open after each failed submit
- No post detail URL or success toast is generated
- Attempted title does not appear on explore, posts list, profile, or group-filtered explore
- Runs on **desktop** and **mobile** Playwright projects

## Test plan

- [x] `pnpm test:e2e post-submission.spec.ts --grep "E2E-POST-003"`
- [x] `pnpm test:e2e:headed post-submission.spec.ts` (desktop + mobile passed locally)
- [x] CI E2E passes with `E2E_AUTHOR_PASSWORD` secret configured

Closes #413