### PR TITLE
fix: Chat user avatar should navigate to profile [RC1-023]

### DIFF
--- a/quotevote-frontend/src/__tests__/components/Chat/MessageBox.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Chat/MessageBox.test.tsx
@@ -143,7 +143,20 @@ describe('MessageBox', () => {
       }
       if (query === GET_ROSTER) {
         return {
-          data: { roster: { buddies: [], pendingRequests: [], blockedUsers: [] } },
+          data: {
+            getRoster: [
+              {
+                _id: 'roster-1',
+                userId: 'user1',
+                buddyId: 'user2',
+                status: 'accepted',
+                buddy: {
+                  _id: 'user2',
+                  username: 'other-user',
+                },
+              },
+            ],
+          },
           loading: false,
           error: undefined,
         }
@@ -194,6 +207,60 @@ describe('MessageBox', () => {
     })
 
     expect(screen.getByText('Direct Message')).toBeInTheDocument()
+  })
+
+  it('renders avatar as a profile link when DM buddy username is available', async () => {
+    render(<MessageBox />)
+
+    const profileLink = await screen.findByRole('link', { name: 'Open other-user profile' })
+    expect(profileLink).toHaveAttribute('href', '/dashboard/profile/other-user')
+  })
+
+  it('renders avatar as a profile link for staged room username', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockUseAppStore.mockImplementation((selector: any) => {
+      const state = {
+        user: { data: mockCurrentUser },
+        chat: {
+          selectedRoom: {
+            _id: null,
+            title: 'Staged DM',
+            avatar: null,
+            messageType: 'USER',
+            users: ['user1', 'user3'],
+            username: 'staged user',
+          },
+          buddyList: [],
+          presenceMap: {},
+        },
+        setSelectedChatRoom: jest.fn(),
+        setSnackbar: jest.fn(),
+      }
+      return selector(state)
+    })
+
+    render(<MessageBox />)
+
+    const profileLink = await screen.findByRole('link', { name: 'Open staged user profile' })
+    expect(profileLink).toHaveAttribute('href', '/dashboard/profile/staged%20user')
+  })
+
+  it('does not render avatar as profile link for non-user rooms', async () => {
+    const groupRoom: ChatRoom = {
+      _id: 'group-room-1',
+      title: 'Group Chat',
+      messageType: 'POST',
+      users: ['user1', 'user2', 'user3'],
+      created: new Date().toISOString(),
+    }
+
+    render(<MessageBox roomOverride={groupRoom} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Group Chat')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByRole('link', { name: /Open .* profile/ })).not.toBeInTheDocument()
   })
 
   it('renders back button and calls setSelectedChatRoom when clicked', async () => {
@@ -281,4 +348,3 @@ describe('MessageBox', () => {
     expect(screen.getByText('No room selected')).toBeInTheDocument()
   })
 })
-

--- a/quotevote-frontend/src/__tests__/components/Chat/MessageItem.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Chat/MessageItem.test.tsx
@@ -183,6 +183,20 @@ describe('MessageItem', () => {
     expect(avatars.length).toBeGreaterThan(0)
   })
 
+  it('renders profile link on other user avatar', () => {
+    render(<MessageItem message={mockOtherMessage} />)
+
+    const profileLink = screen.getByRole('link', { name: 'Open otheruser profile' })
+    expect(profileLink).toHaveAttribute('href', '/dashboard/profile/otheruser')
+  })
+
+  it('renders profile link on own avatar', () => {
+    render(<MessageItem message={mockOwnMessage} />)
+
+    const profileLink = screen.getByRole('link', { name: 'Open currentuser profile' })
+    expect(profileLink).toHaveAttribute('href', '/dashboard/profile/currentuser')
+  })
+
   it('displays read indicator for own messages when read', () => {
     render(<MessageItem message={mockOwnMessage} />)
 
@@ -321,4 +335,3 @@ describe('MessageItem', () => {
     expect(container.firstChild).toBeNull()
   })
 })
-

--- a/quotevote-frontend/src/components/BuddyList/BuddyItemList.tsx
+++ b/quotevote-frontend/src/components/BuddyList/BuddyItemList.tsx
@@ -104,6 +104,7 @@ export default function BuddyItemList({ buddyList, className }: BuddyItemListPro
                         avatar: typeof item.user.avatar === 'string' ? item.user.avatar : null,
                         messageType: 'USER',
                         users: [currentUser._id!.toString(), item.user._id],
+                        username: item.user.username,
                     };
                     setSelectedChatRoom(staged);
                 }

--- a/quotevote-frontend/src/components/Chat/MessageBox.tsx
+++ b/quotevote-frontend/src/components/Chat/MessageBox.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useRef } from 'react'
+import Link from 'next/link'
 import { ArrowLeft, Settings, Ban, UserX, Trash2 } from 'lucide-react'
 import { useQuery } from '@apollo/client/react'
 
@@ -25,9 +26,10 @@ import type { ChatRoom, StagedChatRoom } from '@/types/chat'
 
 interface HeaderProps {
   room: ChatRoom | null
+  stagedProfileUsername?: string | null
 }
 
-function Header({ room }: HeaderProps) {
+function Header({ room, stagedProfileUsername }: HeaderProps) {
   const currentUser = useAppStore((state) => state.user.data)
   const setSelectedChatRoom = useAppStore((state) => state.setSelectedChatRoom)
   const setChatOpen = useAppStore((state) => state.setChatOpen)
@@ -39,7 +41,15 @@ function Header({ room }: HeaderProps) {
       fetchPolicy: 'cache-and-network',
     },
   )
-  const { data: rosterData } = useQuery<{ getRoster: Array<{ _id: string; userId: string; buddyId: string; status: string }> }>(
+  const { data: rosterData } = useQuery<{
+    getRoster: Array<{
+      _id: string
+      userId: string
+      buddyId: string
+      status: string
+      buddy?: { _id?: string; username?: string | null } | null
+    }>
+  }>(
     GET_ROSTER,
     { skip: !currentUser },
   )
@@ -67,6 +77,19 @@ function Header({ room }: HeaderProps) {
 
   const rosterEntries = rosterData?.getRoster ?? []
   const currentUserIdStr = currentUser?._id?.toString()
+
+  const otherUsernameFromRoster =
+    otherUserId
+      ? rosterEntries.find((r) => r.buddy?._id?.toString() === otherUserId)?.buddy?.username ?? null
+      : null
+  const profileUsername =
+    messageType === 'USER'
+      ? stagedProfileUsername ?? otherUsernameFromRoster ?? null
+      : null
+  const profileHref = profileUsername
+    ? `/dashboard/profile/${encodeURIComponent(profileUsername)}`
+    : null
+
   const isBlocked = !!(
     otherUserId &&
     currentUserIdStr &&
@@ -140,12 +163,27 @@ function Header({ room }: HeaderProps) {
         </Button>
 
         <div className="flex min-w-0 flex-1 items-center gap-3">
-          <DisplayAvatar
-            avatar={avatar as string | Record<string, unknown> | undefined}
-            username={title || ''}
-            size={44}
-            className="flex-shrink-0 ring-2 ring-white shadow-sm"
-          />
+          {profileHref ? (
+            <Link
+              href={profileHref}
+              aria-label={`Open ${profileUsername} profile`}
+              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#52b274] focus-visible:ring-offset-2"
+            >
+              <DisplayAvatar
+                avatar={avatar as string | Record<string, unknown> | undefined}
+                username={title || ''}
+                size={44}
+                className="flex-shrink-0 ring-2 ring-white shadow-sm"
+              />
+            </Link>
+          ) : (
+            <DisplayAvatar
+              avatar={avatar as string | Record<string, unknown> | undefined}
+              username={title || ''}
+              size={44}
+              className="flex-shrink-0 ring-2 ring-white shadow-sm"
+            />
+          )}
 
           <div className="min-w-0 flex-1">
             <div className="truncate text-base font-bold text-foreground" style={{ letterSpacing: '-0.01em' }}>
@@ -211,6 +249,9 @@ function MessageBox({ roomOverride }: MessageBoxProps) {
   const ensureAuth = useGuestGuard()
   const selectedRoomId = useAppStore((state) => state.chat.selectedRoom)
   const isStagedRoom = selectedRoomId !== null && typeof selectedRoomId === 'object'
+  const stagedProfileUsername = isStagedRoom
+    ? (selectedRoomId as StagedChatRoom).username ?? null
+    : null
 
   const { data: roomsData } = useQuery<{ messageRooms: ChatRoom[] }>(GET_CHAT_ROOMS, {
     fetchPolicy: 'cache-and-network',
@@ -256,7 +297,7 @@ function MessageBox({ roomOverride }: MessageBoxProps) {
 
   return (
     <div className="flex h-full flex-col bg-background">
-      <Header room={room} />
+      <Header room={room} stagedProfileUsername={stagedProfileUsername} />
       <div
         className="flex flex-1 flex-col overflow-hidden"
         style={{

--- a/quotevote-frontend/src/components/Chat/MessageItem.tsx
+++ b/quotevote-frontend/src/components/Chat/MessageItem.tsx
@@ -2,6 +2,7 @@
 
 import type { FC } from 'react';
 import { useMemo, memo } from 'react';
+import Link from 'next/link';
 import { useMutation } from '@apollo/client/react';
 import { Check, CheckCheck, Trash2 } from 'lucide-react';
 
@@ -102,8 +103,31 @@ const MessageItemComponent: FC<MessageItemProps> = ({ message }) => {
     'Unknown';
 
   const avatarRaw = message.user?.avatar;
+  const profileUsername = message.user?.username ?? (isOwnMessage ? currentUser.username : null);
+  const profileHref = profileUsername
+    ? `/dashboard/profile/${encodeURIComponent(profileUsername)}`
+    : null;
 
   const timeLabel = formatTime(message.created);
+
+  const avatarNode = (
+    <DisplayAvatar
+      avatar={avatarRaw as string | Record<string, unknown> | undefined}
+      username={senderName}
+      size={40}
+      className="ring-2 ring-white shadow-sm"
+    />
+  );
+
+  const avatarWithLink = profileHref ? (
+    <Link
+      href={profileHref}
+      aria-label={`Open ${profileUsername} profile`}
+      className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#52b274] focus-visible:ring-offset-2"
+    >
+      {avatarNode}
+    </Link>
+  ) : avatarNode;
 
   return (
     <div
@@ -114,12 +138,7 @@ const MessageItemComponent: FC<MessageItemProps> = ({ message }) => {
     >
       {isDefaultDirection && (
         <div className="mr-2.5 flex h-10 w-10 flex-shrink-0 items-center justify-center">
-          <DisplayAvatar
-            avatar={avatarRaw as string | Record<string, unknown> | undefined}
-            username={senderName}
-            size={40}
-            className="ring-2 ring-white shadow-sm"
-          />
+          {avatarWithLink}
         </div>
       )}
 
@@ -186,12 +205,7 @@ const MessageItemComponent: FC<MessageItemProps> = ({ message }) => {
 
       {!isDefaultDirection && (
         <div className="ml-2.5 flex h-10 w-10 flex-shrink-0 items-center justify-center">
-          <DisplayAvatar
-            avatar={avatarRaw as string | Record<string, unknown> | undefined}
-            username={senderName}
-            size={40}
-            className="ring-2 ring-white shadow-sm"
-          />
+          {avatarWithLink}
         </div>
       )}
     </div>

--- a/quotevote-frontend/src/components/Profile/ProfileHeader.tsx
+++ b/quotevote-frontend/src/components/Profile/ProfileHeader.tsx
@@ -161,6 +161,7 @@ export function ProfileHeader({ profileUser }: ProfileHeaderProps) {
             : (avatar?.url ?? null),
         messageType: 'USER',
         users: [loggedInUserIdString, _id],
+        username: username || undefined,
       };
       setSelectedChatRoom(staged);
     }

--- a/quotevote-frontend/src/types/chat.ts
+++ b/quotevote-frontend/src/types/chat.ts
@@ -188,6 +188,7 @@ export interface StagedChatRoom {
   avatar: string | null;
   messageType: 'USER';
   users: string[];
+  username?: string;
 }
 
 /**


### PR DESCRIPTION
**Closes:** #375    
**Labels:** `bug` `rc1` `chat` `profile` `routing`

---

### Summary
Clicking a user avatar inside chat (and anywhere else) should navigate to that user's profile page.

### Acceptance Criteria

- Chat avatar clicks route to the correct profile page.
- Behavior is consistent across relevant desktop and mobile views.
- No regressions are introduced in adjacent workflows.

### Test Results
  PASS  src/__tests__/components/Chat/MessageBox.test.tsx
  MessageBox
    ✓ renders "No room selected" when no room is provided (12 ms)
    ✓ renders room header with correct title and avatar (15 ms)
    ✓ renders avatar as a profile link when DM buddy username is available (22 ms)
    ✓ renders avatar as a profile link for staged room username (9 ms)
    ✓ does not render avatar as profile link for non-user rooms (5 ms)
    ✓ renders back button and calls setSelectedChatRoom when clicked (7 ms)
    ✓ renders MessageItemList and MessageSend components when room is selected (4 ms)
    ✓ renders settings menu with block, remove buddy, and delete options for USER rooms (7 ms)
    ✓ accepts roomOverride prop to override selected room (5 ms)
    ✓ handles loading state while fetching rooms (1 ms)
Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total

 PASS  src/__tests__/components/Chat/MessageItem.test.tsx
  MessageItem
    ✓ renders own message with correct styling (30 ms)
    ✓ renders other user message with correct styling (3 ms)
    ✓ displays sender name for other user messages (2 ms)
    ✓ does not display sender name for own messages (4 ms)
    ✓ displays avatar for other user messages on the left (1 ms)
    ✓ displays avatar for own messages on the right (4 ms)
    ✓ renders profile link on other user avatar (13 ms)
    ✓ renders profile link on own avatar (5 ms)
    ✓ displays read indicator for own messages when read (6 ms)
    ✓ displays unread indicator for own messages when not read (4 ms)
    ✓ displays timestamp (3 ms)
    ✓ shows delete button on hover for own messages (5 ms)
    ✓ deletes message when delete button is clicked (57 ms)
    ✓ handles delete errors gracefully (56 ms)
    ✓ does not show delete button for other user messages (1 ms)
    ✓ handles missing user data gracefully (2 ms)
    ✓ handles missing avatar gracefully (1 ms)
    ✓ returns null when no current user

Test Suites: 1 passed, 1 total
Tests:       18 passed, 18 total