### PR TITLE
fix(backend): duplicate featuredSlot index + seed script wrong DB

### DIFF
--- a/quotevote-backend/app/data/models/Post.ts
+++ b/quotevote-backend/app/data/models/Post.ts
@@ -26,8 +26,6 @@ const PostSchema = new Schema<PostDocument, PostModel>(
       type: Number,
       min: 1,
       max: 12,
-      unique: true,
-      sparse: true,
     },
     messageRoomId: { type: String },
     urlId: { type: String },


### PR DESCRIPTION
# Pull Request Template

## Description

Two small, unrelated backend hotfixes found while doing local setup for #394/#395, bundled here since both are one-line-scale config/typo fixes with no shared code:

1. **`Post.ts`** declared the same unique+sparse index on `featuredSlot` twice — once via field-level `unique`/`sparse` options, once via an explicit `PostSchema.index(...)` call. Mongoose warns about this on every server boot. Removed the redundant field-level flags; the explicit `.index()` call (already grouped with the other `featuredSlot` indexes) remains the single source of truth, so behavior is unchanged.
2. **`scripts/seed-data.ts`** never called `dotenv.config()`, so `process.env.MONGO_URI` was always empty when run directly, silently falling back to its hardcoded default database name instead of whatever `.env` specifies. If that default differs from the database the running server actually connects to, seeded users land in the wrong database — the app then reports "invalid credentials" for logins that should work, with no indication the seed data even landed somewhere else. Added `dotenv.config()` so it reads the same `.env` the server does.

(A third fix found in the same session — a completely missing `user(username)` resolver — was split out into #425 since it's a larger, distinct change implementing a previously-unbuilt feature rather than a config fix.)

## Related Issue (Link to issue ticket)

None — found doing local setup for #394/#395, filed as standalone hotfixes rather than bundled into that unrelated work.

## Motivation and Context

**(1)** Not a functional bug, but trains contributors to skim past console warnings — a habit that causes real ones to get missed later.

**(2)** This one cost real debugging time: seeded a local dev DB, tried logging in with the seeded credentials, got a generic "invalid credentials" error that gave no hint the actual problem was two different databases in play. Anyone else running this script for local setup would hit the same silent trap.

**Before (`Post.ts`, every `pnpm dev` startup):**
```
(node:91073) [MONGOOSE] Warning: Duplicate schema index on {"featuredSlot":1} found. This is often due to declaring an index using both "index: true" and "schema.index()". Please remove the duplicate index definition.
```
**After:** warning no longer prints; index behavior (uniqueness + sparse) unchanged.

**Before (`seed-data.ts`):** running `npx tsx scripts/seed-data.ts` with `.env` set to `MONGO_URI=mongodb://localhost:27017/quotevote-dev` actually seeded `mongodb://localhost:27017/quotevote` (the hardcoded fallback, no `.env` loaded) — then logging in against the real server (connected to `quotevote-dev`) failed:
```
curl -X POST http://localhost:4000/auth/login -d '{"username":"alice@quote.vote","password":"securepassword123"}'
{"message":"Invalid username or password."}
```
**After:** script loads `.env`, seeds the correct database, login succeeds:
```
curl -X POST http://localhost:4000/auth/login -d '{"username":"alice@quote.vote","password":"securepassword123"}'
{"accessToken":"eyJhbGciOiJIUzI1NiIs...","user":{"email":"alice@quote.vote",...}}
```

## How Has This Been Tested?

- Reproduced both issues locally against a Dockerized MongoDB before fixing.
- After fix (1): confirmed only one `{featuredSlot:1}` index declaration with matching options remains in the schema.
- After fix (2): re-ran the seed script, confirmed via direct DB query that users land in the database specified by `.env`, then confirmed login succeeds end-to-end via `curl` against the running server (see output above).

## Screenshots (if appropriate - Postman, etc)

N/A — terminal output included above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed (backend CI green; unrelated pre-existing frontend test failure noted below, not caused by this change).

## Note on CI

`Frontend CI` fails on this PR due to a pre-existing, unrelated Jest test (`ProfileHeaderMessage.test.tsx` expecting a `username` field no longer present on the message object). Proof it's unrelated to this PR: this PR only touches two backend files (`quotevote-backend/app/data/models/Post.ts`, `quotevote-backend/scripts/seed-data.ts`); diffing both the failing test file and the component it tests against `upstream/main` shows **zero difference**:

```
git diff upstream/main <this-branch> -- quotevote-frontend/src/__tests__/components/Profile/ProfileHeaderMessage.test.tsx
git diff upstream/main <this-branch> -- quotevote-frontend/src/components/Profile/ProfileHeader.tsx
# both empty — byte-identical to main
```

This failure exists on `main` right now, independent of this PR. `Vercel` shows "Authorization required to deploy," which is a fork-PR permissions gate, not a build failure. `Backend CI` (the only check covering this PR's actual changes) passes.
