### PR TITLE
Improve Create Quote composer UX (#427)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,10 @@ CI runs `lint`, `type-check`, and `test` (Jest) for both frontend and backend on
 - **UI**: shadcn/ui (New York style) + Tailwind CSS 4.x + lucide-react icons. No Material-UI.
 - **State**: Zustand (`src/store/`) — no Redux, no provider wrappers needed
 - **Data fetching**: Apollo Client 4 for GraphQL (`src/lib/apollo/`, `src/graphql/`)
-- **Forms**: React Hook Form + Zod validation
+- **Forms**: React Hook Form + Zod validation (e.g. `src/lib/validation/submitPostSchema.ts` for Create Quote)
 - **Testing**: Jest 30 + React Testing Library (unit, `src/__tests__/`); Playwright (E2E, `e2e/`)
+
+**Create Quote composer** (`src/components/SubmitPost/`): required title, body, and tag; optional citation and attribution; drafts in `sessionStorage`; POST disabled until Zod validation passes. E2E uses `E2E_PUBLIC_TAG_NAME` (see `quotevote-frontend/.env.e2e.example`).
 
 ### Backend
 
@@ -85,7 +87,8 @@ quotevote-frontend/
     components/ui/    # shadcn/ui components
     hooks/            # Custom React hooks
     lib/apollo/       # Apollo Client setup
-    lib/utils/        # Utility functions
+    lib/utils/        # Utility functions (e.g. submitPostDraft sessionStorage helpers)
+    lib/constants/    # Shared constants (form limits, etc.)
     store/            # Zustand stores
     types/            # All TypeScript type definitions (mandatory location)
     graphql/          # Queries, mutations, subscriptions

--- a/quotevote-backend/app/data/inputs/PostInput.ts
+++ b/quotevote-backend/app/data/inputs/PostInput.ts
@@ -9,6 +9,5 @@ export const PostInput = new GraphQLInputObjectType({
     text: { type: new GraphQLNonNull(GraphQLString) },
     citationUrl: { type: GraphQLString },
     attribution: { type: GraphQLString },
-    attributionType: { type: GraphQLString },
   },
 });

--- a/quotevote-backend/app/data/models/Post.ts
+++ b/quotevote-backend/app/data/models/Post.ts
@@ -9,6 +9,7 @@ const PostSchema = new Schema<PostDocument, PostModel>(
     text: { type: String, required: true },
     url: { type: String },
     citationUrl: { type: String, default: null },
+    attribution: { type: String, default: null },
     bookmarkedBy: [{ type: String }],
     rejectedBy: [{ type: String }],
     approvedBy: [{ type: String }],

--- a/quotevote-backend/app/data/types/Post.ts
+++ b/quotevote-backend/app/data/types/Post.ts
@@ -39,6 +39,7 @@ export const PostType: GraphQLObjectType<PostShape, GraphQLContext> = new GraphQ
     title: { type: GraphQLString },
     text: { type: GraphQLString },
     citationUrl: { type: GraphQLString },
+    attribution: { type: GraphQLString },
     url: { type: GraphQLString },
     deleted: { type: GraphQLBoolean },
     upvotes: { type: GraphQLInt },

--- a/quotevote-backend/app/types/common.ts
+++ b/quotevote-backend/app/types/common.ts
@@ -111,6 +111,7 @@ export interface Post {
   text: string;
   url?: string;
   citationUrl?: string;
+  attribution?: string;
   upvotes?: number;
   downvotes?: number;
   reported?: number;
@@ -449,6 +450,7 @@ export interface PostInput {
   text?: string;
   url?: string;
   citationUrl?: string;
+  attribution?: string;
   enable_voting?: boolean;
 }
 

--- a/quotevote-backend/prisma/schema/post.prisma
+++ b/quotevote-backend/prisma/schema/post.prisma
@@ -8,6 +8,7 @@ model Post {
   text           String
   url            String?
   citationUrl    String?
+  attribution    String?
   upvotes        Int      @default(0)
   downvotes      Int      @default(0)
   reported       Int      @default(0)

--- a/quotevote-frontend/.env.e2e.example
+++ b/quotevote-frontend/.env.e2e.example
@@ -22,8 +22,10 @@
 E2E_AUTHOR_USERNAME=authorUser
 E2E_AUTHOR_PASSWORD=
 
-# Group title to select in composer (must exist on API; use a public-privacy group e.g. QA)
-E2E_PUBLIC_GROUP_NAME=QA
+# Tag title to select in composer (must exist on API; use a public-privacy tag e.g. QA)
+E2E_PUBLIC_TAG_NAME=QA
+# Legacy alias (still read by e2e/helpers/post-composer.ts if E2E_PUBLIC_TAG_NAME is unset):
+# E2E_PUBLIC_GROUP_NAME=QA
 
 # Frontend URL under test (Playwright baseURL)
 PLAYWRIGHT_BASE_URL=http://localhost:3000

--- a/quotevote-frontend/README.md
+++ b/quotevote-frontend/README.md
@@ -125,7 +125,7 @@ End-to-end specs live in `e2e/` and run against a real browser. Playwright start
 ```bash
 pnpm exec playwright install chromium
 cp .env.e2e.example .env.e2e.local
-# Edit .env.e2e.local — set E2E_AUTHOR_PASSWORD and E2E_PUBLIC_GROUP_NAME
+# Edit .env.e2e.local — set E2E_AUTHOR_PASSWORD and E2E_PUBLIC_TAG_NAME
 ```
 
 **Run commands:**
@@ -187,6 +187,20 @@ describe('MyComponent', () => {
   })
 })
 ```
+
+## Create Quote composer
+
+The **Create Quote** dialog is implemented in `src/components/SubmitPost/` (`SubmitPostForm.tsx`).
+
+| Area | Details |
+|------|---------|
+| **Required fields** | Title, quote body, tag (shown in UI; saved as `groupId` via GraphQL) |
+| **Optional fields** | Citation URL, attribution (“Who said this?”) — under **Add details (optional)** |
+| **Validation** | React Hook Form + Zod (`src/lib/validation/submitPostSchema.ts`); POST stays disabled until valid |
+| **Drafts** | Auto-saved to `sessionStorage` per user (`quotevote:submit-post-draft:{userId}`); cleared on successful post |
+| **Limits** | Title 200 chars (`src/lib/constants/submitPost.ts`); attribution 120 chars (`src/lib/constants/attribution.ts`) |
+
+**E2E helpers** (`e2e/helpers/post-composer.ts`): `openPostComposer()`, `selectPostTag()` (test IDs: `post-tag-select`, `post-tag-error`).
 
 ## 🏗️ Building for Production
 

--- a/quotevote-frontend/e2e/helpers/post-composer.ts
+++ b/quotevote-frontend/e2e/helpers/post-composer.ts
@@ -1,6 +1,10 @@
 import { expect, type Page } from '@playwright/test';
 
-export const PUBLIC_GROUP_NAME = process.env.E2E_PUBLIC_GROUP_NAME ?? 'Public';
+export const PUBLIC_TAG_NAME =
+  process.env.E2E_PUBLIC_TAG_NAME ?? process.env.E2E_PUBLIC_GROUP_NAME ?? 'Public';
+
+/** @deprecated Use selectPostTag */
+export const PUBLIC_GROUP_NAME = PUBLIC_TAG_NAME;
 
 export async function openPostComposer(page: Page): Promise<void> {
   const createButton = page.getByTestId('create-post-button').locator('visible=true');
@@ -10,11 +14,14 @@ export async function openPostComposer(page: Page): Promise<void> {
   await expect(composer).toBeVisible();
 }
 
-export async function selectPostGroup(page: Page, groupName = PUBLIC_GROUP_NAME): Promise<void> {
-  await page.getByTestId('post-group-select').click();
-  await page.getByPlaceholder('Search or type new group name...').fill(groupName);
-  await page.getByRole('button', { name: groupName, exact: true }).click();
+export async function selectPostTag(page: Page, tagName = PUBLIC_TAG_NAME): Promise<void> {
+  await page.getByTestId('post-tag-select').click();
+  await page.getByPlaceholder('Search or type new tag name...').fill(tagName);
+  await page.getByRole('button', { name: tagName, exact: true }).click();
 }
+
+/** @deprecated Use selectPostTag */
+export const selectPostGroup = selectPostTag;
 
 export async function assertComposerRemainsOpen(page: Page): Promise<void> {
   await expect(page.getByTestId('post-composer')).toBeVisible();
@@ -32,13 +39,13 @@ export async function assertPostTitleNotVisibleOnPage(
 export async function assertInvalidPostNotPublished(
   page: Page,
   titleMarker: string,
-  groupName = PUBLIC_GROUP_NAME
+  tagName = PUBLIC_TAG_NAME
 ): Promise<void> {
   const surfaces = [
     '/dashboard/explore',
     '/dashboard/post',
     '/dashboard/profile',
-    `/dashboard/explore?q=${encodeURIComponent(groupName)}`,
+    `/dashboard/explore?q=${encodeURIComponent(tagName)}`,
   ];
 
   for (const path of surfaces) {

--- a/quotevote-frontend/e2e/highlight-popup.spec.ts
+++ b/quotevote-frontend/e2e/highlight-popup.spec.ts
@@ -14,7 +14,7 @@ import { deletePostViaApi, loginViaApi } from './helpers/api';
 import { AUTHOR_PASSWORD, AUTHOR_USERNAME } from './helpers/auth';
 import { selectPostText } from './helpers/selection';
 
-const PUBLIC_GROUP_NAME = process.env.E2E_PUBLIC_GROUP_NAME ?? 'Public';
+import { PUBLIC_TAG_NAME } from './helpers/post-composer';
 
 test.describe('E2E-HILITE-001: Highlight Action Popup', () => {
   test.skip(!AUTHOR_PASSWORD, 'E2E_AUTHOR_PASSWORD is required');
@@ -58,9 +58,9 @@ test.describe('E2E-HILITE-001: Highlight Action Popup', () => {
       await page.getByTestId('post-title-input').fill(postTitle);
       await page.getByTestId('post-body-input').fill(postBody);
 
-      await page.getByTestId('post-group-select').click();
-      await page.getByPlaceholder('Search or type new group name...').fill(PUBLIC_GROUP_NAME);
-      await page.getByRole('button', { name: PUBLIC_GROUP_NAME, exact: true }).click();
+      await page.getByTestId('post-tag-select').click();
+      await page.getByPlaceholder('Search or type new tag name...').fill(PUBLIC_TAG_NAME);
+      await page.getByRole('button', { name: PUBLIC_TAG_NAME, exact: true }).click();
 
       await page.getByTestId('post-submit-button').click();
       await expect(page.getByTestId('post-composer')).toBeHidden({ timeout: 30_000 });

--- a/quotevote-frontend/e2e/mobile.spec.ts
+++ b/quotevote-frontend/e2e/mobile.spec.ts
@@ -25,7 +25,7 @@ import { deletePostViaApi, loginViaApi } from './helpers/api';
 import { AUTHOR_PASSWORD, AUTHOR_USERNAME } from './helpers/auth';
 import { selectMobilePostText } from './helpers/selection';
 
-const PUBLIC_GROUP_NAME = process.env.E2E_PUBLIC_GROUP_NAME ?? 'Public';
+import { PUBLIC_TAG_NAME } from './helpers/post-composer';
 
 test.describe('E2E-MOB-005: Mobile Highlight Selection', () => {
   test.skip(!AUTHOR_PASSWORD, 'E2E_AUTHOR_PASSWORD is required');
@@ -72,9 +72,9 @@ test.describe('E2E-MOB-005: Mobile Highlight Selection', () => {
       await page.getByTestId('post-title-input').fill(postTitle);
       await page.getByTestId('post-body-input').fill(postBody);
 
-      await page.getByTestId('post-group-select').click();
-      await page.getByPlaceholder('Search or type new group name...').fill(PUBLIC_GROUP_NAME);
-      await page.getByRole('button', { name: PUBLIC_GROUP_NAME, exact: true }).click();
+      await page.getByTestId('post-tag-select').click();
+      await page.getByPlaceholder('Search or type new tag name...').fill(PUBLIC_TAG_NAME);
+      await page.getByRole('button', { name: PUBLIC_TAG_NAME, exact: true }).click();
 
       await page.getByTestId('post-submit-button').click();
       await expect(page.getByTestId('post-composer')).toBeHidden({ timeout: 30_000 });

--- a/quotevote-frontend/e2e/post-submission.spec.ts
+++ b/quotevote-frontend/e2e/post-submission.spec.ts
@@ -15,7 +15,7 @@ import {
   assertComposerRemainsOpen,
   assertInvalidPostNotPublished,
   openPostComposer,
-  selectPostGroup,
+  selectPostTag,
 } from './helpers/post-composer';
 
 test.describe('E2E-POST-001: Create Public Post', () => {
@@ -57,8 +57,8 @@ test.describe('E2E-POST-001: Create Public Post', () => {
     await expect(titleInput).toHaveValue(postTitle);
     await expect(bodyInput).toHaveValue(postBody);
 
-    // Step: select Public group
-    await selectPostGroup(page);
+    // Step: select Public tag
+    await selectPostTag(page);
 
     // Step: submit
     const submitButton = page.getByTestId('post-submit-button');
@@ -97,7 +97,7 @@ test.describe('E2E-POST-001: Create Public Post', () => {
 test.describe('E2E-POST-003: Post Validation', () => {
   test.skip(!AUTHOR_PASSWORD, 'E2E_AUTHOR_PASSWORD is required');
 
-  test('blocks submission and shows inline validation for missing required fields', async ({
+  test('blocks submission until required fields are valid', async ({
     page,
   }) => {
     const uniqueSuffix = `${Date.now()}-${test.info().project.name}`;
@@ -111,49 +111,28 @@ test.describe('E2E-POST-003: Post Validation', () => {
     // Step 2: Open the post composer
     await openPostComposer(page);
     const composer = page.getByTestId('post-composer');
+    const submitButton = page.getByTestId('post-submit-button');
 
-    // Step 3: Attempt submit with empty title, body, and group
-    await page.getByTestId('post-submit-button').click();
-
-    await expect(page.getByTestId('post-title-error')).toBeVisible();
-    await expect(page.getByTestId('post-title-error')).toHaveText('Title is required');
-    await expect(page.getByTestId('post-body-error')).toBeVisible();
-    await expect(page.getByTestId('post-body-error')).toHaveText('Post content is required');
-    await expect(page.getByTestId('post-group-error')).toBeVisible();
-    await expect(page.getByTestId('post-group-error')).toHaveText('Please select or create a group');
+    // Step 3: POST stays disabled with empty title, body, and tag
+    await expect(submitButton).toBeDisabled();
     await assertComposerRemainsOpen(page);
 
-    // Step 4: Enter title and body but leave group unselected, then submit again
+    // Step 4: Enter title and body but leave tag unselected
     await page.getByTestId('post-title-input').fill(attemptedTitle);
     await page.getByTestId('post-body-input').fill(attemptedBody);
-    await page.getByTestId('post-submit-button').click();
-
-    await expect(page.getByTestId('post-group-error')).toBeVisible();
-    await expect(page.getByTestId('post-group-error')).toHaveText('Please select or create a group');
-    await expect(page.getByTestId('post-title-error')).toHaveCount(0);
-    await expect(page.getByTestId('post-body-error')).toHaveCount(0);
+    await expect(submitButton).toBeDisabled();
     await assertComposerRemainsOpen(page);
 
-    // Step 5: Select group but leave body empty, then submit again
-    await selectPostGroup(page);
+    // Step 5: Select tag but leave body empty
+    await selectPostTag(page);
     await page.getByTestId('post-body-input').fill('');
-    await page.getByTestId('post-submit-button').click();
-
-    await expect(page.getByTestId('post-body-error')).toBeVisible();
-    await expect(page.getByTestId('post-body-error')).toHaveText('Post content is required');
-    await expect(page.getByTestId('post-title-error')).toHaveCount(0);
-    await expect(page.getByTestId('post-group-error')).toHaveCount(0);
+    await expect(submitButton).toBeDisabled();
     await assertComposerRemainsOpen(page);
 
-    // Step 6: Clear title, enter body text, then submit again
+    // Step 6: Clear title, enter body text, keep tag selected
     await page.getByTestId('post-title-input').fill('');
     await page.getByTestId('post-body-input').fill(attemptedBody);
-    await page.getByTestId('post-submit-button').click();
-
-    await expect(page.getByTestId('post-title-error')).toBeVisible();
-    await expect(page.getByTestId('post-title-error')).toHaveText('Title is required');
-    await expect(page.getByTestId('post-body-error')).toHaveCount(0);
-    await expect(page.getByTestId('post-group-error')).toHaveCount(0);
+    await expect(submitButton).toBeDisabled();
     await assertComposerRemainsOpen(page);
 
     // Step 7: Confirm no post was created from any invalid submission attempt

--- a/quotevote-frontend/e2e/post-submission.spec.ts
+++ b/quotevote-frontend/e2e/post-submission.spec.ts
@@ -2,7 +2,7 @@
  * Post submission E2E specs (post-submission.spec.ts)
  *
  * - E2E-POST-001: Create Public Post (happy path)
- * - E2E-POST-003: Post Validation (required-field inline errors)
+ * - E2E-POST-003: Post Validation (POST disabled until required fields are valid)
  *
  * Actor: Registered User (authorUser)
  * Auth State: Logged in (precondition via global-setup storageState)

--- a/quotevote-frontend/src/__tests__/components/Profile/ProfileHeaderMessage.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/ProfileHeaderMessage.test.tsx
@@ -128,6 +128,7 @@ describe('ProfileHeader — Message button', () => {
       avatar: 'https://example.com/avatar.jpg',
       messageType: 'USER',
       users: ['currentuser', 'user1'],
+      username: 'testuser',
     });
     expect(setChatOpen).toHaveBeenCalledWith(true);
   });

--- a/quotevote-frontend/src/__tests__/utils/submitPostDraft.test.ts
+++ b/quotevote-frontend/src/__tests__/utils/submitPostDraft.test.ts
@@ -1,0 +1,108 @@
+import {
+  clearSubmitPostDraft,
+  formValuesToDraft,
+  isSubmitPostDraftEmpty,
+  readSubmitPostDraft,
+  resolveDraftTag,
+  writeSubmitPostDraft,
+} from '@/lib/utils/submitPostDraft'
+
+describe('submitPostDraft', () => {
+  const userId = 'user-123'
+  const storageKey = 'quotevote:submit-post-draft:user-123'
+  const store = new Map<string, string>()
+
+  beforeEach(() => {
+    store.clear()
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          store.set(key, value)
+        },
+        removeItem: (key: string) => {
+          store.delete(key)
+        },
+        clear: () => {
+          store.clear()
+        },
+      },
+    })
+  })
+
+  it('persists and restores draft values', () => {
+    writeSubmitPostDraft(userId, {
+      title: 'My quote',
+      text: 'Quote body',
+      citationUrl: 'https://example.com',
+      attribution: 'Ada Lovelace',
+      tag: { _id: 'tag-1', title: 'Public' },
+    })
+
+    expect(readSubmitPostDraft(userId)).toEqual({
+      title: 'My quote',
+      text: 'Quote body',
+      citationUrl: 'https://example.com',
+      attribution: 'Ada Lovelace',
+      tag: { _id: 'tag-1', title: 'Public' },
+    })
+  })
+
+  it('clears storage when draft is empty', () => {
+    writeSubmitPostDraft(userId, {
+      title: 'Draft',
+      text: 'Body',
+      citationUrl: '',
+      attribution: '',
+      tag: null,
+    })
+    expect(sessionStorage.getItem(storageKey)).not.toBeNull()
+
+    writeSubmitPostDraft(userId, {
+      title: '',
+      text: '',
+      citationUrl: '',
+      attribution: '',
+      tag: null,
+    })
+
+    expect(sessionStorage.getItem(storageKey)).toBeNull()
+    expect(isSubmitPostDraftEmpty(readSubmitPostDraft(userId) ?? {
+      title: '',
+      text: '',
+      citationUrl: '',
+      attribution: '',
+      tag: null,
+    })).toBe(true)
+  })
+
+  it('serializes form values and resolves saved tags against options', () => {
+    const draft = formValuesToDraft({
+      title: 'Title',
+      text: 'Body',
+      citationUrl: '',
+      attribution: '',
+      tag: { _id: 'tag-1', title: 'Public' },
+    })
+
+    expect(draft.tag).toEqual({ _id: 'tag-1', title: 'Public' })
+    expect(
+      resolveDraftTag(draft.tag, [{ _id: 'tag-1', title: 'Public' }])
+    ).toEqual({ _id: 'tag-1', title: 'Public' })
+  })
+
+  it('clearSubmitPostDraft removes saved draft', () => {
+    writeSubmitPostDraft(userId, {
+      title: 'Saved',
+      text: 'Body',
+      citationUrl: '',
+      attribution: '',
+      tag: 'New Tag',
+    })
+
+    clearSubmitPostDraft(userId)
+
+    expect(readSubmitPostDraft(userId)).toBeNull()
+  })
+})

--- a/quotevote-frontend/src/__tests__/utils/submitPostSchema.test.ts
+++ b/quotevote-frontend/src/__tests__/utils/submitPostSchema.test.ts
@@ -1,13 +1,13 @@
 /**
  * Tests for submit post schema validation - Citation URL related fields
  */
-import { submitPostSchema } from '@/lib/validation/submitPostSchema'
+import { submitPostSchema, isSubmitPostFormReady } from '@/lib/validation/submitPostSchema'
 
-// Helper to create valid base post data (group is required by the schema)
+// Helper to create valid base post data (tag is required by the schema)
 const validBasePost = {
   title: 'Test Post',
   text: 'This is post content without any links',
-  group: 'test-group-id', // Group is required by schema refine
+  tag: 'test-tag-id', // Tag is required by schema refine
 }
 
 describe('submitPostSchema - Citation URL validation', () => {
@@ -128,6 +128,23 @@ describe('submitPostSchema - Citation URL validation', () => {
         citationUrl: 'https://source.com/original-article'
       })
       expect(result.success).toBe(false)
+    })
+  })
+
+  describe('isSubmitPostFormReady', () => {
+    it('returns false when required fields are missing', () => {
+      expect(isSubmitPostFormReady({ title: '', text: '', citationUrl: '' })).toBe(false)
+      expect(
+        isSubmitPostFormReady({
+          title: 'Title',
+          text: 'Body',
+          citationUrl: '',
+        })
+      ).toBe(false)
+    })
+
+    it('returns true when required fields are valid', () => {
+      expect(isSubmitPostFormReady(validBasePost)).toBe(true)
     })
   })
 })

--- a/quotevote-frontend/src/app/dashboard/layout.tsx
+++ b/quotevote-frontend/src/app/dashboard/layout.tsx
@@ -44,7 +44,7 @@ import {
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
-import { SubmitPost } from '@/components/SubmitPost/SubmitPost';
+import { SubmitPost, SUBMIT_POST_DIALOG_CLASS } from '@/components/SubmitPost';
 import { DashboardSidebars } from '@/components/DashboardSidebars';
 
 /* ------------------------------------------------------------------ */
@@ -552,10 +552,9 @@ export default function DashboardLayout({
       <ChatPanel />
 
       <Dialog open={submitDialogOpen} onOpenChange={setSubmitDialogOpen}>
-        {/* z-[70] keeps the full-screen create form above the mobile bottom
-            nav (z-[60]) so the POST button isn't hidden behind it. */}
-        <DialogContent className="max-w-md p-0 z-[70]" showCloseButton={false}>
-          <DialogTitle className="sr-only">Create Quote</DialogTitle>
+        {/* Full-bleed on mobile; z-[70] stays above bottom nav (z-[60]). */}
+        <DialogContent className={SUBMIT_POST_DIALOG_CLASS} showCloseButton={false}>
+          <DialogTitle className="sr-only">Create Quotes</DialogTitle>
           <SubmitPost setOpen={setSubmitDialogOpen} />
         </DialogContent>
       </Dialog>

--- a/quotevote-frontend/src/components/Navbars/MainNavBar.tsx
+++ b/quotevote-frontend/src/components/Navbars/MainNavBar.tsx
@@ -19,7 +19,7 @@ import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { DisplayAvatar } from '@/components/DisplayAvatar';
 import { NotificationMenu } from '@/components/Notifications/NotificationMenu';
 import ChatMenu from '@/components/Chat/ChatMenu';
-import { SubmitPost } from '@/components/SubmitPost/SubmitPost';
+import { SubmitPost, SUBMIT_POST_DIALOG_CLASS } from '@/components/SubmitPost';
 import { AdminIconButton } from '../CustomButtons/AdminIconButton';
 import { SettingsIconButton } from '../CustomButtons/SettingsIconButton';
 import type { MainNavBarProps } from '@/types/components';
@@ -147,7 +147,7 @@ export function MainNavBar({}: MainNavBarProps) {
                 }}
                 className="bg-[#52b274] text-white font-semibold min-w-[150px] hover:bg-[#459963] transition-colors"
               >
-                Create Quote
+                Create Quotes
               </Button>
               <Button
                 variant="ghost"
@@ -280,7 +280,7 @@ export function MainNavBar({}: MainNavBarProps) {
                   }}
                   className="w-full justify-start bg-gradient-to-r from-[#2AE6B2] to-[#27C4E1] text-white font-semibold hover:from-[#27C4E1] hover:to-[#178BE1] hover:shadow-[0_4px_12px_rgba(42,230,178,0.3)] transition-all"
                 >
-                  Create Quote
+                  Create Quotes
                 </Button>
 
                 <div className="h-0.5 bg-gradient-to-r from-[#2AE6B2] via-[#27C4E1] to-[#178BE1] my-4" />
@@ -339,8 +339,8 @@ export function MainNavBar({}: MainNavBarProps) {
 
       {/* Create Quote Dialog */}
       <Dialog open={submitDialogOpen} onOpenChange={setSubmitDialogOpen}>
-        <DialogContent className={isMediumScreen ? 'max-w-md' : 'max-w-full h-full'} showCloseButton={false}>
-          <DialogTitle className="sr-only">Create Quote</DialogTitle>
+        <DialogContent className={SUBMIT_POST_DIALOG_CLASS} showCloseButton={false}>
+          <DialogTitle className="sr-only">Create Quotes</DialogTitle>
           <SubmitPost setOpen={setSubmitDialogOpen} />
         </DialogContent>
       </Dialog>

--- a/quotevote-frontend/src/components/Profile/NoFollowers.tsx
+++ b/quotevote-frontend/src/components/Profile/NoFollowers.tsx
@@ -5,7 +5,7 @@ import type { NoFollowersProps } from '@/types/profile';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
-import { SubmitPost } from '@/components/SubmitPost/SubmitPost';
+import { SubmitPost, SUBMIT_POST_DIALOG_CLASS } from '@/components/SubmitPost';
 
 export function NoFollowers({ filter }: NoFollowersProps) {
   const isFollowing = filter === 'following';
@@ -48,8 +48,8 @@ export function NoFollowers({ filter }: NoFollowersProps) {
 
       {/* Create Quote dialog — same flow as the navbar's create button */}
       <Dialog open={submitOpen} onOpenChange={setSubmitOpen}>
-        <DialogContent className="max-w-md p-0" showCloseButton={false}>
-          <DialogTitle className="sr-only">Create Quote</DialogTitle>
+        <DialogContent className={SUBMIT_POST_DIALOG_CLASS} showCloseButton={false}>
+          <DialogTitle className="sr-only">Create Quotes</DialogTitle>
           <SubmitPost setOpen={setSubmitOpen} />
         </DialogContent>
       </Dialog>

--- a/quotevote-frontend/src/components/Sidebar/Sidebar.tsx
+++ b/quotevote-frontend/src/components/Sidebar/Sidebar.tsx
@@ -18,7 +18,7 @@ import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { DisplayAvatar } from '@/components/DisplayAvatar';
 import { NotificationMenu } from '@/components/Notifications/NotificationMenu';
 import ChatMenu from '@/components/Chat/ChatMenu';
-import { SubmitPost } from '@/components/SubmitPost/SubmitPost';
+import { SubmitPost, SUBMIT_POST_DIALOG_CLASS } from '@/components/SubmitPost';
 import { AdminIconButton } from '../CustomButtons/AdminIconButton';
 import { SettingsIconButton } from '../CustomButtons/SettingsIconButton';
 import type { SidebarProps, SidebarWrapperProps } from '@/types/components';
@@ -365,8 +365,8 @@ export function Sidebar({
 
       {/* Create Quote Dialog */}
       <Dialog open={openCreateQuote} onOpenChange={setOpenCreateQuote}>
-        <DialogContent className="max-w-md p-0" showCloseButton={false}>
-          <DialogTitle className="sr-only">Create Quote</DialogTitle>
+        <DialogContent className={SUBMIT_POST_DIALOG_CLASS} showCloseButton={false}>
+          <DialogTitle className="sr-only">Create Quotes</DialogTitle>
           <SubmitPost setOpen={setOpenCreateQuote} />
         </DialogContent>
       </Dialog>

--- a/quotevote-frontend/src/components/SubmitPost/SubmitPost.tsx
+++ b/quotevote-frontend/src/components/SubmitPost/SubmitPost.tsx
@@ -18,14 +18,18 @@ export function SubmitPost({ setOpen }: SubmitPostProps) {
 
   if (!user || !userId) {
     return (
-      <div className="p-4 text-center text-muted-foreground">
+      <div className="flex h-full min-h-[12rem] items-center justify-center p-4 text-center text-muted-foreground">
         Please log in to create a post.
       </div>
     )
   }
 
   if (error) {
-    return <div className="p-4 text-center text-destructive">Something went wrong!</div>
+    return (
+      <div className="flex h-full min-h-[12rem] items-center justify-center p-4 text-center text-destructive">
+        Something went wrong!
+      </div>
+    )
   }
 
   if (loading) {
@@ -39,11 +43,13 @@ export function SubmitPost({ setOpen }: SubmitPostProps) {
   })
 
   return (
-    <SubmitPostForm
-      options={groupsOptions}
-      user={{ _id: String(userId), ...user } as { _id: string; [key: string]: unknown }}
-      setOpen={setOpen}
-    />
+    <div className="flex h-full min-h-0 w-full flex-1 flex-col">
+      <SubmitPostForm
+        options={groupsOptions}
+        user={{ _id: String(userId), ...user } as { _id: string; [key: string]: unknown }}
+        setOpen={setOpen}
+      />
+    </div>
   )
 }
 

--- a/quotevote-frontend/src/components/SubmitPost/SubmitPostForm.tsx
+++ b/quotevote-frontend/src/components/SubmitPost/SubmitPostForm.tsx
@@ -152,6 +152,14 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
 
     const sanitizedCitationUrl = citationUrl ? sanitizeUrl(citationUrl) : null
 
+    if (citationUrl?.trim() && !sanitizedCitationUrl) {
+      setError('citationUrl', {
+        type: 'manual',
+        message: 'Invalid URL format. Please enter a valid http or https URL.',
+      })
+      return
+    }
+
     const tagData = typeof tag === 'string' ? { title: tag } : tag
 
     try {

--- a/quotevote-frontend/src/components/SubmitPost/SubmitPostForm.tsx
+++ b/quotevote-frontend/src/components/SubmitPost/SubmitPostForm.tsx
@@ -11,7 +11,6 @@ import {
   Card,
   CardHeader,
   CardTitle,
-  CardContent,
   CardFooter,
   CardAction,
 } from '@/components/ui/card'
@@ -20,21 +19,45 @@ import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Combobox } from '@/components/ui/combobox'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useAppStore } from '@/store'
+import { useDebounce } from '@/hooks/useDebounce'
 import { useResponsive } from '@/hooks/useResponsive'
-import { submitPostSchema, type SubmitPostFormValues } from '@/lib/validation/submitPostSchema'
+import { submitPostSchema, isSubmitPostFormReady, type SubmitPostFormValues } from '@/lib/validation/submitPostSchema'
 import { sanitizeUrl } from '@/lib/utils/sanitizeUrl'
+import {
+  clearSubmitPostDraft,
+  draftToFormValues,
+  formValuesToDraft,
+  readSubmitPostDraft,
+  resolveDraftTag,
+  writeSubmitPostDraft,
+} from '@/lib/utils/submitPostDraft'
+import { ATTRIBUTION_MAX_LENGTH } from '@/lib/constants/attribution'
+import { SUBMIT_POST_TITLE_MAX_LENGTH } from '@/lib/constants/submitPost'
 import { CREATE_GROUP, SUBMIT_POST } from '@/graphql/mutations'
 import { GROUPS_QUERY } from '@/graphql/queries'
-import { SubmitPostAlert } from './SubmitPostAlert'
 import type { SubmitPostFormProps } from '@/types/components'
 import { cn } from '@/lib/utils'
+
+function CharacterCount({ current, max }: { current: number; max: number }) {
+  if (current === 0) return null
+
+  const ratio = current / max
+
+  return (
+    <p
+      className={cn(
+        'mt-1 text-right text-xs text-muted-foreground',
+        ratio >= 1 && 'text-destructive',
+        ratio >= 0.8 && ratio < 1 && 'text-amber-600'
+      )}
+      aria-live="polite"
+    >
+      {current}/{max}
+    </p>
+  )
+}
 
 export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormProps) {
   const router = useRouter()
@@ -42,27 +65,75 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
   const setSelectedPost = useAppStore((state) => state.setSelectedPost)
   const apolloClient = useApolloClient()
   const [submitPost, { loading }] = useMutation(SUBMIT_POST)
-  const [createGroup, { loading: loadingGroup }] = useMutation(CREATE_GROUP)
-  const [error, setError] = useState<Error | { message?: string } | null>(null)
-  const [showAlert, setShowAlert] = useState(false)
-  const [isCreatingGroup, setIsCreatingGroup] = useState(false)
-  const [newGroupName, setNewGroupName] = useState('')
+  const [createTag, { loading: loadingTag }] = useMutation(CREATE_GROUP)
+  const [isCreatingTag, setIsCreatingTag] = useState(false)
+  const [newTagName, setNewTagName] = useState('')
   const errorAlertRef = useRef<HTMLDivElement>(null)
+  const citationErrorRef = useRef<HTMLParagraphElement>(null)
+  const hasRestoredDraftRef = useRef(false)
+  const tagReconciledRef = useRef(false)
 
   const {
     register,
     handleSubmit,
     control,
     reset,
+    setError,
+    setValue,
+    watch,
     formState: { errors },
   } = useForm<SubmitPostFormValues>({
     resolver: zodResolver(submitPostSchema),
+    mode: 'onChange',
+    reValidateMode: 'onChange',
     defaultValues: {
       title: '',
       text: '',
       citationUrl: '',
+      attribution: '',
     },
   })
+
+  const title = watch('title') ?? ''
+  const attribution = watch('attribution') ?? ''
+  const formValues = watch()
+  const debouncedFormValues = useDebounce(formValues, 300)
+  const canSubmit = isSubmitPostFormReady(formValues)
+
+  useEffect(() => {
+    if (hasRestoredDraftRef.current) return
+
+    const draft = readSubmitPostDraft(user._id)
+    if (!draft) {
+      hasRestoredDraftRef.current = true
+      return
+    }
+
+    reset(draftToFormValues(draft, options))
+    hasRestoredDraftRef.current = true
+  }, [user._id, options, reset])
+
+  useEffect(() => {
+    if (!hasRestoredDraftRef.current || tagReconciledRef.current || options.length === 0) return
+
+    const draft = readSubmitPostDraft(user._id)
+    if (!draft?.tag) {
+      tagReconciledRef.current = true
+      return
+    }
+
+    const resolvedTag = resolveDraftTag(draft.tag, options)
+    if (resolvedTag) {
+      setValue('tag', resolvedTag, { shouldDirty: false })
+    }
+
+    tagReconciledRef.current = true
+  }, [options, user._id, setValue])
+
+  useEffect(() => {
+    if (!hasRestoredDraftRef.current) return
+    writeSubmitPostDraft(user._id, formValuesToDraft(debouncedFormValues))
+  }, [debouncedFormValues, user._id])
 
   useEffect(() => {
     if (errors.text?.message?.includes('Links are not allowed') && errorAlertRef.current) {
@@ -70,60 +141,70 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
     }
   }, [errors.text])
 
+  useEffect(() => {
+    if (errors.citationUrl?.message && citationErrorRef.current) {
+      citationErrorRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }
+  }, [errors.citationUrl])
+
   const onSubmit = async (values: SubmitPostFormValues) => {
-    const { title, text, group, citationUrl } = values
+    const { title, text, tag, citationUrl, attribution: attr } = values
 
     const sanitizedCitationUrl = citationUrl ? sanitizeUrl(citationUrl) : null
 
-    if (citationUrl && !sanitizedCitationUrl) {
-      setError({ message: 'Invalid URL format.' })
-      setShowAlert(true)
-      return
-    }
-
-    const groupData = typeof group === 'string' ? { title: group } : group
+    const tagData = typeof tag === 'string' ? { title: tag } : tag
 
     try {
-      let newGroup: { _id: string } | undefined
-      const isNewGroup = groupData && !('_id' in groupData)
+      let newTag: { _id: string } | undefined
+      const isNewTag = tagData && !('_id' in tagData)
 
-      if (isNewGroup) {
-        const groupTitle =
-          typeof groupData === 'object' && 'title' in groupData ? groupData.title : ''
+      if (isNewTag) {
+        const tagTitle =
+          typeof tagData === 'object' && 'title' in tagData ? tagData.title : ''
 
-        setIsCreatingGroup(true)
-        setNewGroupName(groupTitle)
+        setIsCreatingTag(true)
+        setNewTagName(tagTitle)
 
-        const createGroupResult = await createGroup({
+        const createTagResult = await createTag({
           variables: {
             group: {
               creatorId: user._id,
-              title: groupTitle,
-              description: `Description for: ${groupTitle} group`,
+              title: tagTitle,
+              description: `Description for: ${tagTitle} tag`,
               privacy: 'public',
             },
           },
           refetchQueries: [{ query: GROUPS_QUERY, variables: { limit: 0 } }],
         })
 
-        newGroup = (createGroupResult.data as { createGroup?: { _id: string } })?.createGroup
-        setIsCreatingGroup(false)
-        setNewGroupName('')
+        newTag = (createTagResult.data as { createGroup?: { _id: string } })?.createGroup
+        setIsCreatingTag(false)
+        setNewTagName('')
 
-        if (!newGroup?._id) {
-          throw new Error('Group was not created. Please try again.')
+        if (!newTag?._id) {
+          setError('tag', {
+            type: 'manual',
+            message: 'Tag was not created. Please try again.',
+          })
+          return
         }
       }
 
-      const postGroupId = isNewGroup
-        ? newGroup!._id
-        : groupData && typeof groupData === 'object' && '_id' in groupData
-          ? (groupData as { _id: string })._id
+      const postTagId = isNewTag
+        ? newTag!._id
+        : tagData && typeof tagData === 'object' && '_id' in tagData
+          ? (tagData as { _id: string })._id
           : undefined
 
-      if (!postGroupId) {
-        throw new Error('Please select or create a group before posting.')
+      if (!postTagId) {
+        setError('tag', {
+          type: 'manual',
+          message: 'Please select or create a tag before posting.',
+        })
+        return
       }
+
+      const resolvedAttribution = attr?.trim() ? attr.trim() : null
 
       const submitResult = await submitPost({
         variables: {
@@ -131,8 +212,9 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
             userId: user._id,
             text,
             title,
-            groupId: postGroupId,
+            groupId: postTagId,
             citationUrl: sanitizedCitationUrl,
+            attribution: resolvedAttribution,
           },
         },
       })
@@ -140,6 +222,8 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
       const addPostResult = (submitResult.data as { addPost?: { _id: string; url: string } })?.addPost
       const { _id } = addPostResult || {}
       if (_id) {
+        clearSubmitPostDraft(user._id)
+        reset()
         setSelectedPost(_id)
         apolloClient.cache.evict({ fieldName: 'posts' })
         apolloClient.cache.gc()
@@ -148,44 +232,30 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
         router.push('/dashboard/explore')
       }
     } catch (err) {
-      setIsCreatingGroup(false)
-      setNewGroupName('')
-      setError(
-        err instanceof Error ? err : { message: 'An error occurred while creating your post' }
-      )
-      setShowAlert(true)
+      setIsCreatingTag(false)
+      setNewTagName('')
+      const message =
+        err instanceof Error ? err.message : 'An error occurred while creating your post'
+      toast.error('Could not create post', { description: message })
     }
   }
 
-  const hideAlert = () => {
-    setShowAlert(false)
-    setError(null)
-    reset()
-  }
+  const padX = isMobile ? 'px-4' : 'px-5'
 
   return (
-    <>
-      {showAlert && error && (
-        <SubmitPostAlert
-          hideAlert={hideAlert}
-          shareableLink=""
-          error={error}
-          setShowAlert={setShowAlert}
-          setOpen={setOpen}
-        />
-      )}
-      <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onSubmit)} className="flex h-full min-h-0 flex-col">
         <Card
           data-testid="post-composer"
           className={cn(
-            'flex flex-col w-full',
-            isMobile ? 'h-dvh max-h-dvh' : 'max-h-[calc(100vh-200px)]'
+            'flex h-full min-h-0 w-full flex-col gap-0 rounded-none border-0 py-0 shadow-none',
+            !isMobile && 'sm:rounded-lg sm:border sm:shadow-sm'
           )}
         >
           <CardHeader
             className={cn(
-              'flex flex-row items-center justify-between',
-              isMobile ? 'p-4' : 'p-5'
+              'flex shrink-0 flex-row items-center justify-between border-b py-3',
+              padX,
+              !isMobile && 'sm:py-4'
             )}
           >
             <CardTitle className="text-2xl text-[#52b274]">Create Quote</CardTitle>
@@ -196,168 +266,187 @@ export function SubmitPostForm({ options = [], user, setOpen }: SubmitPostFormPr
                 size="icon"
                 onClick={() => setOpen(false)}
                 className="text-[#52b274]"
+                aria-label="Close"
               >
                 <X className="h-5 w-5" />
               </Button>
             </CardAction>
           </CardHeader>
 
-          <CardContent
-            className={cn(
-              'flex-1 flex flex-col overflow-hidden',
-              isMobile ? 'px-4' : 'px-5'
-            )}
-          >
-            <div className="flex-1 flex flex-col min-h-0">
-              {/* Title — no label, placeholder only (matches monorepo InputBase) */}
-              <Input
-                id="title"
-                data-testid="post-title-input"
-                placeholder="Enter Title"
-                {...register('title')}
-                className={cn('text-lg border-0 shadow-none px-0 focus-visible:ring-0 rounded-none', errors.title && 'border-b border-destructive')}
-              />
-              {errors.title && (
-                <p className="text-sm text-destructive mt-1" data-testid="post-title-error">
-                  {errors.title.message}
-                </p>
-              )}
-
-              <div className="border-t my-2" />
-
-              {/* Content — scrollable, no label, placeholder only (matches monorepo) */}
-              <div className="flex-1 flex flex-col min-h-0 overflow-auto">
-                <Textarea
-                  id="text"
-                  data-testid="post-body-input"
-                  placeholder="Enter your post content (no links allowed)"
-                  {...register('text')}
-                  className={cn(
-                    'h-full resize-none border-0 shadow-none focus-visible:ring-0 px-0 rounded-none',
-                    isMobile ? 'min-h-[50vh]' : 'min-h-[75vh]',
-                    errors.text && 'border border-destructive'
-                  )}
-                />
-                {errors.text && (
-                  <div
-                    ref={errorAlertRef}
-                    className="flex items-center gap-2 bg-red-50 border border-red-400 rounded p-3 mt-2"
-                  >
-                    <AlertTriangle className="h-5 w-5 text-red-500 shrink-0" />
-                    <p
-                      className="text-sm text-red-600 font-medium"
-                      data-testid="post-body-error"
-                    >
-                      {errors.text.message}
-                    </p>
-                  </div>
-                )}
-              </div>
-
-              <div className="border-t my-4" />
-
-              {/* Citation URL — below content, with tooltip (matches monorepo layout) */}
-              <div className="flex items-center gap-2">
-                <Input
-                  id="citationUrl"
-                  placeholder="Source URL (e.g. https://wikipedia.org/wiki/...)"
-                  {...register('citationUrl')}
-                  className={cn('flex-1', errors.citationUrl && 'border-destructive')}
-                />
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 text-[#52b274] shrink-0"
-                      >
-                        <Info className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="top" className="max-w-xs">
-                      <p>One citation per post. No other links allowed in the body.</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </div>
-              {errors.citationUrl && (
-                <p className="text-sm text-destructive mt-1">{errors.citationUrl.message}</p>
-              )}
-            </div>
-          </CardContent>
-
-          <CardFooter
-            className={cn(
-              'flex flex-col gap-4 border-t pt-5',
-              isMobile ? 'px-4 pb-4' : 'px-5 pb-5'
-            )}
-          >
-            <div
+          {/* Fixed title */}
+          <div className={cn('shrink-0 border-b py-3', padX)}>
+            <Input
+              id="title"
+              data-testid="post-title-input"
+              placeholder="Enter Title"
+              maxLength={SUBMIT_POST_TITLE_MAX_LENGTH}
+              {...register('title')}
               className={cn(
-                'flex w-full gap-4',
-                isMobile ? 'flex-col' : 'flex-row items-center justify-between'
+                'rounded-none border-0 px-0 text-lg shadow-none focus-visible:ring-0',
+                errors.title && 'border-b border-destructive'
               )}
-            >
+            />
+            {errors.title && (
+              <p className="mt-1 text-sm text-destructive" data-testid="post-title-error">
+                {errors.title.message}
+              </p>
+            )}
+            <CharacterCount current={title.length} max={SUBMIT_POST_TITLE_MAX_LENGTH} />
+
+            <div className="mt-3 flex flex-col gap-2">
               <div className="flex items-center gap-2">
-                <Label className="font-medium">Who can see your post</Label>
-                {isCreatingGroup && (
-                  <span className="text-sm text-[#52b274] italic">
-                    Creating group &quot;{newGroupName}&quot;...
+                {isCreatingTag && (
+                  <span className="text-sm italic text-[#52b274]">
+                    Creating tag &quot;{newTagName}&quot;...
                   </span>
                 )}
               </div>
 
-              <div className={cn('w-full', isMobile ? '' : 'max-w-[220px]')}>
-                <Controller
-                  name="group"
-                  control={control}
-                  render={({ field }) => (
-                    <Combobox
-                      options={
-                        options as Array<{ _id?: string; title: string; [key: string]: unknown }>
-                      }
-                      value={field.value || null}
-                      onValueChange={field.onChange}
-                      placeholder="Select or create a group"
-                      label=""
-                      error={!!errors.group}
-                      errorMessage={errors.group?.message}
-                      errorTestId="post-group-error"
-                      disabled={loadingGroup || loading}
-                      allowCreate={true}
-                      triggerTestId="post-group-select"
-                      createOptionTestId="post-group-create"
-                      className="bg-[rgba(160,243,204,0.6)]"
-                    />
-                  )}
+              <Controller
+                name="tag"
+                control={control}
+                render={({ field }) => (
+                  <Combobox
+                    options={
+                      options as Array<{ _id?: string; title: string; [key: string]: unknown }>
+                    }
+                    value={field.value || null}
+                    onValueChange={field.onChange}
+                    placeholder="Select or create a tag"
+                    label=""
+                    error={!!errors.tag}
+                    errorMessage={errors.tag?.message}
+                    errorTestId="post-tag-error"
+                    disabled={loadingTag || loading}
+                    allowCreate={true}
+                    side={isMobile ? 'top' : 'bottom'}
+                    triggerTestId="post-tag-select"
+                    createOptionTestId="post-tag-create"
+                    className="bg-[rgba(160,243,204,0.6)]"
+                  />
+                )}
+              />
+            </div>
+          </div>
+
+          {/* Only the post body scrolls */}
+          <div className={cn('flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain py-3', padX)}>
+            <Textarea
+              id="text"
+              data-testid="post-body-input"
+              placeholder="Enter your post content (no links allowed)"
+              rows={8}
+              {...register('text')}
+              style={{ fieldSizing: 'fixed', minHeight: '100%' }}
+              className={cn(
+                'min-h-full w-full flex-1 resize-none rounded-none border-0 px-0 shadow-none focus-visible:ring-0',
+                errors.text && 'border border-destructive'
+              )}
+            />
+            {errors.text && (
+              <div
+                ref={errorAlertRef}
+                className="mt-2 flex shrink-0 items-center gap-2 rounded border border-red-400 bg-red-50 p-3"
+              >
+                <AlertTriangle className="h-5 w-5 shrink-0 text-red-500" />
+                <p className="text-sm font-medium text-red-600" data-testid="post-body-error">
+                  {errors.text.message}
+                </p>
+              </div>
+            )}
+          </div>
+
+          {/* Optional details */}
+          <div className={cn('shrink-0 space-y-3 border-t py-3', padX)}>
+            <p className="text-sm font-medium text-black">Add details (optional)</p>
+
+            <div className="space-y-4 rounded-md border border-border/60 bg-muted/30 p-3">
+              <div>
+                <Label htmlFor="citationUrl" className="mb-1.5 block text-sm font-medium">
+                  Citation link
+                </Label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    id="citationUrl"
+                    data-testid="post-citation-input"
+                    placeholder="https://example.com/article (optional)"
+                    {...register('citationUrl')}
+                    className={cn('flex-1 bg-background', errors.citationUrl && 'border-destructive')}
+                  />
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 shrink-0 text-[#52b274]"
+                        aria-label="Citation help"
+                      >
+                        <Info className="h-4 w-4" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent side="top" className="z-[80] max-w-xs p-3">
+                      <p className="text-sm">
+                        One citation per post. No other links allowed in the body.
+                      </p>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+                {errors.citationUrl && (
+                  <p
+                    ref={citationErrorRef}
+                    className="mt-1 text-sm text-destructive"
+                    data-testid="post-citation-error"
+                  >
+                    {errors.citationUrl.message}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <Label htmlFor="attribution" className="mb-1.5 block text-sm font-medium">
+                  Who said this?
+                </Label>
+                <Input
+                  id="attribution"
+                  data-testid="post-attribution-input"
+                  placeholder="Enter name here"
+                  maxLength={ATTRIBUTION_MAX_LENGTH}
+                  className="bg-background"
+                  {...register('attribution')}
                 />
+                <CharacterCount current={attribution.length} max={ATTRIBUTION_MAX_LENGTH} />
               </div>
             </div>
+          </div>
 
-            <div className="flex justify-end w-full">
-              <Button
-                id="submit-button"
-                data-testid="post-submit-button"
-                type="submit"
-                variant="default"
-                className="w-full bg-[#52b274] hover:bg-[#52b274]/90 text-white text-lg"
-                disabled={loadingGroup || loading}
-              >
-                {loading || loadingGroup ? (
-                  <>
-                    <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-                    Posting...
-                  </>
-                ) : (
-                  'POST'
-                )}
-              </Button>
-            </div>
+          <CardFooter
+            className={cn(
+              'flex shrink-0 flex-col gap-3 border-t pt-3',
+              padX,
+              'pb-[max(0.75rem,env(safe-area-inset-bottom))]',
+              !isMobile && 'sm:pb-4 sm:pt-4'
+            )}
+          >
+            <Button
+              id="submit-button"
+              data-testid="post-submit-button"
+              type="submit"
+              variant="default"
+              className="w-full bg-[#52b274] text-lg text-white hover:bg-[#52b274]/90"
+              disabled={loadingTag || loading || !canSubmit}
+            >
+              {loading || loadingTag ? (
+                <>
+                  <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                  Posting...
+                </>
+              ) : (
+                'POST'
+              )}
+            </Button>
           </CardFooter>
         </Card>
-      </form>
-    </>
+    </form>
   )
 }

--- a/quotevote-frontend/src/components/SubmitPost/SubmitPostSkeleton.tsx
+++ b/quotevote-frontend/src/components/SubmitPost/SubmitPostSkeleton.tsx
@@ -1,23 +1,44 @@
 'use client'
 
-import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Card, CardFooter, CardHeader } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
+import { useResponsive } from '@/hooks/useResponsive'
 
 export function SubmitPostSkeleton() {
+  const { isMobile } = useResponsive()
+
   return (
-    <Card className="w-full">
-      <CardHeader>
-        <Skeleton className="h-8 w-32" />
+    <Card
+      className={cn(
+        'flex h-full min-h-0 w-full flex-col gap-0 rounded-none border-0 py-0 shadow-none',
+        !isMobile && 'sm:rounded-lg sm:border sm:shadow-sm'
+      )}
+    >
+      <CardHeader className="flex shrink-0 flex-row items-center justify-between border-b px-4 py-3">
+        <Skeleton className="h-8 w-36" />
+        <Skeleton className="h-8 w-8 rounded-md" />
       </CardHeader>
-      <CardContent className="space-y-4">
+      <div className="shrink-0 border-b px-4 py-3">
         <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-40 w-full" />
-        <Skeleton className="h-10 w-full" />
-        <div className="flex justify-end">
-          <Skeleton className="h-10 w-24" />
+        <div className="mt-3 flex flex-col gap-2">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-10 w-full" />
         </div>
-      </CardContent>
+      </div>
+      <div className="min-h-0 flex-1 px-4 py-3">
+        <Skeleton className="h-full min-h-48 w-full" />
+      </div>
+      <div className="shrink-0 space-y-3 border-t px-4 py-3">
+        <Skeleton className="h-4 w-40" />
+        <div className="space-y-4 rounded-md border border-border/60 bg-muted/30 p-3">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      </div>
+      <CardFooter className="flex shrink-0 flex-col gap-3 border-t px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+        <Skeleton className="h-11 w-full" />
+      </CardFooter>
     </Card>
   )
 }
-

--- a/quotevote-frontend/src/components/SubmitPost/index.ts
+++ b/quotevote-frontend/src/components/SubmitPost/index.ts
@@ -2,4 +2,5 @@ export { SubmitPost } from './SubmitPost'
 export { SubmitPostForm } from './SubmitPostForm'
 export { SubmitPostAlert } from './SubmitPostAlert'
 export { SubmitPostSkeleton } from './SubmitPostSkeleton'
+export { SUBMIT_POST_DIALOG_CLASS } from './submitPostDialog'
 

--- a/quotevote-frontend/src/components/SubmitPost/submitPostDialog.ts
+++ b/quotevote-frontend/src/components/SubmitPost/submitPostDialog.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared DialogContent classes for Create Quote across all hosts.
+ * Mobile: edge-to-edge sheet. Desktop: fixed-height centered dialog.
+ * Keep height utilities simple — complex min()/calc() arbitrary values can fail to emit.
+ */
+export const SUBMIT_POST_DIALOG_CLASS =
+  'z-[70] flex flex-col gap-0 overflow-hidden p-0 ' +
+  'inset-0 top-0 left-0 h-dvh max-h-dvh w-full max-w-none translate-x-0 translate-y-0 rounded-none border-0 ' +
+  'sm:inset-auto sm:top-1/2 sm:left-1/2 sm:h-[640px] sm:max-h-[85dvh] sm:w-full sm:max-w-lg ' +
+  'sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg sm:border'

--- a/quotevote-frontend/src/components/ui/combobox.tsx
+++ b/quotevote-frontend/src/components/ui/combobox.tsx
@@ -26,6 +26,8 @@ export interface ComboboxProps {
   className?: string
   disabled?: boolean
   allowCreate?: boolean
+  /** Prefer "top" when the trigger sits near the bottom of the viewport (e.g. mobile composer footer). */
+  side?: 'top' | 'bottom' | 'left' | 'right'
   triggerTestId?: string
   createOptionTestId?: string
   errorTestId?: string
@@ -35,13 +37,14 @@ export function Combobox({
   options,
   value,
   onValueChange,
-  placeholder = 'Select or create a group',
+  placeholder = 'Select or create a tag',
   label,
   error,
   errorMessage,
   className,
   disabled = false,
   allowCreate = true,
+  side = 'bottom',
   triggerTestId,
   createOptionTestId,
   errorTestId,
@@ -112,6 +115,17 @@ export function Combobox({
     typeof value !== 'string' &&
     (value as ComboboxOption).title === option.title
 
+  const listRef = React.useRef<HTMLDivElement>(null)
+
+  // Dialog scroll-lock (react-remove-scroll) swallows wheel events on nested popovers.
+  // Manually apply delta so the tag list scrolls with the mouse wheel.
+  const handleListWheel = (event: React.WheelEvent<HTMLDivElement>) => {
+    const el = listRef.current
+    if (!el) return
+    event.stopPropagation()
+    el.scrollTop += event.deltaY
+  }
+
   return (
     <div className={cn('w-full', className)}>
       {label && (
@@ -120,7 +134,7 @@ export function Combobox({
         </Label>
       )}
 
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover open={open} onOpenChange={setOpen} modal={true}>
         <PopoverTrigger asChild>
           <Button
             ref={triggerRef}
@@ -143,16 +157,19 @@ export function Combobox({
 
         <PopoverContent
           className="z-[80] p-0"
-          style={{ width: triggerWidth }}
+          style={{ width: Math.max(triggerWidth, 220) }}
           align="start"
+          side={side}
           sideOffset={4}
+          collisionPadding={16}
           onOpenAutoFocus={(e) => e.preventDefault()}
+          onWheel={(e) => e.stopPropagation()}
         >
           {/* Search input */}
           <div className="border-b px-3 py-2">
             <Input
               ref={inputRef}
-              placeholder="Search or type new group name..."
+              placeholder="Search or type new tag name..."
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={handleKeyDown}
@@ -160,11 +177,16 @@ export function Combobox({
             />
           </div>
 
-          {/* Options list */}
-          <div className="max-h-[200px] overflow-y-auto py-1">
+          {/* Options list — taller on short viewports so more choices stay reachable */}
+          <div
+            ref={listRef}
+            data-scroll-lock-scrollable=""
+            onWheel={handleListWheel}
+            className="max-h-[min(40dvh,280px)] overflow-y-auto overscroll-contain py-1"
+          >
             {filteredOptions.length === 0 ? (
               <p className="py-4 text-center text-sm text-muted-foreground">
-                {inputValue ? 'No matching groups.' : 'No groups yet. Type a name to create one.'}
+                {inputValue ? 'No matching tags.' : 'No tags yet. Type a name to create one.'}
               </p>
             ) : (
               filteredOptions.map((option) => (

--- a/quotevote-frontend/src/graphql/mutations.ts
+++ b/quotevote-frontend/src/graphql/mutations.ts
@@ -171,6 +171,7 @@ export const SUBMIT_POST = gql`
       _id
       url
       citationUrl
+      attribution
     }
   }
 `

--- a/quotevote-frontend/src/lib/constants/attribution.ts
+++ b/quotevote-frontend/src/lib/constants/attribution.ts
@@ -1,0 +1,1 @@
+export const ATTRIBUTION_MAX_LENGTH = 120

--- a/quotevote-frontend/src/lib/constants/submitPost.ts
+++ b/quotevote-frontend/src/lib/constants/submitPost.ts
@@ -1,0 +1,1 @@
+export const SUBMIT_POST_TITLE_MAX_LENGTH = 200

--- a/quotevote-frontend/src/lib/utils/submitPostDraft.ts
+++ b/quotevote-frontend/src/lib/utils/submitPostDraft.ts
@@ -1,0 +1,140 @@
+import type { SubmitPostFormValues } from '@/lib/validation/submitPostSchema'
+import type { SubmitPostDraft, SubmitPostDraftTag } from '@/types/submitPostDraft'
+
+const DRAFT_KEY_PREFIX = 'quotevote:submit-post-draft:'
+
+export function getSubmitPostDraftKey(userId: string): string {
+  return `${DRAFT_KEY_PREFIX}${userId}`
+}
+
+function isDraftTagEmpty(tag: SubmitPostDraft['tag']): boolean {
+  if (tag == null) return true
+  if (typeof tag === 'string') return tag.trim().length === 0
+  return tag.title.trim().length === 0
+}
+
+export function isSubmitPostDraftEmpty(draft: SubmitPostDraft): boolean {
+  return (
+    !draft.title.trim() &&
+    !draft.text.trim() &&
+    !draft.citationUrl.trim() &&
+    !draft.attribution.trim() &&
+    isDraftTagEmpty(draft.tag)
+  )
+}
+
+export function readSubmitPostDraft(userId: string): SubmitPostDraft | null {
+  if (typeof window === 'undefined') return null
+
+  try {
+    const raw = sessionStorage.getItem(getSubmitPostDraftKey(userId))
+    if (!raw) return null
+
+    const parsed = JSON.parse(raw) as Partial<SubmitPostDraft>
+    if (typeof parsed !== 'object' || parsed === null) return null
+
+    return {
+      title: typeof parsed.title === 'string' ? parsed.title : '',
+      text: typeof parsed.text === 'string' ? parsed.text : '',
+      citationUrl: typeof parsed.citationUrl === 'string' ? parsed.citationUrl : '',
+      attribution: typeof parsed.attribution === 'string' ? parsed.attribution : '',
+      tag: normalizeDraftTag(parsed.tag),
+    }
+  } catch {
+    return null
+  }
+}
+
+function normalizeDraftTag(value: unknown): SubmitPostDraft['tag'] {
+  if (value == null) return null
+  if (typeof value === 'string') return value
+  if (typeof value === 'object' && value !== null && 'title' in value) {
+    const tag = value as SubmitPostDraftTag
+    if (typeof tag.title !== 'string') return null
+    return {
+      _id: typeof tag._id === 'string' ? tag._id : undefined,
+      title: tag.title,
+    }
+  }
+  return null
+}
+
+export function writeSubmitPostDraft(userId: string, draft: SubmitPostDraft): void {
+  if (typeof window === 'undefined') return
+
+  if (isSubmitPostDraftEmpty(draft)) {
+    clearSubmitPostDraft(userId)
+    return
+  }
+
+  sessionStorage.setItem(getSubmitPostDraftKey(userId), JSON.stringify(draft))
+}
+
+export function clearSubmitPostDraft(userId: string): void {
+  if (typeof window === 'undefined') return
+  sessionStorage.removeItem(getSubmitPostDraftKey(userId))
+}
+
+export function formValuesToDraft(values: SubmitPostFormValues): SubmitPostDraft {
+  const { title, text, citationUrl, attribution, tag } = values
+
+  let serializedTag: SubmitPostDraft['tag'] = null
+  if (tag) {
+    if (typeof tag === 'string') {
+      serializedTag = tag
+    } else {
+      serializedTag = {
+        _id: '_id' in tag && typeof tag._id === 'string' ? tag._id : undefined,
+        title: tag.title,
+      }
+    }
+  }
+
+  return {
+    title: title ?? '',
+    text: text ?? '',
+    citationUrl: citationUrl ?? '',
+    attribution: attribution ?? '',
+    tag: serializedTag,
+  }
+}
+
+type TagOption = { _id?: string; title: string }
+
+export function resolveDraftTag(
+  draftTag: SubmitPostDraft['tag'],
+  options: TagOption[]
+): SubmitPostFormValues['tag'] {
+  if (draftTag == null) return undefined
+
+  if (typeof draftTag === 'string') {
+    const trimmed = draftTag.trim()
+    if (!trimmed) return undefined
+    const match = options.find((option) => option._id === trimmed || option.title === trimmed)
+    return match ?? { title: trimmed }
+  }
+
+  const trimmedTitle = draftTag.title.trim()
+  if (!trimmedTitle) return undefined
+
+  if (draftTag._id) {
+    const match = options.find((option) => option._id === draftTag._id)
+    return match ?? { _id: draftTag._id, title: trimmedTitle }
+  }
+
+  const match = options.find((option) => option.title === trimmedTitle)
+  return match ?? { title: trimmedTitle }
+}
+
+export function draftToFormValues(
+  draft: SubmitPostDraft,
+  options: TagOption[]
+): SubmitPostFormValues {
+  return {
+    title: draft.title,
+    text: draft.text,
+    citationUrl: draft.citationUrl,
+    attribution: draft.attribution,
+    tag: resolveDraftTag(draft.tag, options),
+  }
+}

--- a/quotevote-frontend/src/lib/validation/submitPostSchema.ts
+++ b/quotevote-frontend/src/lib/validation/submitPostSchema.ts
@@ -4,12 +4,14 @@
 
 import { z } from 'zod'
 import { containsUrl, sanitizeUrl } from '@/lib/utils/sanitizeUrl'
+import { ATTRIBUTION_MAX_LENGTH } from '@/lib/constants/attribution'
+import { SUBMIT_POST_TITLE_MAX_LENGTH } from '@/lib/constants/submitPost'
 
 export const submitPostSchema = z.object({
   title: z
     .string()
     .min(1, 'Title is required')
-    .max(200, 'Title should be less than 200 characters'),
+    .max(SUBMIT_POST_TITLE_MAX_LENGTH, `Title should be less than ${SUBMIT_POST_TITLE_MAX_LENGTH} characters`),
   text: z
     .string()
     .min(1, 'Post content is required')
@@ -28,16 +30,20 @@ export const submitPostSchema = z.object({
         message: 'Invalid URL format. Please enter a valid http or https URL.',
       }
     ),
-  group: z
+  attribution: z
+    .string()
+    .max(ATTRIBUTION_MAX_LENGTH, `Attribution should be less than ${ATTRIBUTION_MAX_LENGTH} characters`)
+    .optional(),
+  tag: z
     .union([
       z.object({
         _id: z.string(),
         title: z.string(),
       }),
       z.object({
-        title: z.string().min(1, 'Group name cannot be empty'),
+        title: z.string().min(1, 'Tag name cannot be empty'),
       }),
-      z.string().min(1, 'Please select or create a group'),
+      z.string().min(1, 'Please select or create a tag'),
     ])
     .optional()
     .refine(
@@ -48,8 +54,12 @@ export const submitPostSchema = z.object({
           return (value as { title: string }).title.trim().length > 0
         return false
       },
-      { message: 'Please select or create a group' }
+      { message: 'Please select or create a tag' }
     ),
 })
 
 export type SubmitPostFormValues = z.infer<typeof submitPostSchema>
+
+export function isSubmitPostFormReady(values: SubmitPostFormValues): boolean {
+  return submitPostSchema.safeParse(values).success
+}

--- a/quotevote-frontend/src/types/components.ts
+++ b/quotevote-frontend/src/types/components.ts
@@ -651,7 +651,7 @@ export interface SubmitPostProps {
 
 export interface SubmitPostFormProps {
   /**
-   * Array of available groups for selection
+   * Array of available tags for selection
    */
   options?: Group[];
   /**
@@ -693,7 +693,7 @@ export interface SubmitPostAlertProps {
 export interface SubmitPostFormValues {
   title: string;
   text: string;
-  group: Group | { title: string } | string;
+  tag: Group | { title: string } | string;
 }
 
 // Quotes Component Types

--- a/quotevote-frontend/src/types/post.ts
+++ b/quotevote-frontend/src/types/post.ts
@@ -77,6 +77,7 @@ export interface Post {
   text?: string | null
   url?: string | null
   citationUrl?: string | null
+  attribution?: string | null
   upvotes?: number | null
   downvotes?: number | null
   approvedBy?: string[] | null
@@ -119,6 +120,7 @@ export interface PostCardProps {
   title: string | null | undefined
   url: string | null | undefined
   citationUrl?: string | null
+  attribution?: string | null
   bookmarkedBy?: string[]
   approvedBy?: string[]
   rejectedBy?: string[]

--- a/quotevote-frontend/src/types/submitPostDraft.ts
+++ b/quotevote-frontend/src/types/submitPostDraft.ts
@@ -1,0 +1,12 @@
+export interface SubmitPostDraftTag {
+  _id?: string
+  title: string
+}
+
+export interface SubmitPostDraft {
+  title: string
+  text: string
+  citationUrl: string
+  attribution: string
+  tag: SubmitPostDraftTag | string | null
+}


### PR DESCRIPTION
## Summary
- Redesigns the Create Quote composer with a mobile-friendly layout, tag selector below the title, and optional citation/attribution grouped under **Add details (optional)**
- Adds post `attribution` support end-to-end (GraphQL, Mongoose, Prisma) and removes unused `attributionType`
- Improves UX with sessionStorage draft persistence, inline validation, disabled POST until required fields are valid, character counts, and tag-first copy (UI says tag; API still uses `groupId`)
- Updates E2E helpers/specs and developer docs (`README.md`, `CLAUDE.md`, `.env.e2e.example`)

## Test plan
- [x] Open Create Quote on desktop and mobile; confirm title, body, tag, optional details, and POST disabled/enabled states
- [x] Close and reopen composer; confirm draft restores from sessionStorage
- [x] Submit a valid post; confirm draft clears and post appears on explore
- [x] Run `pnpm type-check`, `pnpm test`, and `pnpm lint` in `quotevote-frontend/`
- [x] Run `pnpm type-check`, `pnpm test`, and `pnpm lint` in `quotevote-backend/`
- [x] Run `pnpm test:e2e post-submission.spec.ts` with `E2E_AUTHOR_PASSWORD` and `E2E_PUBLIC_TAG_NAME` set


Made with [Cursor](https://cursor.com)