### PR TITLE
fix(frontend): featured posts navigate to post detail (RC1-004) #355

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ quotevote-backend/compose.yml
 quotevote-backend/dockerfile
 session_state.md
 graphify-out/
+
+# Local Cursor IDE rules / agent config (machine-specific)
+.cursor/

--- a/quotevote-backend/app/server.ts
+++ b/quotevote-backend/app/server.ts
@@ -112,8 +112,8 @@ async function startServer() {
         getBuddyList: [BuddyWithPresence!]!
         getRoster: [Roster!]!
         
-        # Action reactions
-        actionReactions(actionId: ID!): [Reaction!]!
+        # Action reactions (String! — matches hosted/legacy API; ID! breaks clients)
+        actionReactions(actionId: String!): [Reaction!]!
         
         # Admin / reports
         getBotReportedUsers(sortBy: String, limit: Int): [User!]!

--- a/quotevote-frontend/.env.example
+++ b/quotevote-frontend/.env.example
@@ -1,0 +1,14 @@
+# Quote.Vote API — local development
+# Copy to `.env.local` and adjust for your machine. Never commit `.env.local`.
+NEXT_PUBLIC_SERVER_URL=http://localhost:4000
+NEXT_PUBLIC_GRAPHQL_ENDPOINT=http://localhost:4000/graphql
+
+# Optional: point at hosted staging/production instead of local backend
+# NEXT_PUBLIC_SERVER_URL=https://api.quote.vote
+# NEXT_PUBLIC_GRAPHQL_ENDPOINT=https://api.quote.vote/graphql
+
+# WebSocket is auto-derived by getGraphqlWsServerUrl():
+#   ws://localhost:4000/graphql   (local)
+#   wss://api.quote.vote/graphql  (hosted)
+# Login is a REST endpoint (not GraphQL):
+#   POST {NEXT_PUBLIC_SERVER_URL}/auth/login  →  { username, password }  →  { token }

--- a/quotevote-frontend/.env.local
+++ b/quotevote-frontend/.env.local
@@ -1,8 +1,0 @@
-# Quote.Vote API — local development
-NEXT_PUBLIC_SERVER_URL=http://localhost:4000
-NEXT_PUBLIC_GRAPHQL_ENDPOINT=http://localhost:4000/graphql
-
-# WebSocket is auto-derived by getGraphqlWsServerUrl():
-#   ws://localhost:4000/graphql
-# Login is a REST endpoint (not GraphQL):
-#   POST http://localhost:4000/login  →  { username, password }  →  { token }

--- a/quotevote-frontend/.gitignore
+++ b/quotevote-frontend/.gitignore
@@ -38,6 +38,9 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env
+.env*.local
+!.env.example
+!.env.e2e.example
 
 # vercel
 .vercel

--- a/quotevote-frontend/README.md
+++ b/quotevote-frontend/README.md
@@ -58,14 +58,19 @@ The application will be available at [http://localhost:3000](http://localhost:30
 
 ### Environment Variables
 
-Create a `.env.local` file in the root directory with the following variable:
+Copy the example env file and adjust as needed:
+
+```bash
+cp .env.example .env.local
+```
 
 ```env
 # GraphQL endpoint URL (must be prefixed with NEXT_PUBLIC_)
+NEXT_PUBLIC_SERVER_URL=http://localhost:4000
 NEXT_PUBLIC_GRAPHQL_ENDPOINT=http://localhost:4000/graphql
 ```
 
-The server URL is automatically derived from the GraphQL endpoint by removing the `/graphql` suffix.
+`.env.local` is gitignored — keep machine-specific overrides (including hosted API URLs) there only.
 
 ## 🎯 Path Aliases
 

--- a/quotevote-frontend/e2e/featured-posts.spec.ts
+++ b/quotevote-frontend/e2e/featured-posts.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * RC1-004 — Featured posts should navigate to post detail page
+ *
+ * Clicking a featured post card on the homepage should open the
+ * corresponding post detail route.
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const FEATURED_POSTS = [
+  {
+    __typename: "Post",
+    _id: "feat-e2e-1",
+    userId: "user-1",
+    groupId: "general",
+    title: "E2E Featured Post One",
+    text: "First featured post body used for navigation regression coverage.",
+    upvotes: 5,
+    downvotes: 0,
+    bookmarkedBy: [],
+    created: new Date().toISOString(),
+    url: "/post/general/e2e-featured-post-one/feat-e2e-1",
+    citationUrl: null,
+    creator: {
+      __typename: "User",
+      _id: "user-1",
+      name: "Featured Author",
+      username: "featured_author",
+      avatar: null,
+      contributorBadge: false,
+    },
+    votes: [],
+    comments: [{ __typename: "Comment", _id: "c1" }],
+    quotes: [],
+    messageRoom: null,
+  },
+  {
+    __typename: "Post",
+    _id: "feat-e2e-2",
+    userId: "user-2",
+    groupId: "climate",
+    title: "E2E Featured Post Two",
+    text: "Second featured post body used for navigation regression coverage.",
+    upvotes: 3,
+    downvotes: 1,
+    bookmarkedBy: [],
+    created: new Date().toISOString(),
+    url: "/post/climate/e2e-featured-post-two/feat-e2e-2",
+    citationUrl: null,
+    creator: {
+      __typename: "User",
+      _id: "user-2",
+      name: "Second Author",
+      username: "second_author",
+      avatar: null,
+      contributorBadge: false,
+    },
+    votes: [],
+    comments: [],
+    quotes: [{ __typename: "Quote", _id: "q1" }],
+    messageRoom: null,
+  },
+] as const;
+
+async function mockFeaturedPostsGraphQL(page: Page) {
+  await page.route("**/graphql", async (route) => {
+    const request = route.request();
+    if (request.method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+
+    let query = "";
+    try {
+      const payload = request.postDataJSON() as { query?: string } | null;
+      query = payload?.query || "";
+    } catch {
+      await route.fallback();
+      return;
+    }
+
+    if (!query.includes("featuredPosts")) {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: {
+          featuredPosts: {
+            __typename: "Posts",
+            entities: FEATURED_POSTS,
+            pagination: {
+              __typename: "Pagination",
+              total_count: FEATURED_POSTS.length,
+              limit: 10,
+              offset: 0,
+            },
+          },
+        },
+      }),
+    });
+  });
+}
+
+test.describe("RC1-004 Featured posts navigate to post detail", () => {
+  // Homepage featured posts are for logged-out visitors; clear stored auth.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockFeaturedPostsGraphQL(page);
+  });
+
+  test("clicking each featured post card opens the corresponding post page", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const cards = page.getByTestId("featured-post-card");
+    await expect(cards).toHaveCount(FEATURED_POSTS.length);
+
+    for (const post of FEATURED_POSTS) {
+      await page.goto("/");
+      await expect(cards).toHaveCount(FEATURED_POSTS.length);
+
+      const card = page.getByTestId("featured-post-card").filter({
+        hasText: post.title,
+      });
+      await expect(card).toBeVisible();
+      await expect(card).toHaveAttribute(
+        "href",
+        `/dashboard${post.url.replace(/\?/g, "")}`
+      );
+
+      await card.click();
+      await expect(page).toHaveURL(new RegExp(`/dashboard${post.url}$`));
+
+      await page.goBack();
+      await expect(page).toHaveURL(/\/$/);
+      await expect(cards.first()).toBeVisible();
+    }
+  });
+});

--- a/quotevote-frontend/src/__tests__/app/page.test.tsx
+++ b/quotevote-frontend/src/__tests__/app/page.test.tsx
@@ -544,6 +544,89 @@ describe('LandingPage', () => {
     });
   });
 
+  // ── Featured posts navigation (RC1-004) ────────────────────
+
+  describe('Featured posts navigation', () => {
+    const featuredPosts = [
+      {
+        _id: 'feat-1',
+        userId: 'u1',
+        title: 'Featured Democracy Debate',
+        text: 'A thoughtful take on civic discourse.',
+        created: new Date().toISOString(),
+        url: '/post/general/featured-democracy-debate/feat-1',
+        upvotes: 12,
+        downvotes: 1,
+        creator: { _id: 'u1', name: 'Alex Author', username: 'alex' },
+        comments: [{ _id: 'c1' }],
+        quotes: [],
+      },
+      {
+        _id: 'feat-2',
+        userId: 'u2',
+        title: 'Climate Action Now',
+        text: 'We need practical climate policy.',
+        created: new Date().toISOString(),
+        url: '/post/climate/climate-action-now/feat-2',
+        upvotes: 8,
+        downvotes: 0,
+        creator: { _id: 'u2', name: 'Sam Writer', username: 'sam' },
+        comments: [],
+        quotes: [{ _id: 'q1' }],
+      },
+    ];
+
+    beforeEach(() => {
+      mockUseQuery.mockReturnValue({
+        loading: false,
+        error: undefined,
+        data: {
+          featuredPosts: {
+            entities: featuredPosts,
+            pagination: { total_count: 2, limit: 10, offset: 0 },
+          },
+          posts: { entities: [] },
+          searchUser: [],
+        },
+      });
+    });
+
+    it('renders featured post cards as links to post detail routes', () => {
+      renderLandingPage();
+
+      expect(
+        screen.getByRole('heading', { name: /featured posts/i })
+      ).toBeInTheDocument();
+
+      const firstCard = screen.getByRole('link', {
+        name: /read featured post: featured democracy debate/i,
+      });
+      expect(firstCard).toHaveAttribute(
+        'href',
+        '/dashboard/post/general/featured-democracy-debate/feat-1'
+      );
+
+      const secondCard = screen.getByRole('link', {
+        name: /read featured post: climate action now/i,
+      });
+      expect(secondCard).toHaveAttribute(
+        'href',
+        '/dashboard/post/climate/climate-action-now/feat-2'
+      );
+    });
+
+    it('makes the full card the clickable navigation target', () => {
+      renderLandingPage();
+
+      const cards = screen.getAllByTestId('featured-post-card');
+      expect(cards).toHaveLength(2);
+      cards.forEach((card) => {
+        expect(card.tagName.toLowerCase()).toBe('a');
+        expect(card).toHaveAttribute('href');
+      });
+    });
+  });
+
   // ── Auth redirect ──────────────────────────────────────────
 
   describe('Auth redirect', () => {

--- a/quotevote-frontend/src/app/components/LandingPage/LandingPageContent.tsx
+++ b/quotevote-frontend/src/app/components/LandingPage/LandingPageContent.tsx
@@ -1971,6 +1971,10 @@ function FeaturedPostCard({ post, timeAgo }: { post: Post; timeAgo: string }) {
   const downvotes = post.downvotes ?? 0;
   const commentCount = post.comments?.length || 0;
   const quoteCount = post.quotes?.length || 0;
+  const href = post.url ? toAppPostUrl(post.url) : undefined;
+  const ariaLabel = post.title
+    ? `Read featured post: ${post.title}`
+    : 'Read featured post';
 
   const displayText = post.text
     ? post.text.length > 200
@@ -1978,98 +1982,125 @@ function FeaturedPostCard({ post, timeAgo }: { post: Post; timeAgo: string }) {
       : post.text
     : '';
 
-  return (
-    <div
-      className="flex-shrink-0 w-[85%] sm:w-[420px] snap-center"
-      role="listitem"
-    >
-      <div
-        className="rounded-2xl p-6 h-full flex flex-col transition-all hover:-translate-y-1"
-        style={{
-          background: '#ffffff',
-          border: '1px solid #e2e8f0',
-          boxShadow: '0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04)',
-        }}
-      >
-        {/* Header: author + star badge */}
-        <div className="flex items-center gap-3 mb-4">
-          <div
-            className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 text-sm font-bold"
-            style={{
-              background: '#f0fdf4',
-              color: '#2ecc71',
-            }}
-          >
-            {creatorName[0]?.toUpperCase() || '?'}
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-semibold truncate" style={{ color: '#0f172a' }}>{creatorName}</p>
-            <p className="text-xs truncate" style={{ color: '#94a3b8' }}>
-              @{username} · {timeAgo}
-            </p>
-          </div>
-          <div
-            className="flex items-center gap-1 px-2 py-1 rounded-full flex-shrink-0"
-            style={{
-              background: '#f0fdf4',
-              border: '1px solid #bbf7d0',
-            }}
-          >
-            <Star size={12} style={{ color: '#2ecc71' }} aria-hidden />
-            <span className="text-[10px] font-bold" style={{ color: '#2ecc71' }}>
-              Featured
-            </span>
-          </div>
-        </div>
+  const cardClassName =
+    'rounded-2xl p-6 h-full flex flex-col transition-all hover:-translate-y-1';
+  const cardStyle: React.CSSProperties = {
+    background: '#ffffff',
+    border: '1px solid #e2e8f0',
+    boxShadow: '0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04)',
+  };
 
-        {/* Title */}
-        {post.title && (
-          <h3 className="text-base font-bold mb-2 leading-snug line-clamp-2" style={{ color: '#0f172a' }}>
-            {post.title}
-          </h3>
-        )}
-
-        {/* Body */}
-        {displayText && (
-          <p
-            className="text-sm leading-relaxed mb-4 flex-1 line-clamp-4"
-            style={{ color: '#475569' }}
-          >
-            {displayText}
-          </p>
-        )}
-
-        {/* Engagement stats */}
+  const cardContent = (
+    <>
+      {/* Header: author + star badge */}
+      <div className="flex items-center gap-3 mb-4">
         <div
-          className="flex items-center gap-4 pt-4 mt-auto"
-          style={{ borderTop: '1px solid #e2e8f0' }}
+          className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 text-sm font-bold"
+          style={{
+            background: '#f0fdf4',
+            color: '#2ecc71',
+          }}
         >
-          <div className="flex items-center gap-1.5">
-            <ThumbsUp size={14} style={{ color: '#2ecc71' }} aria-hidden />
-            <span className="text-xs tabular-nums" style={{ color: '#64748b' }}>
-              {upvotes}
-            </span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <ThumbsDown size={14} style={{ color: '#ef4444' }} aria-hidden />
-            <span className="text-xs tabular-nums" style={{ color: '#64748b' }}>
-              {downvotes}
-            </span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <MessageCircle size={14} style={{ color: '#27C4E1' }} aria-hidden />
-            <span className="text-xs tabular-nums" style={{ color: '#64748b' }}>
-              {commentCount}
-            </span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <MessageSquareQuote size={14} style={{ color: '#c8a03c' }} aria-hidden />
-            <span className="text-xs tabular-nums" style={{ color: '#64748b' }}>
-              {quoteCount}
-            </span>
-          </div>
+          {creatorName[0]?.toUpperCase() || '?'}
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold truncate" style={{ color: '#0f172a' }}>
+            {creatorName}
+          </p>
+          <p className="text-xs truncate" style={{ color: '#94a3b8' }}>
+            @{username} · {timeAgo}
+          </p>
+        </div>
+        <div
+          className="flex items-center gap-1 px-2 py-1 rounded-full flex-shrink-0"
+          style={{
+            background: '#f0fdf4',
+            border: '1px solid #bbf7d0',
+          }}
+        >
+          <Star size={12} style={{ color: '#2ecc71' }} aria-hidden />
+          <span className="text-[10px] font-bold" style={{ color: '#2ecc71' }}>
+            Featured
+          </span>
         </div>
       </div>
+
+      {/* Title */}
+      {post.title && (
+        <h3
+          className="text-base font-bold mb-2 leading-snug line-clamp-2"
+          style={{ color: '#0f172a' }}
+        >
+          {post.title}
+        </h3>
+      )}
+
+      {/* Body */}
+      {displayText && (
+        <p
+          className="text-sm leading-relaxed mb-4 flex-1 line-clamp-4"
+          style={{ color: '#475569' }}
+        >
+          {displayText}
+        </p>
+      )}
+
+      {/* Engagement stats */}
+      <div
+        className="flex items-center gap-4 pt-4 mt-auto"
+        style={{ borderTop: '1px solid #e2e8f0' }}
+      >
+        <div className="flex items-center gap-1.5">
+          <ThumbsUp size={14} style={{ color: '#2ecc71' }} aria-hidden />
+          <span className="text-xs tabular-nums" style={{ color: '#64748b' }}>
+            {upvotes}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <ThumbsDown size={14} style={{ color: '#ef4444' }} aria-hidden />
+          <span className="text-xs tabular-nums" style={{ color: '#64748b' }}>
+            {downvotes}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <MessageCircle size={14} style={{ color: '#27C4E1' }} aria-hidden />
+          <span className="text-xs tabular-nums" style={{ color: '#64748b' }}>
+            {commentCount}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <MessageSquareQuote size={14} style={{ color: '#c8a03c' }} aria-hidden />
+          <span className="text-xs tabular-nums" style={{ color: '#64748b' }}>
+            {quoteCount}
+          </span>
+        </div>
+      </div>
+    </>
+  );
+
+  return (
+    <div className="flex-shrink-0 w-[85%] sm:w-[420px] snap-center" role="listitem">
+      {href ? (
+        <Link
+          href={href}
+          className={`${cardClassName} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2ecc71] focus-visible:ring-offset-2`}
+          style={cardStyle}
+          aria-label={ariaLabel}
+          data-testid="featured-post-card"
+          data-post-id={post._id}
+        >
+          {cardContent}
+        </Link>
+      ) : (
+        <div
+          className={cardClassName}
+          style={cardStyle}
+          data-testid="featured-post-card"
+          data-post-id={post._id}
+        >
+          {cardContent}
+        </div>
+      )}
     </div>
   );
 }

--- a/quotevote-frontend/src/components/Activity/ActivityList.tsx
+++ b/quotevote-frontend/src/components/Activity/ActivityList.tsx
@@ -175,7 +175,12 @@ function LoadActivityList({
     <div className="space-y-5">
       {activities.map((activity) => (
         <div
-          key={activity._id}
+          key={
+            activity._id ||
+            [activity.postId, activity.activityType, activity.voteId, activity.commentId, activity.quoteId]
+              .filter(Boolean)
+              .join('-')
+          }
           className="rounded-lg shadow-lg border"
           style={{ borderRadius: 7 }}
         >

--- a/quotevote-frontend/src/components/Activity/PaginatedActivityList.tsx
+++ b/quotevote-frontend/src/components/Activity/PaginatedActivityList.tsx
@@ -230,10 +230,23 @@ export function PaginatedActivityList({
     (activity) => !hiddenPosts.includes(activity._id)
   )
 
-  // Render individual activity
-  const renderActivity = (activity: ActivityEntity) => (
-    <LoadActivityCard key={activity._id} activity={activity} width={width} />
-  )
+  // Render individual activity — keys must be stable across inserts/removes/reorders.
+  // `_id` is requested by GET_USER_ACTIVITY; composite fields are stable fallbacks only.
+  const renderActivity = (activity: ActivityEntity) => {
+    const key =
+      activity._id ||
+      [
+        activity.postId,
+        activity.activityType,
+        activity.voteId,
+        activity.commentId,
+        activity.quoteId,
+      ]
+        .filter((part) => part !== undefined && part !== null && part !== '')
+        .join('-')
+
+    return <LoadActivityCard key={key} activity={activity} width={width} />
+  }
 
   // Render empty state
   const renderEmpty = () => (

--- a/quotevote-frontend/src/graphql/queries.ts
+++ b/quotevote-frontend/src/graphql/queries.ts
@@ -109,7 +109,7 @@ export const GET_GROUP = gql`
  * Get action reactions query
  */
 export const GET_ACTION_REACTIONS = gql`
-  query GetActionReactions($actionId: ID!) {
+  query GetActionReactions($actionId: String!) {
     actionReactions(actionId: $actionId) {
       _id
       userId
@@ -715,6 +715,7 @@ export const GET_USER_ACTIVITY = gql`
       activityEvent: $activityEvent
     ) {
       entities {
+        _id
         created
         postId
         userId


### PR DESCRIPTION
## Summary
- Make each featured post card a link to its post detail route via `toAppPostUrl`.
- Add unit and E2E regression coverage for featured-post navigation (desktop + mobile).
- Stop tracking `.env.local` (add `.env.example` + gitignore) so API overrides stay machine-local.
- Fix `GetActionReactions` variable type (`String!`) to match the hosted API and avoid 400s.
- Request activity `_id` and use stable keys in activity lists (no index-based keys).
- Ignore local `.cursor/` so IDE/agent rules stay machine-specific.

## Commits
1. `fix(frontend): navigate featured posts to detail pages (RC1-004)`
   - Featured post card → post detail navigation
   - Unit + E2E coverage
   - Untrack `.env.local`; add `.env.example` and frontend gitignore/README updates
2. `fix: align actionReactions types and stabilize activity list keys`
   - `GetActionReactions($actionId: String!)` (frontend + backend schema)
   - `GET_USER_ACTIVITY` requests entity `_id`
   - Stable React keys in `ActivityList` / `PaginatedActivityList`
3. `chore: ignore local .cursor directory`
   - Root `.gitignore` entry for `.cursor/`

## Test plan
- [ ] Open homepage logged out; confirm Featured Posts cards are links.
- [ ] Click each featured card and land on `/dashboard/post/...` for that post.
- [ ] Confirm browser back returns to the homepage with cards still visible.
- [ ] Open a post with comments/votes; confirm no `GetActionReactions` 400 in the console.
- [ ] Open a profile activity feed; confirm no React unique-key warning.
- [ ] `pnpm test -- src/__tests__/app/page.test.tsx` (featured posts navigation cases)
- [ ] `pnpm test:e2e featured-posts.spec.ts`
- [ ] Confirm `.env.local` is ignored and new clones use `cp .env.example .env.local`
- [ ] Confirm `.cursor/` is ignored and not present in the PR diff