### PR TITLE
fix(RC1-002): guest profile avatar navigation and related guest UX fixes

### DIFF
--- a/quotevote-frontend/src/__tests__/components/Profile/ProfileHeaderMessage.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/ProfileHeaderMessage.test.tsx
@@ -129,7 +129,6 @@ describe('ProfileHeader — Message button', () => {
       username: 'testuser',
       messageType: 'USER',
       users: ['currentuser', 'user1'],
-      username: 'testuser',
     });
     expect(setChatOpen).toHaveBeenCalledWith(true);
   });

--- a/quotevote-frontend/src/__tests__/components/Profile/UserFollowDisplay.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/UserFollowDisplay.test.tsx
@@ -83,6 +83,13 @@ describe('UserFollowDisplay', () => {
     expect(link).toHaveAttribute('href', '/dashboard/profile/testuser');
   });
 
+  it('links the avatar to the user profile (RC1-002: works for logged-out users)', () => {
+    const { getByTestId } = render(<UserFollowDisplay {...mockUser} />);
+    const avatarLink = getByTestId('display-avatar').closest('a');
+    expect(avatarLink).toHaveAttribute('href', '/dashboard/profile/testuser');
+    expect(avatarLink).toHaveAttribute('aria-label', 'Open testuser profile');
+  });
+
   it('handles object avatar structure', () => {
     const userWithObjectAvatar = {
       ...mockUser,

--- a/quotevote-frontend/src/app/components/LandingPage/LandingPageContent.tsx
+++ b/quotevote-frontend/src/app/components/LandingPage/LandingPageContent.tsx
@@ -18,7 +18,6 @@ import {
   ShieldOff,
   Search,
   FileText,
-  User,
   CheckCircle2,
   Users,
   TrendingUp,
@@ -31,6 +30,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
+import { DisplayAvatar } from '@/components/DisplayAvatar';
 import { useAppStore } from '@/store';
 import { SEARCH, GET_FEATURED_POSTS } from '@/graphql/queries';
 import { REQUEST_USER_ACCESS_MUTATION } from '@/graphql/mutations';
@@ -1739,19 +1739,11 @@ function HeroSearch({ router }: HeroSearchProps) {
                       onClick={() => handleCreatorClick(creator)}
                       className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors text-left"
                     >
-                      <div className="w-8 h-8 rounded-full overflow-hidden flex-shrink-0 bg-gray-200 flex items-center justify-center">
-                        {creator.avatar ? (
-                          <Image
-                            src={creator.avatar}
-                            alt={creator.name ?? 'Creator avatar'}
-                            width={32}
-                            height={32}
-                            className="w-full h-full object-cover"
-                          />
-                        ) : (
-                          <User size={16} className="text-gray-400" aria-hidden />
-                        )}
-                      </div>
+                      <DisplayAvatar
+                        avatar={creator.avatar}
+                        username={creator.name || creator.username || ''}
+                        size={32}
+                      />
                       <p className="text-sm font-medium text-gray-900 truncate">{creator.name}</p>
                     </button>
                   ))}

--- a/quotevote-frontend/src/app/dashboard/layout.tsx
+++ b/quotevote-frontend/src/app/dashboard/layout.tsx
@@ -131,13 +131,15 @@ export default function DashboardLayout({
 
   const { data: notifData } = useQuery<{ notifications: Array<{ _id: string; status: string }> }>(
     GET_NOTIFICATIONS,
-    { skip: !loggedIn, fetchPolicy: 'cache-and-network', pollInterval: 60000 }
+    // pollInterval is gated on loggedIn: Apollo keeps polling a query even when
+    // `skip` is true, which would fire authed-only requests for guests.
+    { skip: !loggedIn, fetchPolicy: 'cache-and-network', pollInterval: loggedIn ? 60000 : 0 }
   );
 
   const { data: roomsData } = useQuery<{ messageRooms: ChatRoom[] }>(GET_CHAT_ROOMS, {
     skip: !loggedIn,
     fetchPolicy: 'cache-and-network',
-    pollInterval: 8000,
+    pollInterval: loggedIn ? 8000 : 0,
   });
 
   const unreadCount = useMemo(

--- a/quotevote-frontend/src/components/Profile/UserFollowDisplay.tsx
+++ b/quotevote-frontend/src/components/Profile/UserFollowDisplay.tsx
@@ -18,13 +18,17 @@ export function UserFollowDisplay({
       className="flex flex-row items-center justify-center gap-4 p-4 border-b last:border-b-0"
       id="component-user-follow-display"
     >
-      <div className="flex-shrink-0">
+      <Link
+        href={`/dashboard/profile/${username}`}
+        aria-label={`Open ${username} profile`}
+        className="shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#52b274] focus-visible:ring-offset-2"
+      >
         <DisplayAvatar
           avatar={avatar as string | Record<string, unknown> | undefined}
           username={username}
           size={50}
         />
-      </div>
+      </Link>
       <div className="flex-1 flex flex-col gap-1">
         <Link
           href={`/dashboard/profile/${username}`}


### PR DESCRIPTION
## Summary
- Closes #353 (RC1-002): make follower/following list avatars navigate to `/dashboard/profile/{username}` for logged-out users (username already linked; avatar was not).
- Stop intermittent guest toast `Cannot read properties of undefined (reading '_id')` by gating dashboard `GET_CHAT_ROOMS` / `GET_NOTIFICATIONS` `pollInterval` on `loggedIn` (Apollo continues polling when `skip` is true).
- Fix landing hero People search console errors from empty/`{}` avatar values by using shared `DisplayAvatar`.

## Test plan
- [ ] Logged out: open `/dashboard/explore`, click a post author avatar → lands on that user's public profile
- [ ] Logged out: open a profile → Followers → click another user's avatar → lands on that profile
- [ ] Logged out: stay on `/dashboard/explore` for ~20s → no `_id` toast / no `getChatRooms` errors
- [ ] Landing `/`: search a name with People results → avatars render with no Image `src` console errors
- [ ] Logged in: chat unread badge still updates (poll resumes)


Made with [Cursor](https://cursor.com)