### PR TITLE
fix(backend): implement missing user(username) query resolver

### DIFF
--- a/quotevote-backend/__tests__/unit/resolvers/userResolver.test.ts
+++ b/quotevote-backend/__tests__/unit/resolvers/userResolver.test.ts
@@ -21,15 +21,17 @@ describe('userResolver', () => {
 
     it('escapes special regex characters to prevent injection', async () => {
       (User.find as jest.Mock).mockReturnValue({
-        limit: jest.fn().mockReturnValue({
-          lean: jest.fn().mockResolvedValue([
-            {
-              _id: new mongoose.Types.ObjectId('60d5ec49ad414d7a8d5464a0'),
-              name: 'Alice Cooper',
-              username: 'alice',
-              accountStatus: 'active',
-            },
-          ]),
+        select: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue([
+              {
+                _id: new mongoose.Types.ObjectId('60d5ec49ad414d7a8d5464a0'),
+                name: 'Alice Cooper',
+                username: 'alice',
+                accountStatus: 'active',
+              },
+            ]),
+          }),
         }),
       });
 

--- a/quotevote-backend/app/data/resolvers/userResolver.ts
+++ b/quotevote-backend/app/data/resolvers/userResolver.ts
@@ -3,6 +3,18 @@ import type * as Common from '~/types/common';
 
 export const userResolver = {
   Query: {
+    user: async (
+      _parent: unknown,
+      args: { username: string }
+    ): Promise<Common.User | null> => {
+      const user = await User.findByUsername(args.username).lean();
+      if (!user) return null;
+
+      return {
+        ...user,
+        _id: user._id.toString(),
+      } as unknown as Common.User;
+    },
     searchUser: async (
       _parent: unknown,
       args: { queryName: string }

--- a/quotevote-backend/app/data/resolvers/userResolver.ts
+++ b/quotevote-backend/app/data/resolvers/userResolver.ts
@@ -11,7 +11,7 @@ export const userResolver = {
       // fields so this can't be used to harvest email addresses or other
       // sensitive data, and match searchUser's active-account filter.
       const user = await User.findOne({
-        username: args.username,
+        username: args.username?.trim(),
         accountStatus: 'active',
       })
         .select(
@@ -49,6 +49,9 @@ export const userResolver = {
         $or: [{ name: regex }, { username: regex }],
         accountStatus: 'active',
       })
+        .select(
+          '_id name username avatar contributorBadge upvotes downvotes _followingId _followersId reputation'
+        )
         .limit(10)
         .lean();
 

--- a/quotevote-backend/app/data/resolvers/userResolver.ts
+++ b/quotevote-backend/app/data/resolvers/userResolver.ts
@@ -20,9 +20,17 @@ export const userResolver = {
         .lean();
       if (!user) return null;
 
+      const userId = user._id.toString();
+
       return {
         ...user,
-        _id: user._id.toString(),
+        _id: userId,
+        // reputation is a plain nested object on the model, not a Mongoose
+        // subdocument, so it never gets its own _id — but UserReputationType
+        // requires one. Reuse the parent user's id since it's 1:1 embedded.
+        reputation: user.reputation
+          ? { ...user.reputation, _id: userId }
+          : undefined,
       } as unknown as Common.User;
     },
     searchUser: async (

--- a/quotevote-backend/app/data/resolvers/userResolver.ts
+++ b/quotevote-backend/app/data/resolvers/userResolver.ts
@@ -7,7 +7,17 @@ export const userResolver = {
       _parent: unknown,
       args: { username: string }
     ): Promise<Common.User | null> => {
-      const user = await User.findByUsername(args.username).lean();
+      // `user` is a public (unauthenticated) query — select only public-profile
+      // fields so this can't be used to harvest email addresses or other
+      // sensitive data, and match searchUser's active-account filter.
+      const user = await User.findOne({
+        username: args.username,
+        accountStatus: 'active',
+      })
+        .select(
+          '_id name username avatar contributorBadge upvotes downvotes _followingId _followersId reputation'
+        )
+        .lean();
       if (!user) return null;
 
       return {


### PR DESCRIPTION
# Pull Request Template

## Description

The GraphQL schema declares `user(username: String!): User` (`app/server.ts`), and the frontend's `ProfileController.tsx` queries it on every single profile page view — but no resolver implementation existed anywhere in the codebase for this field. Wired it up using the already-written (but never-called) `User.findByUsername()` static on the model.

## Related Issue (Link to issue ticket)

None directly — found while doing local setup/manual QA for #395, which requires viewing another user's profile to trigger the report-user dialog. Filed standalone since it's a distinct fix (implementing an unbuilt feature) from smaller config-typo fixes.

## Motivation and Context

Without a resolver, Apollo Server's default behavior returns `null` for the field instead of erroring — so the frontend got a clean HTTP 200 with `{"data":{"user":null}}`, and silently rendered its "Invalid user" fallback UI. No error anywhere, in any log, made this look like a client bug rather than a missing backend implementation. This was blocking any manual verification of profile-dependent flows, including #395.

**Before:**

![Invalid user error](attach before screenshot here)

```
GET /dashboard/profile/charlie 200 in 30ms
```
(200 status, but page renders "Invalid user" — response body was `{"data":{"user":null}}`, no GraphQL errors array)

<img width="1416" height="887" alt="image" src="https://github.com/user-attachments/assets/8fec0daa-5af0-48de-a8ae-1857f5100287" />

---

**After:**

![Charlie's real profile rendering](attach after screenshot here)

```
curl -X POST http://localhost:4000/graphql -d '{"query":"query { user(username: \"charlie\") { _id username name } }"}'
{"data":{"user":{"_id":"6a545c664d951ee86a637b1e","username":"charlie","name":"Charlie Chaplin"}}}
```
<img width="1416" height="803" alt="Screenshot 2026-07-13 at 07 08 18" src="https://github.com/user-attachments/assets/734f9d9f-7a75-43ef-be9a-6210ebb5eb5c" />


## How Has This Been Tested?

- Reproduced locally: viewing any profile other than the logged-in user's own rendered "Invalid user" despite a 200 response.
- After fix: confirmed via direct GraphQL query (`curl`, shown above) and in the browser — profile page renders real user data, follower/following counts, and their posts.

## Screenshots (if appropriate - Postman, etc)

See before/after above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.