### PR TITLE
feat(profile): About bio, settings UX, and updateUser (1/4)

### DIFF
--- a/quotevote-backend/__tests__/unit/authentication.test.ts
+++ b/quotevote-backend/__tests__/unit/authentication.test.ts
@@ -158,8 +158,12 @@ describe('Authentication Utils', () => {
             const mockUser = {
                 _id: 'mockId',
                 username: 'testuser',
+                name: 'Test User',
                 email: 'test@example.com',
                 admin: false,
+                accountStatus: 'active',
+                avatar: { topType: 'ShortHairShortFlat', hairColor: 'Brown' },
+                bio: 'Hello',
                 comparePassword: jest.fn().mockResolvedValue(true),
             };
             (User.findOne as jest.Mock).mockResolvedValue(mockUser);
@@ -170,7 +174,12 @@ describe('Authentication Utils', () => {
             expect(jwt.sign).toHaveBeenCalled();
             expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
                 accessToken: 'token',
-                refreshToken: 'token'
+                refreshToken: 'token',
+                user: expect.objectContaining({
+                    username: 'testuser',
+                    avatar: { topType: 'ShortHairShortFlat', hairColor: 'Brown' },
+                    bio: 'Hello',
+                }),
             }));
         });
     });

--- a/quotevote-backend/__tests__/unit/resolvers/userResolver.test.ts
+++ b/quotevote-backend/__tests__/unit/resolvers/userResolver.test.ts
@@ -1,8 +1,28 @@
 import mongoose from 'mongoose';
+import { GraphQLError } from 'graphql';
 import { userResolver } from '~/data/resolvers/userResolver';
 import User from '~/data/models/User';
+import type { GraphQLContext } from '~/types/graphql';
 
 jest.mock('~/data/models/User');
+
+const actorId = '60d5ec49ad414d7a8d5464a0';
+const otherId = '60d5ec49ad414d7a8d5464a1';
+
+function mockContext(overrides: Partial<NonNullable<GraphQLContext['user']>> = {}): GraphQLContext {
+  return {
+    req: {} as GraphQLContext['req'],
+    res: {} as GraphQLContext['res'],
+    pubsub: {} as GraphQLContext['pubsub'],
+    user: {
+      _id: actorId,
+      username: 'alice',
+      email: 'alice@example.com',
+      admin: false,
+      ...overrides,
+    } as NonNullable<GraphQLContext['user']>,
+  };
+}
 
 describe('userResolver', () => {
   beforeEach(() => {
@@ -61,6 +81,147 @@ describe('userResolver', () => {
           accountStatus: 'active',
         },
       ]);
+    });
+  });
+
+  describe('Mutation.updateUser', () => {
+    it('requires authentication', async () => {
+      await expect(
+        userResolver.Mutation.updateUser(
+          null,
+          { user: { _id: actorId, bio: 'Hello' } },
+          { ...mockContext(), user: null }
+        )
+      ).rejects.toThrow(GraphQLError);
+    });
+
+    it('updates own bio as plain text', async () => {
+      (User.findByIdAndUpdate as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          _id: new mongoose.Types.ObjectId(actorId),
+          username: 'alice',
+          bio: 'Thoughtful dialogue',
+        }),
+      });
+
+      const result = await userResolver.Mutation.updateUser(
+        null,
+        { user: { _id: actorId, bio: '  Thoughtful dialogue  ' } },
+        mockContext()
+      );
+
+      expect(User.findByIdAndUpdate).toHaveBeenCalledWith(
+        actorId,
+        { $set: { bio: 'Thoughtful dialogue' } },
+        { new: true }
+      );
+      expect(result.bio).toBe('Thoughtful dialogue');
+    });
+
+    it('rejects HTML in bio', async () => {
+      await expect(
+        userResolver.Mutation.updateUser(
+          null,
+          { user: { _id: actorId, bio: '<b>nope</b>' } },
+          mockContext()
+        )
+      ).rejects.toThrow(/plain text/);
+      expect(User.findByIdAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('forbids non-admin from updating another user', async () => {
+      await expect(
+        userResolver.Mutation.updateUser(
+          null,
+          { user: { _id: otherId, bio: 'Nope' } },
+          mockContext({ admin: false })
+        )
+      ).rejects.toThrow(/Not authorized/);
+    });
+
+    it('allows admin to update contributorBadge on another user', async () => {
+      (User.findByIdAndUpdate as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          _id: new mongoose.Types.ObjectId(otherId),
+          username: 'bob',
+          contributorBadge: true,
+        }),
+      });
+
+      const result = await userResolver.Mutation.updateUser(
+        null,
+        { user: { _id: otherId, contributorBadge: true } },
+        mockContext({ admin: true })
+      );
+
+      expect(User.findByIdAndUpdate).toHaveBeenCalledWith(
+        otherId,
+        { $set: { contributorBadge: true } },
+        { new: true }
+      );
+      expect(result.contributorBadge).toBe(true);
+    });
+  });
+
+  describe('Mutation.updateUserAvatar', () => {
+    const avatarQualities = {
+      topType: 'LongHairStraight',
+      hairColor: 'Brown',
+      clotheType: 'Hoodie',
+    };
+
+    it('requires authentication', async () => {
+      await expect(
+        userResolver.Mutation.updateUserAvatar(
+          null,
+          { user_id: actorId, avatarQualities },
+          { ...mockContext(), user: null }
+        )
+      ).rejects.toThrow(GraphQLError);
+    });
+
+    it('updates own avatar qualities', async () => {
+      (User.findByIdAndUpdate as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          _id: new mongoose.Types.ObjectId(actorId),
+          username: 'alice',
+          avatar: avatarQualities,
+        }),
+      });
+
+      const result = await userResolver.Mutation.updateUserAvatar(
+        null,
+        { user_id: actorId, avatarQualities },
+        mockContext()
+      );
+
+      expect(User.findByIdAndUpdate).toHaveBeenCalledWith(
+        actorId,
+        { $set: { avatar: avatarQualities } },
+        { new: true }
+      );
+      expect(result.avatar).toEqual(avatarQualities);
+    });
+
+    it('forbids updating another user avatar', async () => {
+      await expect(
+        userResolver.Mutation.updateUserAvatar(
+          null,
+          { user_id: otherId, avatarQualities },
+          mockContext({ admin: false })
+        )
+      ).rejects.toThrow(/Not authorized/);
+      expect(User.findByIdAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-object avatarQualities', async () => {
+      await expect(
+        userResolver.Mutation.updateUserAvatar(
+          null,
+          { user_id: actorId, avatarQualities: null },
+          mockContext()
+        )
+      ).rejects.toThrow(/avatarQualities/);
     });
   });
 });

--- a/quotevote-backend/__tests__/unit/utils/bioValidation.test.ts
+++ b/quotevote-backend/__tests__/unit/utils/bioValidation.test.ts
@@ -1,0 +1,33 @@
+import { normalizeBio, BIO_MAX_LENGTH } from '~/data/utils/bioValidation';
+
+describe('bioValidation', () => {
+  describe('normalizeBio', () => {
+    it('trims whitespace', () => {
+      expect(normalizeBio('  hello world  ')).toBe('hello world');
+    });
+
+    it('returns empty string for nullish or blank input', () => {
+      expect(normalizeBio(null)).toBe('');
+      expect(normalizeBio(undefined)).toBe('');
+      expect(normalizeBio('   ')).toBe('');
+    });
+
+    it('accepts plain text within the max length', () => {
+      const bio = 'a'.repeat(BIO_MAX_LENGTH);
+      expect(normalizeBio(bio)).toBe(bio);
+    });
+
+    it('rejects text longer than the max length', () => {
+      expect(() => normalizeBio('a'.repeat(BIO_MAX_LENGTH + 1))).toThrow(
+        `About must be ${BIO_MAX_LENGTH} characters or fewer`
+      );
+    });
+
+    it('rejects HTML markup', () => {
+      expect(() => normalizeBio('Hello <script>alert(1)</script>')).toThrow(
+        'About must be plain text without HTML'
+      );
+      expect(() => normalizeBio('<b>bold</b>')).toThrow('About must be plain text without HTML');
+    });
+  });
+});

--- a/quotevote-backend/__tests__/unit/utils/serializeDate.test.ts
+++ b/quotevote-backend/__tests__/unit/utils/serializeDate.test.ts
@@ -1,0 +1,30 @@
+import { toIsoDateString } from '~/data/utils/serializeDate';
+
+describe('toIsoDateString', () => {
+  it('serializes Date instances to ISO strings', () => {
+    expect(toIsoDateString(new Date('2024-01-15T12:00:00.000Z'))).toBe(
+      '2024-01-15T12:00:00.000Z'
+    );
+  });
+
+  it('serializes millisecond epoch numbers to ISO strings', () => {
+    const ms = Date.UTC(2024, 0, 15);
+    expect(toIsoDateString(ms)).toBe(new Date(ms).toISOString());
+  });
+
+  it('treats small epoch numbers as seconds', () => {
+    expect(toIsoDateString(1705276800)).toBe('2024-01-15T00:00:00.000Z');
+  });
+
+  it('serializes numeric timestamp strings', () => {
+    const ms = Date.UTC(2024, 0, 15);
+    expect(toIsoDateString(String(ms))).toBe(new Date(ms).toISOString());
+  });
+
+  it('returns empty string for invalid values', () => {
+    expect(toIsoDateString(null)).toBe('');
+    expect(toIsoDateString(undefined)).toBe('');
+    expect(toIsoDateString('not-a-date')).toBe('');
+    expect(toIsoDateString(new Date('invalid'))).toBe('');
+  });
+});

--- a/quotevote-backend/app/data/inputs/UserInput.ts
+++ b/quotevote-backend/app/data/inputs/UserInput.ts
@@ -10,6 +10,7 @@ export const UserInput = new GraphQLInputObjectType({
     password: { type: GraphQLString },
     quotes: { type: new GraphQLList(GraphQLString) },
     avatar: { type: GraphQLString },
+    bio: { type: GraphQLString },
     contributorBadge: { type: GraphQLBoolean },
     themePreference: { type: GraphQLString },
   },

--- a/quotevote-backend/app/data/resolvers/userResolver.ts
+++ b/quotevote-backend/app/data/resolvers/userResolver.ts
@@ -1,5 +1,44 @@
+import * as bcrypt from 'bcryptjs';
+import { GraphQLError } from 'graphql';
 import User from '../models/User';
+import { normalizeBio } from '../utils/bioValidation';
 import type * as Common from '~/types/common';
+import type { GraphQLContext } from '~/types/graphql';
+
+type UpdateUserInput = {
+  _id: string;
+  name?: string | null;
+  username?: string | null;
+  email?: string | null;
+  password?: string | null;
+  avatar?: string | null;
+  bio?: string | null;
+  contributorBadge?: boolean | null;
+  themePreference?: string | null;
+};
+
+function toPublicUser(user: {
+  _id: { toString(): string } | string;
+  reputation?: Common.Reputation | null;
+  [key: string]: unknown;
+}): Common.User {
+  const userId = typeof user._id === 'string' ? user._id : user._id.toString();
+  return {
+    ...user,
+    _id: userId,
+    reputation: user.reputation
+      ? { ...user.reputation, _id: user.reputation._id ?? userId }
+      : undefined,
+  } as unknown as Common.User;
+}
+
+function asPublicUserDoc(user: unknown): Common.User {
+  return toPublicUser(user as {
+    _id: { toString(): string } | string;
+    reputation?: Common.Reputation | null;
+    [key: string]: unknown;
+  });
+}
 
 export const userResolver = {
   Query: {
@@ -15,23 +54,12 @@ export const userResolver = {
         accountStatus: 'active',
       })
         .select(
-          '_id name username avatar contributorBadge upvotes downvotes _followingId _followersId reputation'
+          '_id name username avatar bio contributorBadge upvotes downvotes _followingId _followersId reputation'
         )
         .lean();
       if (!user) return null;
 
-      const userId = user._id.toString();
-
-      return {
-        ...user,
-        _id: userId,
-        // reputation is a plain nested object on the model, not a Mongoose
-        // subdocument, so it never gets its own _id — but UserReputationType
-        // requires one. Reuse the parent user's id since it's 1:1 embedded.
-        reputation: user.reputation
-          ? { ...user.reputation, _id: userId }
-          : undefined,
-      } as unknown as Common.User;
+      return asPublicUserDoc(user);
     },
     searchUser: async (
       _parent: unknown,
@@ -50,15 +78,237 @@ export const userResolver = {
         accountStatus: 'active',
       })
         .select(
-          '_id name username avatar contributorBadge upvotes downvotes _followingId _followersId reputation'
+          '_id name username avatar bio contributorBadge upvotes downvotes _followingId _followersId reputation'
         )
         .limit(10)
         .lean();
 
-      return users.map((user) => ({
-        ...user,
-        _id: user._id.toString(),
-      })) as unknown as Common.User[];
+      return users.map((user) => asPublicUserDoc(user));
+    },
+  },
+  Mutation: {
+    updateUser: async (
+      _parent: unknown,
+      args: { user: UpdateUserInput },
+      context: GraphQLContext
+    ): Promise<Common.User> => {
+      if (!context.user?._id) {
+        throw new GraphQLError('Authentication required', {
+          extensions: { code: 'UNAUTHENTICATED' },
+        });
+      }
+
+      const input = args.user;
+      if (!input?._id) {
+        throw new GraphQLError('User id is required', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      const actorId = context.user._id.toString();
+      const targetId = input._id.toString();
+      const isOwnProfile = actorId === targetId;
+      const isAdmin = context.user.admin === true;
+
+      if (!isOwnProfile && !isAdmin) {
+        throw new GraphQLError('Not authorized to update this user', {
+          extensions: { code: 'FORBIDDEN' },
+        });
+      }
+
+      // Admins updating another user may only toggle contributorBadge.
+      if (!isOwnProfile && isAdmin) {
+        if (input.contributorBadge === undefined || input.contributorBadge === null) {
+          throw new GraphQLError('Admins may only update contributorBadge for other users', {
+            extensions: { code: 'FORBIDDEN' },
+          });
+        }
+
+        const adminUpdated = await User.findByIdAndUpdate(
+          targetId,
+          { $set: { contributorBadge: Boolean(input.contributorBadge) } },
+          { new: true }
+        ).lean();
+
+        if (!adminUpdated) {
+          throw new GraphQLError('User not found', {
+            extensions: { code: 'NOT_FOUND' },
+          });
+        }
+
+        return asPublicUserDoc(adminUpdated);
+      }
+
+      const updates: Record<string, unknown> = {};
+
+      if (input.name !== undefined && input.name !== null) {
+        const name = input.name.trim();
+        if (!name) {
+          throw new GraphQLError('Name is required', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
+        if (name.length > 50) {
+          throw new GraphQLError('Name must be under 50 characters', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
+        updates.name = name;
+      }
+
+      if (input.username !== undefined && input.username !== null) {
+        const username = input.username.trim();
+        if (username.length < 4 || username.length > 50) {
+          throw new GraphQLError('Username must be between 4 and 50 characters', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
+
+        const existingUsername = await User.findOne({
+          _id: { $ne: targetId },
+          username,
+        })
+          .select('_id')
+          .lean();
+        if (existingUsername) {
+          throw new GraphQLError('Username already exists!', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
+        updates.username = username;
+      }
+
+      if (input.email !== undefined && input.email !== null) {
+        const email = input.email.trim().toLowerCase();
+        if (!email) {
+          throw new GraphQLError('Email is required', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
+
+        const existingEmail = await User.findOne({
+          _id: { $ne: targetId },
+          email,
+        })
+          .select('_id')
+          .lean();
+        if (existingEmail) {
+          throw new GraphQLError('Email address already exists!', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
+        updates.email = email;
+      }
+
+      if (input.password) {
+        const salt = await bcrypt.genSalt(10);
+        updates.password = await bcrypt.hash(input.password, salt);
+      }
+
+      if (input.avatar !== undefined && input.avatar !== null) {
+        updates.avatar = input.avatar;
+      }
+
+      if (input.bio !== undefined) {
+        try {
+          updates.bio = normalizeBio(input.bio);
+        } catch (err) {
+          throw new GraphQLError(err instanceof Error ? err.message : 'Invalid About text', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
+      }
+
+      if (input.themePreference !== undefined && input.themePreference !== null) {
+        const theme = input.themePreference.trim();
+        if (theme !== 'light' && theme !== 'dark') {
+          throw new GraphQLError('themePreference must be light or dark', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
+        updates.themePreference = theme;
+      }
+
+      if (input.contributorBadge !== undefined && input.contributorBadge !== null) {
+        if (!isAdmin) {
+          throw new GraphQLError('Only admins can update contributorBadge', {
+            extensions: { code: 'FORBIDDEN' },
+          });
+        }
+        updates.contributorBadge = Boolean(input.contributorBadge);
+      }
+
+      if (Object.keys(updates).length === 0) {
+        const current = await User.findById(targetId).lean();
+        if (!current) {
+          throw new GraphQLError('User not found', {
+            extensions: { code: 'NOT_FOUND' },
+          });
+        }
+        return asPublicUserDoc(current);
+      }
+
+      const updated = await User.findByIdAndUpdate(targetId, { $set: updates }, { new: true }).lean();
+
+      if (!updated) {
+        throw new GraphQLError('User not found', {
+          extensions: { code: 'NOT_FOUND' },
+        });
+      }
+
+      return asPublicUserDoc(updated);
+    },
+
+    updateUserAvatar: async (
+      _parent: unknown,
+      args: { user_id: string; avatarQualities?: Record<string, unknown> | null },
+      context: GraphQLContext
+    ): Promise<Common.User> => {
+      if (!context.user?._id) {
+        throw new GraphQLError('Authentication required', {
+          extensions: { code: 'UNAUTHENTICATED' },
+        });
+      }
+
+      const targetId = args.user_id?.toString();
+      if (!targetId) {
+        throw new GraphQLError('User id is required', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      const actorId = context.user._id.toString();
+      const isAdmin = context.user.admin === true;
+      if (actorId !== targetId && !isAdmin) {
+        throw new GraphQLError('Not authorized to update this avatar', {
+          extensions: { code: 'FORBIDDEN' },
+        });
+      }
+
+      if (
+        args.avatarQualities === undefined ||
+        args.avatarQualities === null ||
+        typeof args.avatarQualities !== 'object' ||
+        Array.isArray(args.avatarQualities)
+      ) {
+        throw new GraphQLError('avatarQualities must be an object', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      const updated = await User.findByIdAndUpdate(
+        targetId,
+        { $set: { avatar: args.avatarQualities } },
+        { new: true }
+      ).lean();
+
+      if (!updated) {
+        throw new GraphQLError('User not found', {
+          extensions: { code: 'NOT_FOUND' },
+        });
+      }
+
+      return asPublicUserDoc(updated);
     },
   },
 };

--- a/quotevote-backend/app/data/types/User.ts
+++ b/quotevote-backend/app/data/types/User.ts
@@ -46,6 +46,7 @@ export const UserType: GraphQLObjectType<Common.User, GraphQLContext> = new Grap
     tokens: { type: GraphQLInt },
     _wallet: { type: GraphQLString, resolve: (u) => u._wallet },
     avatar: { type: JSONScalar },
+    bio: { type: GraphQLString },
     _followersId: {
       type: new GraphQLList(GraphQLString),
       resolve: (u) => u._followersId ?? [],
@@ -94,7 +95,15 @@ export const UserType: GraphQLObjectType<Common.User, GraphQLContext> = new Grap
     },
     presence: {
       type: PresenceType,
-      resolve: (user) => Presence.findOne({ userId: user._id }).lean(),
+      resolve: async (user) => {
+        const doc = await Presence.findOne({ userId: user._id }).lean();
+        if (!doc) return null;
+        return {
+          ...doc,
+          _id: doc._id.toString(),
+          userId: doc.userId.toString(),
+        };
+      },
     },
     rosters: {
       type: new GraphQLList(RosterType),

--- a/quotevote-backend/app/data/types/UserReputation.ts
+++ b/quotevote-backend/app/data/types/UserReputation.ts
@@ -74,10 +74,21 @@ export const UserReputationType: GraphQLObjectType<Common.Reputation, GraphQLCon
       },
       lastCalculated: {
         type: new GraphQLNonNull(GraphQLString),
-        resolve: (rep) =>
-          rep.lastCalculated instanceof Date
-            ? rep.lastCalculated.toISOString()
-            : String(rep.lastCalculated),
+        resolve: (rep) => {
+          const value = rep.lastCalculated;
+          if (value instanceof Date) {
+            return Number.isNaN(value.getTime()) ? '' : value.toISOString();
+          }
+          if (typeof value === 'number') {
+            const d = new Date(value);
+            return Number.isNaN(d.getTime()) ? '' : d.toISOString();
+          }
+          if (typeof value === 'string' && value.trim()) {
+            const d = new Date(value);
+            return Number.isNaN(d.getTime()) ? '' : d.toISOString();
+          }
+          return '';
+        },
       },
       createdAt: {
         type: new GraphQLNonNull(GraphQLString),

--- a/quotevote-backend/app/data/types/UserReputation.ts
+++ b/quotevote-backend/app/data/types/UserReputation.ts
@@ -12,6 +12,7 @@ import { UserType } from './User';
 import { ReportReasonEnum, ReportStatusEnum, ReportSeverityEnum } from './enums';
 
 import User from '../models/User';
+import { toIsoDateString } from '../utils/serializeDate';
 
 export const ReputationMetricsType: GraphQLObjectType<Common.ReputationMetrics, GraphQLContext> =
   new GraphQLObjectType<Common.ReputationMetrics, GraphQLContext>({
@@ -74,35 +75,22 @@ export const UserReputationType: GraphQLObjectType<Common.Reputation, GraphQLCon
       },
       lastCalculated: {
         type: new GraphQLNonNull(GraphQLString),
-        resolve: (rep) => {
-          const value = rep.lastCalculated;
-          if (value instanceof Date) {
-            return Number.isNaN(value.getTime()) ? '' : value.toISOString();
-          }
-          if (typeof value === 'number') {
-            const d = new Date(value);
-            return Number.isNaN(d.getTime()) ? '' : d.toISOString();
-          }
-          if (typeof value === 'string' && value.trim()) {
-            const d = new Date(value);
-            return Number.isNaN(d.getTime()) ? '' : d.toISOString();
-          }
-          return '';
-        },
+        // Always ISO-8601 strings for the client (never raw epoch numbers).
+        resolve: (rep) => toIsoDateString(rep.lastCalculated),
       },
       createdAt: {
         type: new GraphQLNonNull(GraphQLString),
-        resolve: (rep) => {
-          const v = (rep as Common.Reputation & { createdAt?: Date | string }).createdAt;
-          return v instanceof Date ? v.toISOString() : (v ?? '');
-        },
+        resolve: (rep) =>
+          toIsoDateString(
+            (rep as Common.Reputation & { createdAt?: Date | string }).createdAt
+          ),
       },
       updatedAt: {
         type: new GraphQLNonNull(GraphQLString),
-        resolve: (rep) => {
-          const v = (rep as Common.Reputation & { updatedAt?: Date | string }).updatedAt;
-          return v instanceof Date ? v.toISOString() : (v ?? '');
-        },
+        resolve: (rep) =>
+          toIsoDateString(
+            (rep as Common.Reputation & { updatedAt?: Date | string }).updatedAt
+          ),
       },
     }),
   });

--- a/quotevote-backend/app/data/utils/authentication.ts
+++ b/quotevote-backend/app/data/utils/authentication.ts
@@ -206,6 +206,8 @@ export const addCreatorToUser = async (
             email: user.email,
             admin: user.admin,
             accountStatus: user.accountStatus,
+            avatar: user.avatar ?? null,
+            bio: user.bio ?? '',
         },
     });
 };

--- a/quotevote-backend/app/data/utils/bioValidation.ts
+++ b/quotevote-backend/app/data/utils/bioValidation.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared validation for user About / bio text.
+ * Plain text only; max length matches frontend PROFILE_BIO_MAX_LENGTH.
+ */
+
+export const BIO_MAX_LENGTH = 500;
+
+/** Detects HTML / markup that should not be stored as plain-text bio. */
+const HTML_TAG_PATTERN = /<\/?[a-z][\s\S]*>/i;
+
+/**
+ * Normalize and validate bio input for updateUser.
+ * Returns trimmed plain text, or empty string when cleared.
+ * Throws Error with a user-facing message on invalid input.
+ */
+export function normalizeBio(raw: string | null | undefined): string {
+  if (raw == null) {
+    return '';
+  }
+
+  const trimmed = raw.trim();
+
+  if (trimmed.length > BIO_MAX_LENGTH) {
+    throw new Error(`About must be ${BIO_MAX_LENGTH} characters or fewer`);
+  }
+
+  if (HTML_TAG_PATTERN.test(trimmed)) {
+    throw new Error('About must be plain text without HTML');
+  }
+
+  return trimmed;
+}

--- a/quotevote-backend/app/data/utils/serializeDate.ts
+++ b/quotevote-backend/app/data/utils/serializeDate.ts
@@ -1,0 +1,27 @@
+/**
+ * Normalize Date / epoch / date-string values to ISO-8601 for GraphQL String fields.
+ * Always returns a string (empty when invalid) so clients can treat dates as strings.
+ */
+export function toIsoDateString(value: unknown): string {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? '' : value.toISOString();
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    // Seconds vs milliseconds (Unix seconds are < 1e12 until year ~33658).
+    const ms = value > 0 && value < 1e12 ? value * 1000 : value;
+    const date = new Date(ms);
+    return Number.isNaN(date.getTime()) ? '' : date.toISOString();
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const trimmed = value.trim();
+    if (/^\d+$/.test(trimmed)) {
+      return toIsoDateString(Number(trimmed));
+    }
+    const date = new Date(trimmed);
+    return Number.isNaN(date.getTime()) ? '' : date.toISOString();
+  }
+
+  return '';
+}

--- a/quotevote-backend/app/server.ts
+++ b/quotevote-backend/app/server.ts
@@ -130,6 +130,8 @@ async function startServer() {
           solidPushPortableState(input: PortableStateInput!): Boolean
           solidAppendActivityEvent(input: ActivityEventInput!): Boolean
           heartbeat: HeartbeatResponse
+          updateUser(user: UserInput!): User
+          updateUserAvatar(user_id: String!, avatarQualities: JSON): User
       }
 
       type SolidConnectionStatus {

--- a/quotevote-backend/app/types/common.ts
+++ b/quotevote-backend/app/types/common.ts
@@ -67,7 +67,8 @@ export interface Reputation {
   conductScore: number;
   activityScore: number;
   metrics: ReputationMetrics;
-  lastCalculated: Date | string;
+  /** Stored as Date in Mongo; GraphQL serializes to ISO-8601 string. */
+  lastCalculated: Date | string | number;
 }
 
 export interface User {

--- a/quotevote-backend/app/types/graphql.ts
+++ b/quotevote-backend/app/types/graphql.ts
@@ -169,6 +169,28 @@ export interface QueryResolvers {
 export interface MutationResolvers {
   // User mutations
   followUser: ResolverFn<Common.User, unknown, { user_id: string; action: string }>;
+  updateUser: ResolverFn<
+    Common.User,
+    unknown,
+    {
+      user: {
+        _id: string;
+        name?: string | null;
+        username?: string | null;
+        email?: string | null;
+        password?: string | null;
+        avatar?: string | null;
+        bio?: string | null;
+        contributorBadge?: boolean | null;
+        themePreference?: string | null;
+      };
+    }
+  >;
+  updateUserAvatar: ResolverFn<
+    Common.User,
+    unknown,
+    { user_id: string; avatarQualities?: Record<string, unknown> | null }
+  >;
   updateUserPassword: ResolverFn<
     boolean,
     unknown,
@@ -232,7 +254,11 @@ export interface MutationResolvers {
 
   // Presence mutations
   heartbeat: ResolverFn<HeartbeatResult>;
-  updatePresence: ResolverFn<Common.Presence, unknown, { presence: Common.PresenceInput }>;
+  updatePresence: ResolverFn<
+    Common.Presence,
+    unknown,
+    { presence: { status: string; statusMessage?: string | null } }
+  >;
 
   // Typing mutations
   updateTyping: ResolverFn<TypingResult, unknown, { typing: Common.TypingInput }>;
@@ -411,7 +437,9 @@ export interface MutationResult {
 
 export interface HeartbeatResult {
   success: boolean;
-  timestamp: number;
+  timestamp: string | number;
+  status?: string;
+  statusMessage?: string;
 }
 
 export interface TypingResult {

--- a/quotevote-frontend/src/__tests__/app/dashboard/settings/page.test.tsx
+++ b/quotevote-frontend/src/__tests__/app/dashboard/settings/page.test.tsx
@@ -3,6 +3,7 @@ import { resetStore } from '@/__tests__/utils/test-utils'
 import { installMemoryStorage, restoreStorage } from '@/__tests__/utils/memoryStorage'
 import { useAppStore } from '@/store/useAppStore'
 import { UPDATE_USER } from '@/graphql/mutations'
+import { GET_USER } from '@/graphql/queries'
 
 // Mock next/navigation
 const mockPush = jest.fn()
@@ -14,10 +15,12 @@ jest.mock('next/navigation', () => ({
 
 // Mock ThemeContext
 const mockToggleTheme = jest.fn().mockReturnValue('light')
+const mockSetTheme = jest.fn()
 const mockToggleNeoBrutalism = jest.fn().mockReturnValue(false)
 jest.mock('@/context/ThemeContext', () => ({
   useTheme: () => ({
     themeMode: 'light',
+    setTheme: mockSetTheme,
     toggleTheme: mockToggleTheme,
     isDarkMode: false,
     neoBrutalism: false,
@@ -38,9 +41,34 @@ const mockUser = {
   username: 'testuser',
   name: 'Test User',
   email: 'test@example.com',
+  bio: 'Existing about text',
   avatar: 'https://example.com/avatar.png',
   admin: false,
   accountStatus: 'active',
+}
+
+const getUserMock = {
+  request: {
+    query: GET_USER,
+    variables: { username: 'testuser' },
+  },
+  result: {
+    data: {
+      user: {
+        _id: 'user-1',
+        name: 'Test User',
+        username: 'testuser',
+        bio: 'Existing about text',
+        upvotes: 0,
+        downvotes: 0,
+        _followingId: [],
+        _followersId: [],
+        avatar: 'https://example.com/avatar.png',
+        contributorBadge: false,
+        reputation: null,
+      },
+    },
+  },
 }
 
 const updateUserMock = {
@@ -52,6 +80,8 @@ const updateUserMock = {
         name: 'Updated Name',
         username: 'testuser',
         email: 'test@example.com',
+        bio: 'Existing about text',
+        themePreference: 'light',
       },
     },
   },
@@ -63,6 +93,7 @@ const updateUserMock = {
         username: 'testuser',
         email: 'test@example.com',
         name: 'Updated Name',
+        bio: 'Existing about text',
         avatar: 'https://example.com/avatar.png',
         admin: false,
         accountStatus: 'active',
@@ -81,45 +112,46 @@ describe('Settings Page', () => {
   })
 
   it('renders settings page heading', () => {
-    render(<SettingsPageClient />)
+    render(<SettingsPageClient />, { mocks: [getUserMock] })
     expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument()
   })
 
   it('renders unified form with all fields', () => {
-    render(<SettingsPageClient />)
+    render(<SettingsPageClient />, { mocks: [getUserMock] })
     expect(screen.getByLabelText('Display Name')).toBeInTheDocument()
     expect(screen.getByLabelText('Username')).toBeInTheDocument()
     expect(screen.getByLabelText('Email')).toBeInTheDocument()
-    // Password field is currently hidden
+    expect(screen.getByLabelText('About')).toBeInTheDocument()
   })
 
   it('renders profile form with user data by default', () => {
-    render(<SettingsPageClient />)
+    render(<SettingsPageClient />, { mocks: [getUserMock] })
     expect(screen.getByDisplayValue('Test User')).toBeInTheDocument()
     expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
     expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Existing about text')).toBeInTheDocument()
   })
 
   it('renders dark mode toggle', () => {
-    render(<SettingsPageClient />)
+    render(<SettingsPageClient />, { mocks: [getUserMock] })
     expect(screen.getByText('Dark Mode')).toBeInTheDocument()
     expect(screen.getByRole('switch', { name: /toggle dark mode/i })).toBeInTheDocument()
   })
 
   it.skip('renders optional password field', () => {
     // Password field is currently hidden/commented out
-    render(<SettingsPageClient />)
+    render(<SettingsPageClient />, { mocks: [getUserMock] })
     expect(screen.getByPlaceholderText('Leave blank to keep current password')).toBeInTheDocument()
   })
 
   it('shows save button as disabled when form is pristine', () => {
-    render(<SettingsPageClient />)
+    render(<SettingsPageClient />, { mocks: [getUserMock] })
     const saveButton = screen.getByRole('button', { name: /save changes/i })
     expect(saveButton).toBeDisabled()
   })
 
   it('enables save button when form is dirty', async () => {
-    render(<SettingsPageClient />, { mocks: [updateUserMock] })
+    render(<SettingsPageClient />, { mocks: [getUserMock, updateUserMock] })
     const nameInput = screen.getByDisplayValue('Test User')
     fireEvent.change(nameInput, { target: { value: 'Updated Name' } })
     await waitFor(() => {
@@ -129,24 +161,24 @@ describe('Settings Page', () => {
   })
 
   it('shows change avatar button', () => {
-    render(<SettingsPageClient />)
+    render(<SettingsPageClient />, { mocks: [getUserMock] })
     expect(screen.getByLabelText('Change avatar')).toBeInTheDocument()
   })
 
   it('navigates to avatar page when avatar is clicked', () => {
-    render(<SettingsPageClient />)
+    render(<SettingsPageClient />, { mocks: [getUserMock] })
     fireEvent.click(screen.getByLabelText('Change avatar'))
     expect(mockPush).toHaveBeenCalledWith('/dashboard/profile/testuser/avatar')
   })
 
   it('renders sign out button', () => {
-    render(<SettingsPageClient />)
+    render(<SettingsPageClient />, { mocks: [getUserMock] })
     expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument()
   })
 
   it.skip('validates password requirements', async () => {
     // Password field is currently hidden/commented out
-    render(<SettingsPageClient />)
+    render(<SettingsPageClient />, { mocks: [getUserMock] })
 
     const pwInput = screen.getByPlaceholderText('Leave blank to keep current password')
     fireEvent.change(pwInput, { target: { value: 'short' } })
@@ -169,14 +201,14 @@ describe('Settings Page', () => {
     })
 
     it('renders the profile background section with pattern options', () => {
-      render(<SettingsPageClient />)
+      render(<SettingsPageClient />, { mocks: [getUserMock] })
       expect(screen.getByText('Profile Background')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Zigzag' })).toBeInTheDocument()
       expect(screen.getByLabelText('Profile background preview')).toBeInTheDocument()
     })
 
     it('persists the selected pattern', async () => {
-      render(<SettingsPageClient />)
+      render(<SettingsPageClient />, { mocks: [getUserMock] })
       fireEvent.click(screen.getByRole('button', { name: 'Zigzag' }))
 
       await waitFor(() => {
@@ -188,12 +220,41 @@ describe('Settings Page', () => {
       )
     })
 
+    it('enables Save Changes when only the background pattern changes', async () => {
+      render(<SettingsPageClient />, { mocks: [getUserMock] })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled()
+      })
+
+      // Default pattern is zigzag — switch to a different one to dirty the form.
+      fireEvent.click(screen.getByRole('button', { name: 'Solid' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /save changes/i })).not.toBeDisabled()
+      })
+    })
+
     it('persists the selected color swatch', async () => {
-      render(<SettingsPageClient />)
+      render(<SettingsPageClient />, { mocks: [getUserMock] })
       fireEvent.click(screen.getByLabelText('Background color #3b82f6'))
 
       await waitFor(() => {
         expect(localStorage.getItem('profileBgColor')).toBe('#3b82f6')
+      })
+    })
+
+    it('enables Save Changes when only the background color changes', async () => {
+      render(<SettingsPageClient />, { mocks: [getUserMock] })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled()
+      })
+
+      fireEvent.click(screen.getByLabelText('Background color #3b82f6'))
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /save changes/i })).not.toBeDisabled()
       })
     })
   })

--- a/quotevote-frontend/src/__tests__/components/Profile/ProfileAvatar.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/ProfileAvatar.test.tsx
@@ -64,7 +64,6 @@ describe('ProfileAvatar', () => {
       user: {
         loading: false,
         loginError: null,
-        // @ts-expect-error - avatar as object in test
         data: { avatar: qualities },
       },
     });

--- a/quotevote-frontend/src/__tests__/components/Profile/ProfileController.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/ProfileController.test.tsx
@@ -25,8 +25,10 @@ jest.mock('../../../components/Profile/ProfileView', () => ({
 }));
 
 // Mock Next.js router
+const mockReplace = jest.fn();
 jest.mock('next/navigation', () => ({
   useParams: () => ({ username: 'testuser' }),
+  useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
 }));
 
 const mockUserData = {
@@ -71,6 +73,7 @@ const mockUserData = {
 
 describe('ProfileController', () => {
   beforeEach(() => {
+    mockReplace.mockClear();
     useAppStore.setState({
       user: {
         loading: false,

--- a/quotevote-frontend/src/__tests__/components/Profile/ProfileHeader.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/ProfileHeader.test.tsx
@@ -150,10 +150,29 @@ describe('ProfileHeader Component', () => {
       });
       // Component may be caught by ErrorBoundary if queries fail, so check for either username or error UI
       await waitFor(() => {
-        const username = screen.queryByText('testuser');
+        const username = screen.queryByText('@testuser');
+        const displayName = screen.queryByText('Test User');
         const errorUI = screen.queryByText(/Something went wrong/i);
-        expect(username || errorUI).toBeTruthy();
+        expect(username || displayName || errorUI).toBeTruthy();
       }, { timeout: 5000 });
+    });
+
+    it('renders display name as the profile heading', async () => {
+      await act(async () => {
+        render(
+          <MockedProvider mocks={createMocks()} addTypename={false}>
+            <ProfileHeader profileUser={mockProfileUser} />
+          </MockedProvider>
+        );
+      });
+      await waitFor(() => {
+        const heading = screen.queryByRole('heading', { name: 'Test User' });
+        const errorUI = screen.queryByText(/Something went wrong/i);
+        expect(heading || errorUI).toBeTruthy();
+      }, { timeout: 5000 });
+      if (!screen.queryByText(/Something went wrong/i)) {
+        expect(screen.getByText('@testuser')).toBeInTheDocument();
+      }
     });
 
     it('renders avatar with correct props', async () => {
@@ -267,7 +286,7 @@ describe('ProfileHeader Component', () => {
       }, { timeout: 5000 });
     });
 
-    it('navigates to avatar page when clicking Edit Profile', async () => {
+    it('navigates to settings page when clicking Edit Profile', async () => {
       const ownProfile: ProfileUser = {
         ...mockProfileUser,
         _id: 'currentuser',
@@ -292,7 +311,7 @@ describe('ProfileHeader Component', () => {
         await act(async () => {
           fireEvent.click(button);
         });
-        expect(mockPush).toHaveBeenCalledWith('/dashboard/profile/testuser/avatar');
+        expect(mockPush).toHaveBeenCalledWith('/dashboard/settings');
       } else {
         // If ErrorBoundary caught an error, skip the navigation test
         expect(screen.queryByText(/Something went wrong/i)).toBeTruthy();

--- a/quotevote-frontend/src/__tests__/components/Profile/ProfileView.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/ProfileView.test.tsx
@@ -91,10 +91,10 @@ describe('ProfileView', () => {
       expect(screen.getByText('Return to homepage.')).toBeInTheDocument();
     });
 
-    it('has link to search page', () => {
+    it('has link to home page', () => {
       render(<ProfileView profileUser={undefined} />);
       const link = screen.getByText('Return to homepage.');
-      expect(link.closest('a')).toHaveAttribute('href', '/search');
+      expect(link.closest('a')).toHaveAttribute('href', '/');
     });
   });
 
@@ -142,6 +142,24 @@ describe('ProfileView', () => {
         expect(screen.getByTestId('reputation-display')).toBeInTheDocument();
       });
       expect(screen.getByText('Reputation')).toBeInTheDocument();
+      expect(screen.getByText('No about text yet')).toBeInTheDocument();
+    });
+
+    it('shows bio text on About tab when present', async () => {
+      const user = userEvent.setup();
+      const userWithBio: ProfileUser = {
+        ...mockProfileUser,
+        bio: 'I care about thoughtful dialogue.',
+      };
+      await act(async () => {
+        render(<ProfileView profileUser={userWithBio} />);
+      });
+      const aboutTab = screen.getByRole('tab', { name: 'About' });
+      await user.click(aboutTab);
+      await waitFor(() => {
+        expect(screen.getByText('I care about thoughtful dialogue.')).toBeInTheDocument();
+      });
+      expect(screen.getByRole('heading', { name: 'About', level: 3 })).toBeInTheDocument();
     });
 
     it('shows voted activity list when Voted tab is clicked', async () => {
@@ -156,7 +174,7 @@ describe('ProfileView', () => {
       });
     });
 
-    it('does not render reputation display when reputation is missing and About tab clicked', async () => {
+    it('shows empty about state when reputation is missing and About tab clicked', async () => {
       const user = userEvent.setup();
       const userWithoutReputation: ProfileUser = {
         ...mockProfileUser,
@@ -169,7 +187,7 @@ describe('ProfileView', () => {
       await user.click(aboutTab);
       await waitFor(() => {
         expect(screen.queryByTestId('reputation-display')).not.toBeInTheDocument();
-        expect(screen.getByText('No additional information available')).toBeInTheDocument();
+        expect(screen.getByText('No about text yet')).toBeInTheDocument();
       });
     });
 

--- a/quotevote-frontend/src/__tests__/components/Profile/ReputationDisplay.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/ReputationDisplay.test.tsx
@@ -60,6 +60,26 @@ describe('ReputationDisplay', () => {
     it('displays last calculated date', () => {
       render(<ReputationDisplay reputation={mockReputation} />);
       expect(screen.getByText(/Last updated:/)).toBeInTheDocument();
+      expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument();
+    });
+
+    it('shows Not available when lastCalculated is invalid', () => {
+      const badReputation: Reputation = {
+        ...mockReputation,
+        lastCalculated: 'not-a-date',
+      };
+      render(<ReputationDisplay reputation={badReputation} />);
+      expect(screen.getByText(/Last updated: Not available/)).toBeInTheDocument();
+    });
+
+    it('parses numeric timestamps for lastCalculated', () => {
+      const stamped: Reputation = {
+        ...mockReputation,
+        lastCalculated: String(Date.UTC(2024, 0, 15)),
+      };
+      render(<ReputationDisplay reputation={stamped} />);
+      expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument();
+      expect(screen.getByText(/Last updated:/)).toBeInTheDocument();
     });
 
     it('calls onRefresh when refresh button is clicked', () => {

--- a/quotevote-frontend/src/__tests__/components/Profile/ReputationDisplay.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/ReputationDisplay.test.tsx
@@ -72,7 +72,8 @@ describe('ReputationDisplay', () => {
       expect(screen.getByText(/Last updated: Not available/)).toBeInTheDocument();
     });
 
-    it('parses numeric timestamps for lastCalculated', () => {
+    it('parses digit-only epoch strings defensively for lastCalculated', () => {
+      // GraphQL returns ISO strings; this covers older/non-GraphQL payloads.
       const stamped: Reputation = {
         ...mockReputation,
         lastCalculated: String(Date.UTC(2024, 0, 15)),

--- a/quotevote-frontend/src/__tests__/components/settings/SettingsContent.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/settings/SettingsContent.test.tsx
@@ -41,6 +41,12 @@ jest.mock('@/components/ui/input', () => ({
   ),
 }))
 
+jest.mock('@/components/ui/textarea', () => ({
+  Textarea: React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'textarea'>>(
+    (props, ref) => <textarea ref={ref} {...props} />
+  ),
+}))
+
 jest.mock('@/components/ui/card', () => ({
   Card: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="card">{children}</div>
@@ -83,13 +89,15 @@ jest.mock('@/components/ui/form', () => ({
       field: { 
         name: string
         value: string
-        onChange: (e: React.ChangeEvent<HTMLInputElement> | string) => void
+        onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | string) => void
         onBlur: () => void
       } 
     }) => React.ReactNode
   }) => {
     const [value, setValue] = React.useState('')
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement> | string) => {
+    const handleChange = (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | string
+    ) => {
       if (typeof e === 'string') {
         setValue(e)
       } else {
@@ -127,6 +135,9 @@ jest.mock('@/components/ui/form', () => ({
   },
   FormMessage: ({ children }: { children?: React.ReactNode }) => 
     children ? <span role="alert">{children}</span> : null,
+  FormDescription: ({ children }: { children?: React.ReactNode }) => (
+    <p data-testid="form-description">{children}</p>
+  ),
 }))
 
 jest.mock('@/components/Avatar', () => ({
@@ -189,6 +200,7 @@ const mockUserData = {
   username: 'testuser',
   email: 'test@example.com',
   name: 'Test User',
+  bio: '',
   avatar: 'https://example.com/avatar.jpg',
   admin: false,
 }

--- a/quotevote-frontend/src/__tests__/hooks/useProfileBackground.test.ts
+++ b/quotevote-frontend/src/__tests__/hooks/useProfileBackground.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import { useProfileBackground } from '@/hooks/useProfileBackground'
 import {
   DEFAULT_PROFILE_BG_COLOR,
@@ -35,13 +35,17 @@ describe('useProfileBackground', () => {
     expect(localStorage.getItem('profileBgPattern')).toBe('zigzag')
   })
 
-  it('hydrates from previously persisted values', () => {
+  it('hydrates from previously persisted values after mount', async () => {
     localStorage.setItem('profileBgColor', '#ef4444')
     localStorage.setItem('profileBgPattern', 'dots')
 
     const { result } = renderHook(() => useProfileBackground())
-    expect(result.current.color).toBe('#ef4444')
-    expect(result.current.pattern).toBe('dots')
+
+    // Effects flush under renderHook; assert the post-mount hydrated values.
+    await waitFor(() => {
+      expect(result.current.color).toBe('#ef4444')
+      expect(result.current.pattern).toBe('dots')
+    })
   })
 
   it('sanitizes invalid input before persisting', () => {

--- a/quotevote-frontend/src/app/dashboard/settings/SettingsPageClient.tsx
+++ b/quotevote-frontend/src/app/dashboard/settings/SettingsPageClient.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import * as z from 'zod'
-import { useMutation } from '@apollo/client/react'
+import { useMutation, useQuery } from '@apollo/client/react'
 import { Camera, Loader2, Moon, Sun, LogOut, Sparkles } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
@@ -13,18 +13,21 @@ import { Button } from '@/components/ui/button'
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import { Card, CardContent } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import { DisplayAvatar } from '@/components/DisplayAvatar'
 import { UPDATE_USER } from '@/graphql/mutations'
+import { GET_USER } from '@/graphql/queries'
 import { replaceGqlError } from '@/lib/utils/replaceGqlError'
 import { useAppStore } from '@/store/useAppStore'
 import { removeToken } from '@/lib/auth'
@@ -35,6 +38,7 @@ import {
   PROFILE_BG_COLORS,
   PROFILE_BG_PATTERNS,
 } from '@/lib/utils/profileBackground'
+import { PROFILE_BIO_MAX_LENGTH, PROFILE_BIO_HTML_PATTERN } from '@/lib/constants/profile'
 import { cn } from '@/lib/utils'
 import type { SettingsUserData } from '@/types/settings'
 import type { UpdateUserResponse } from '@/types/test'
@@ -46,6 +50,12 @@ const settingsSchema = z.object({
     .min(4, 'Username must be at least 4 characters')
     .max(50, 'Username must be under 50 characters'),
   email: z.string().email('Please enter a valid email'),
+  bio: z
+    .string()
+    .max(PROFILE_BIO_MAX_LENGTH, `About must be ${PROFILE_BIO_MAX_LENGTH} characters or fewer`)
+    .refine((val) => !PROFILE_BIO_HTML_PATTERN.test(val), {
+      message: 'About must be plain text without HTML',
+    }),
   password: z.string().refine((val) => !val || val.length >= 8, {
     message: 'Password must be at least 8 characters',
   }),
@@ -57,34 +67,66 @@ export default function SettingsPageClient() {
   const router = useRouter()
   const userData = useAppStore((state) => state.user.data) as SettingsUserData | undefined
   const setUserData = useAppStore((state) => state.setUserData)
-  const { toggleTheme, isDarkMode, neoBrutalism, toggleNeoBrutalism } = useTheme()
+  const { setTheme, isDarkMode, neoBrutalism, toggleNeoBrutalism } = useTheme()
   const {
     color: profileBgColor,
     pattern: profileBgPattern,
     setColor: setProfileBgColor,
     setPattern: setProfileBgPattern,
+    hydrated: profileBgHydrated,
   } = useProfileBackground()
 
   const username = userData?.username ?? ''
   const email = userData?.email ?? ''
   const name = userData?.name ?? ''
+  const bio = typeof userData?.bio === 'string' ? userData.bio : ''
   const userId = userData?.id ?? userData?._id ?? ''
 
   const [localDarkMode, setLocalDarkMode] = useState(isDarkMode)
   const [originalDarkMode, setOriginalDarkMode] = useState(isDarkMode)
   const [localBrutalism, setLocalBrutalism] = useState(neoBrutalism)
+  const [originalBgColor, setOriginalBgColor] = useState(profileBgColor)
+  const [originalBgPattern, setOriginalBgPattern] = useState(profileBgPattern)
+  const [bgBaselineReady, setBgBaselineReady] = useState(false)
 
   const [updateUser, { loading }] = useMutation<UpdateUserResponse>(UPDATE_USER)
 
-  const form = useForm<SettingsFormValues>({
-    resolver: zodResolver(settingsSchema),
-    defaultValues: { name, username, email, password: '' },
+  const { data: profileData } = useQuery<{ user: { bio?: string | null } | null }>(GET_USER, {
+    variables: { username },
+    skip: !username,
+    fetchPolicy: 'cache-and-network',
   })
 
-  const handleThemeToggle = useCallback(() => {
-    const newMode = toggleTheme()
-    setLocalDarkMode(newMode === 'dark')
-  }, [toggleTheme])
+  const form = useForm<SettingsFormValues>({
+    resolver: zodResolver(settingsSchema),
+    defaultValues: { name, username, email, bio, password: '' },
+  })
+
+  useEffect(() => {
+    const fetchedBio = profileData?.user?.bio
+    if (typeof fetchedBio === 'string' && form.getValues('bio') === bio) {
+      form.setValue('bio', fetchedBio, { shouldDirty: false })
+    }
+  }, [profileData?.user?.bio, bio, form])
+
+  useEffect(() => {
+    setLocalDarkMode(isDarkMode)
+  }, [isDarkMode])
+
+  useEffect(() => {
+    if (!profileBgHydrated || bgBaselineReady) return
+    setOriginalBgColor(profileBgColor)
+    setOriginalBgPattern(profileBgPattern)
+    setBgBaselineReady(true)
+  }, [profileBgHydrated, profileBgColor, profileBgPattern, bgBaselineReady])
+
+  const handleThemeToggle = useCallback(
+    (checked: boolean) => {
+      setTheme(checked ? 'dark' : 'light')
+      setLocalDarkMode(checked)
+    },
+    [setTheme]
+  )
 
   const handleBrutalismToggle = useCallback(() => {
     const next = toggleNeoBrutalism()
@@ -92,7 +134,11 @@ export default function SettingsPageClient() {
   }, [toggleNeoBrutalism])
 
   const themeDirty = localDarkMode !== originalDarkMode
-  const isFormDirty = form.formState.isDirty || themeDirty
+  const bgDirty =
+    bgBaselineReady &&
+    (profileBgColor.toLowerCase() !== originalBgColor.toLowerCase() ||
+      profileBgPattern !== originalBgPattern)
+  const isFormDirty = form.formState.isDirty || themeDirty || bgDirty
 
   const handleSignOut = useCallback(() => {
     removeToken()
@@ -101,9 +147,19 @@ export default function SettingsPageClient() {
 
   const onSubmit = async (values: SettingsFormValues) => {
     const { password, ...otherValues } = values
+
+    // Background is localStorage-only; if that's the only change, just accept baseline.
+    if (!form.formState.isDirty && !themeDirty && bgDirty) {
+      setOriginalBgColor(profileBgColor)
+      setOriginalBgPattern(profileBgPattern)
+      toast.success('Settings saved successfully')
+      return
+    }
+
     const userInput: Record<string, unknown> = {
       _id: userId,
       ...otherValues,
+      bio: otherValues.bio.trim(),
       themePreference: localDarkMode ? 'dark' : 'light',
     }
     if (password) {
@@ -111,21 +167,34 @@ export default function SettingsPageClient() {
     }
 
     try {
-      const result = await updateUser({ variables: { user: userInput } })
+      const result = await updateUser({
+        variables: { user: userInput },
+        refetchQueries: [
+          {
+            query: GET_USER,
+            variables: { username: otherValues.username },
+          },
+        ],
+        awaitRefetchQueries: true,
+      })
       const updated = result.data?.updateUser
       if (updated) {
         setUserData({
           ...userData,
           ...updated,
+          bio: updated.bio ?? otherValues.bio.trim(),
           avatar: userData?.avatar as string | undefined,
           themePreference: localDarkMode ? 'dark' : 'light',
         })
         setOriginalDarkMode(localDarkMode)
+        setOriginalBgColor(profileBgColor)
+        setOriginalBgPattern(profileBgPattern)
         toast.success('Settings saved successfully')
         form.reset({
           name: updated.name ?? otherValues.name,
           username: updated.username ?? otherValues.username,
           email: updated.email ?? otherValues.email,
+          bio: (updated.bio as string | undefined) ?? otherValues.bio.trim(),
           password: '',
         })
       }
@@ -148,7 +217,6 @@ export default function SettingsPageClient() {
         <CardContent className="pt-6">
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-              {/* Avatar */}
               <div className="flex items-center gap-4">
                 <button
                   type="button"
@@ -180,7 +248,6 @@ export default function SettingsPageClient() {
 
               <Separator />
 
-              {/* Name */}
               <FormField
                 control={form.control}
                 name="name"
@@ -195,7 +262,6 @@ export default function SettingsPageClient() {
                 )}
               />
 
-              {/* Username */}
               <FormField
                 control={form.control}
                 name="username"
@@ -210,7 +276,6 @@ export default function SettingsPageClient() {
                 )}
               />
 
-              {/* Email */}
               <FormField
                 control={form.control}
                 name="email"
@@ -225,28 +290,31 @@ export default function SettingsPageClient() {
                 )}
               />
 
-              {/* Password field hidden for now */}
-              {/* <FormField
+              <FormField
                 control={form.control}
-                name="password"
+                name="bio"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Password</FormLabel>
+                    <FormLabel>About</FormLabel>
                     <FormControl>
-                      <Input
-                        type="password"
-                        placeholder="Leave blank to keep current password"
+                      <Textarea
+                        placeholder="Tell others a little about yourself"
+                        rows={4}
+                        maxLength={PROFILE_BIO_MAX_LENGTH}
+                        className="resize-y min-h-[96px]"
                         {...field}
                       />
                     </FormControl>
+                    <FormDescription>
+                      Plain text only · {field.value?.length ?? 0}/{PROFILE_BIO_MAX_LENGTH}
+                    </FormDescription>
                     <FormMessage />
                   </FormItem>
                 )}
-              /> */}
+              />
 
               <Separator />
 
-              {/* Dark mode */}
               <div className="flex items-center justify-between">
                 <div className="space-y-0.5">
                   <Label htmlFor="dark-mode">Dark Mode</Label>
@@ -269,7 +337,6 @@ export default function SettingsPageClient() {
                 </div>
               </div>
 
-              {/* Neo-brutalism */}
               <div className="flex items-center justify-between">
                 <div className="space-y-0.5">
                   <Label htmlFor="neo-brutalism">Neo-Brutalism</Label>
@@ -292,7 +359,6 @@ export default function SettingsPageClient() {
 
               <Separator />
 
-              {/* Profile Background */}
               <div className="space-y-3">
                 <div className="space-y-0.5">
                   <Label>Profile Background</Label>
@@ -301,7 +367,6 @@ export default function SettingsPageClient() {
                   </p>
                 </div>
 
-                {/* Live preview */}
                 <div
                   className="h-20 w-full rounded-md border border-border"
                   style={getProfileBackgroundStyle(profileBgColor, profileBgPattern)}
@@ -309,13 +374,11 @@ export default function SettingsPageClient() {
                   role="img"
                 />
 
-                {/* Color */}
                 <div className="space-y-1.5">
                   <p className="text-xs font-medium text-muted-foreground">Color</p>
                   <div className="flex flex-wrap items-center gap-2">
                     {PROFILE_BG_COLORS.map((c) => {
-                      const selected =
-                        profileBgColor.toLowerCase() === c.toLowerCase()
+                      const selected = profileBgColor.toLowerCase() === c.toLowerCase()
                       return (
                         <button
                           key={c}
@@ -346,7 +409,6 @@ export default function SettingsPageClient() {
                   </div>
                 </div>
 
-                {/* Pattern */}
                 <div className="space-y-1.5">
                   <p className="text-xs font-medium text-muted-foreground">Pattern</p>
                   <div className="flex flex-wrap gap-2">
@@ -372,7 +434,6 @@ export default function SettingsPageClient() {
 
               <Separator />
 
-              {/* Footer */}
               <div className="flex items-center gap-3 flex-wrap">
                 <Button
                   type="button"

--- a/quotevote-frontend/src/app/globals.css
+++ b/quotevote-frontend/src/app/globals.css
@@ -1395,6 +1395,22 @@ body {
 }
 
 /* ============================================================ */
+/* SONNER TOASTS — close on trailing edge (right in LTR)         */
+/* ============================================================ */
+
+[data-sonner-toaster] {
+  --toast-close-button-start: auto;
+  --toast-close-button-end: 0;
+  --toast-close-button-transform: translate(35%, -35%);
+}
+
+[data-sonner-toast][data-styled="true"] [data-close-button] {
+  left: auto !important;
+  right: 0 !important;
+  transform: translate(35%, -35%) !important;
+}
+
+/* ============================================================ */
 /* SONNER TOASTS — brutalist chips, color per variant            */
 /* ============================================================ */
 

--- a/quotevote-frontend/src/app/layout.tsx
+++ b/quotevote-frontend/src/app/layout.tsx
@@ -72,7 +72,7 @@ export default function RootLayout({
                 <Eyebrow />
                 {children}
                 <AuthGateDialog />
-                <Toaster position="top-right" richColors />
+                <Toaster position="top-right" richColors closeButton />
               </AuthModalProvider>
             </ThemeContextProvider>
           </ApolloProviderWrapper>

--- a/quotevote-frontend/src/components/Profile/ProfileController.tsx
+++ b/quotevote-frontend/src/components/Profile/ProfileController.tsx
@@ -9,29 +9,38 @@ import { ProfileView } from './ProfileView';
 import type { ProfileUser } from '@/types/profile';
 
 export function ProfileController() {
-  const { username } = useParams<{ username: string }>();
+  const { username: paramUsername } = useParams<{ username?: string }>();
   const loggedInUser = useAppStore((state) => state.user.data);
   const setSelectedPage = useAppStore((state) => state.setSelectedPage);
 
+  const targetUsername =
+    (typeof paramUsername === 'string' && paramUsername.trim()) ||
+    (typeof loggedInUser?.username === 'string' && loggedInUser.username.trim()) ||
+    '';
+
   const { data: userData, loading } = useQuery<{
-    user?: ProfileUser;
+    user?: ProfileUser | null;
   }>(GET_USER, {
-    variables: { username: username || loggedInUser.username },
-    skip: !username && !loggedInUser.username,
+    variables: { username: targetUsername },
+    skip: !targetUsername,
   });
 
   useEffect(() => {
     setSelectedPage('');
   }, [setSelectedPage]);
 
-  // Derive userInfo directly from query data instead of using effect
-  const userInfo = userData?.user;
+  // Keep SSR and the first client paint on the loading UI until the persisted
+  // store rehydrates a username (or a route param is present). Otherwise the
+  // server can render LoadingSpinner while the client briefly renders
+  // "Invalid user" and triggers a hydration mismatch.
+  if (!targetUsername || loading) {
+    return <ProfileView loading />;
+  }
 
   return (
     <ProfileView
-      profileUser={userInfo}
-      loading={loading}
+      profileUser={userData?.user ?? undefined}
+      loading={false}
     />
   );
 }
-

--- a/quotevote-frontend/src/components/Profile/ProfileController.tsx
+++ b/quotevote-frontend/src/components/Profile/ProfileController.tsx
@@ -1,17 +1,31 @@
 'use client';
 
-import { useEffect } from 'react';
-import { useParams } from 'next/navigation';
+import { useEffect, useSyncExternalStore } from 'react';
+import { useParams, useRouter } from 'next/navigation';
 import { useQuery } from '@apollo/client/react';
 import { useAppStore } from '@/store';
 import { GET_USER } from '@/graphql/queries';
 import { ProfileView } from './ProfileView';
 import type { ProfileUser } from '@/types/profile';
 
+function subscribePersistHydration(onChange: () => void): () => void {
+  return useAppStore.persist.onFinishHydration(onChange);
+}
+
+function getPersistHydrated(): boolean {
+  return useAppStore.persist.hasHydrated();
+}
+
 export function ProfileController() {
+  const router = useRouter();
   const { username: paramUsername } = useParams<{ username?: string }>();
   const loggedInUser = useAppStore((state) => state.user.data);
   const setSelectedPage = useAppStore((state) => state.setSelectedPage);
+  const storeHydrated = useSyncExternalStore(
+    subscribePersistHydration,
+    getPersistHydrated,
+    () => false
+  );
 
   const targetUsername =
     (typeof paramUsername === 'string' && paramUsername.trim()) ||
@@ -29,11 +43,16 @@ export function ProfileController() {
     setSelectedPage('');
   }, [setSelectedPage]);
 
+  useEffect(() => {
+    if (!storeHydrated || targetUsername) return;
+    router.replace('/auths/login');
+  }, [storeHydrated, targetUsername, router]);
+
   // Keep SSR and the first client paint on the loading UI until the persisted
   // store rehydrates a username (or a route param is present). Otherwise the
   // server can render LoadingSpinner while the client briefly renders
   // "Invalid user" and triggers a hydration mismatch.
-  if (!targetUsername || loading) {
+  if (!storeHydrated || !targetUsername || loading) {
     return <ProfileView loading />;
   }
 

--- a/quotevote-frontend/src/components/Profile/ProfileHeader.tsx
+++ b/quotevote-frontend/src/components/Profile/ProfileHeader.tsx
@@ -155,7 +155,7 @@ export function ProfileHeader({ profileUser }: ProfileHeaderProps) {
       const staged: StagedChatRoom = {
         _id: null,
         title: name || username || 'Chat',
-        avatar: (avatar as string | Record<string, unknown> | null | undefined) ?? null,
+        avatar: typeof avatar === 'string' ? avatar : null,
         messageType: 'USER',
         users: [loggedInUserIdString, _id],
         username: username || undefined,

--- a/quotevote-frontend/src/components/Profile/ProfileHeader.tsx
+++ b/quotevote-frontend/src/components/Profile/ProfileHeader.tsx
@@ -155,10 +155,7 @@ export function ProfileHeader({ profileUser }: ProfileHeaderProps) {
       const staged: StagedChatRoom = {
         _id: null,
         title: name || username || 'Chat',
-        avatar:
-          typeof avatar === 'string'
-            ? avatar
-            : (avatar?.url ?? null),
+        avatar: (avatar as string | Record<string, unknown> | null | undefined) ?? null,
         messageType: 'USER',
         users: [loggedInUserIdString, _id],
         username: username || undefined,
@@ -228,7 +225,7 @@ export function ProfileHeader({ profileUser }: ProfileHeaderProps) {
             {sameUser ? (
               <Button
                 variant="outline"
-                onClick={() => router.push(`/dashboard/profile/${username}/avatar`)}
+                onClick={() => router.push('/dashboard/settings')}
               >
                 <Pencil className="mr-2 h-4 w-4" />
                 Edit Profile
@@ -269,10 +266,10 @@ export function ProfileHeader({ profileUser }: ProfileHeaderProps) {
           </div>
         </div>
 
-        {/* Username + handle */}
+        {/* Display name + handle */}
         <div className="space-y-0.5 mb-3">
           <div className="flex items-center gap-2">
-            <h2 className="text-xl font-bold text-foreground">{username}</h2>
+            <h2 className="text-xl font-bold text-foreground">{name || username}</h2>
             {contributorBadge && (
               <ProfileBadgeContainer>
                 <ProfileBadge type="contributor" />

--- a/quotevote-frontend/src/components/Profile/ProfileView.tsx
+++ b/quotevote-frontend/src/components/Profile/ProfileView.tsx
@@ -22,7 +22,7 @@ export function ProfileView({
         <Card>
           <CardContent className="pt-6 text-center">
             <h3 className="text-lg font-semibold mb-2">Invalid user</h3>
-            <Link href="/search" className="text-primary hover:underline">
+            <Link href="/" className="text-primary hover:underline">
               Return to homepage.
             </Link>
           </CardContent>
@@ -75,19 +75,28 @@ export function ProfileView({
           />
         </TabsContent>
 
-        <TabsContent value="about" className="mt-4">
+        <TabsContent value="about" className="mt-4 space-y-4">
+          <Card>
+            <CardContent className="pt-6 space-y-2">
+              <h3 className="text-sm font-semibold text-foreground">About</h3>
+              {profileUser.bio?.trim() ? (
+                <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+                  {profileUser.bio.trim()}
+                </p>
+              ) : (
+                <p className="text-muted-foreground text-sm py-2">
+                  No about text yet
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
           {profileUser.reputation ? (
             <ReputationDisplay
               reputation={profileUser.reputation}
               onRefresh={() => window.location.reload()}
             />
-          ) : (
-            <Card>
-              <CardContent className="py-12 text-center">
-                <p className="text-muted-foreground">No additional information available</p>
-              </CardContent>
-            </Card>
-          )}
+          ) : null}
         </TabsContent>
       </Tabs>
     </div>

--- a/quotevote-frontend/src/components/Profile/ReputationDisplay.tsx
+++ b/quotevote-frontend/src/components/Profile/ReputationDisplay.tsx
@@ -47,8 +47,18 @@ export function ReputationDisplay({
     return 'Poor';
   };
 
-  const formatDate = (dateString: string): string => {
-    return new Date(dateString).toLocaleDateString();
+  const formatDate = (dateValue: string | Date | null | undefined): string => {
+    if (dateValue == null || dateValue === '') return 'Not available';
+
+    const date =
+      dateValue instanceof Date
+        ? dateValue
+        : typeof dateValue === 'number' || /^\d+$/.test(String(dateValue))
+          ? new Date(Number(dateValue))
+          : new Date(dateValue);
+
+    if (Number.isNaN(date.getTime())) return 'Not available';
+    return date.toLocaleDateString();
   };
 
   const scoreColor = getScoreColor(reputation.overallScore);

--- a/quotevote-frontend/src/components/Profile/ReputationDisplay.tsx
+++ b/quotevote-frontend/src/components/Profile/ReputationDisplay.tsx
@@ -47,13 +47,17 @@ export function ReputationDisplay({
     return 'Poor';
   };
 
+  /**
+   * GraphQL returns ISO-8601 strings for lastCalculated. Keep light defensive
+   * parsing for Date instances and digit-only epoch strings from older payloads.
+   */
   const formatDate = (dateValue: string | Date | null | undefined): string => {
     if (dateValue == null || dateValue === '') return 'Not available';
 
     const date =
       dateValue instanceof Date
         ? dateValue
-        : typeof dateValue === 'number' || /^\d+$/.test(String(dateValue))
+        : /^\d+$/.test(dateValue.trim())
           ? new Date(Number(dateValue))
           : new Date(dateValue);
 

--- a/quotevote-frontend/src/components/settings/SettingsContent.tsx
+++ b/quotevote-frontend/src/components/settings/SettingsContent.tsx
@@ -27,6 +27,7 @@ import { cn } from '@/lib/utils'
 import { UPDATE_USER } from '@/graphql/mutations'
 import { replaceGqlError } from '@/lib/utils/replaceGqlError'
 import Avatar from '@/components/Avatar'
+import { parseAvatarToUrl } from '@/lib/avatar'
 import { useAppStore } from '@/store/useAppStore'
 import { PROFILE_BIO_MAX_LENGTH, PROFILE_BIO_HTML_PATTERN } from '@/lib/constants/profile'
 import type { 
@@ -74,6 +75,8 @@ export default function SettingsContent({ setOpen }: SettingsContentProps) {
   const setUserData = useAppStore((state) => state.setUserData)
 
   const avatar = userData?.avatar as UserAvatar | string | Record<string, unknown> | undefined
+  const avatarSrc =
+    parseAvatarToUrl(avatar) ?? (typeof avatar === 'string' ? avatar : undefined)
   const username = userData?.username ?? ''
   const email = userData?.email ?? ''
   const name = userData?.name ?? ''
@@ -148,8 +151,8 @@ export default function SettingsContent({ setOpen }: SettingsContentProps) {
                 className="group relative flex-shrink-0"
                 aria-label="Change avatar"
               >
-                <Avatar 
-                  src={avatar}
+                <Avatar
+                  src={avatarSrc}
                   alt={watchedName || 'User avatar'}
                   size={96}
                   fallback={watchedName.charAt(0).toUpperCase() || 'U'}

--- a/quotevote-frontend/src/components/settings/SettingsContent.tsx
+++ b/quotevote-frontend/src/components/settings/SettingsContent.tsx
@@ -12,12 +12,14 @@ import { Button } from '@/components/ui/button'
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import { Card, CardContent } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { cn } from '@/lib/utils'
@@ -26,6 +28,7 @@ import { UPDATE_USER } from '@/graphql/mutations'
 import { replaceGqlError } from '@/lib/utils/replaceGqlError'
 import Avatar from '@/components/Avatar'
 import { useAppStore } from '@/store/useAppStore'
+import { PROFILE_BIO_MAX_LENGTH, PROFILE_BIO_HTML_PATTERN } from '@/lib/constants/profile'
 import type { 
   SettingsFormValues, 
   SettingsContentProps, 
@@ -41,6 +44,12 @@ const settingsSchema = z.object({
     .min(5, 'Username should be more than 4 characters')
     .max(50, 'Username should be less than 50 characters'),
   email: z.string().email('Entered value does not match email format'),
+  bio: z
+    .string()
+    .max(PROFILE_BIO_MAX_LENGTH, `About must be ${PROFILE_BIO_MAX_LENGTH} characters or fewer`)
+    .refine((val) => !PROFILE_BIO_HTML_PATTERN.test(val), {
+      message: 'About must be plain text without HTML',
+    }),
   password: z
     .string()
     .optional()
@@ -64,10 +73,11 @@ export default function SettingsContent({ setOpen }: SettingsContentProps) {
   const userData = useAppStore((state) => state.user.data) as SettingsUserData | undefined
   const setUserData = useAppStore((state) => state.setUserData)
 
-  const avatar = userData?.avatar as UserAvatar | string | undefined
+  const avatar = userData?.avatar as UserAvatar | string | Record<string, unknown> | undefined
   const username = userData?.username ?? ''
   const email = userData?.email ?? ''
   const name = userData?.name ?? ''
+  const bio = typeof userData?.bio === 'string' ? userData.bio : ''
   const userId = userData?.id ?? userData?._id ?? ''
 
   const [updateUser, { loading, error }] = useMutation<UpdateUserResponse>(UPDATE_USER)
@@ -78,13 +88,16 @@ export default function SettingsContent({ setOpen }: SettingsContentProps) {
       username,
       name,
       email,
+      bio,
       password: '',
     },
   })
 
   const onSubmit: SubmitHandler<SettingsFormValues> = async (values) => {
     const { password, ...otherValues } = values;
-    const updateVariables = !password || password.length === 0 ? otherValues : values;
+    const updateVariables = !password || password.length === 0
+      ? { ...otherValues, bio: otherValues.bio.trim() }
+      : { ...values, bio: values.bio.trim() };
 
     try {
       const result = await updateUser({
@@ -97,28 +110,23 @@ export default function SettingsContent({ setOpen }: SettingsContentProps) {
       });
 
       if (result.data?.updateUser) {
-        const updatedAvatar = typeof avatar === 'string' 
-          ? avatar 
-          : (avatar as UserAvatar)?.url || (avatar as UserAvatar)?.src || '';
-
         setUserData({
           ...userData,
           ...otherValues,
-          avatar: updatedAvatar,
+          bio: otherValues.bio.trim(),
+          // Keep the existing avatar value (URL or qualities object) — profile
+          // updates must not coerce avataaars objects into an empty string.
+          avatar: userData?.avatar,
         });
         
         setShowSuccess(true);
         setTimeout(() => setShowSuccess(false), 3000);
-        form.reset(values);
+        form.reset({ ...values, bio: values.bio.trim() });
       }
     } catch (_err) {
       // Error handled by Apollo
     }
   };
-
-  const avatarUrl = typeof avatar === 'string' 
-    ? avatar 
-    : (avatar as UserAvatar)?.url || (avatar as UserAvatar)?.src || ''
 
   // eslint-disable-next-line react-hooks/incompatible-library -- react-hook-form watch is safe here, compiler skips memoization
   const watchedName = (form.watch('name') as string) || name || '';
@@ -141,7 +149,7 @@ export default function SettingsContent({ setOpen }: SettingsContentProps) {
                 aria-label="Change avatar"
               >
                 <Avatar 
-                  src={avatarUrl}
+                  src={avatar}
                   alt={watchedName || 'User avatar'}
                   size={96}
                   fallback={watchedName.charAt(0).toUpperCase() || 'U'}
@@ -200,6 +208,33 @@ export default function SettingsContent({ setOpen }: SettingsContentProps) {
                       <FormControl>
                         <Input type="email" {...field} />
                       </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardContent className="p-4">
+                <FormField
+                  control={form.control as Control<SettingsFormValues>}
+                  name="bio"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>About</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="Tell others a little about yourself"
+                          rows={4}
+                          maxLength={PROFILE_BIO_MAX_LENGTH}
+                          className="resize-y min-h-[96px]"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Plain text only · {field.value?.length ?? 0}/{PROFILE_BIO_MAX_LENGTH}
+                      </FormDescription>
                       <FormMessage />
                     </FormItem>
                   )}

--- a/quotevote-frontend/src/context/ThemeContext.tsx
+++ b/quotevote-frontend/src/context/ThemeContext.tsx
@@ -29,42 +29,44 @@ export const useTheme = (): ThemeContextValue => {
   return context
 }
 
-export function ThemeContextProvider({
-  children,
-}: ThemeContextProviderProps) {
-  const user = useAppStore((s) => s.user.data)
-  const isLoggedIn = Boolean(user?._id)
-
-  // Initialize theme mode from localStorage (fast, before Redux finishes hydrating)
-  const getInitialThemeMode = (): ThemeMode => {
-    if (typeof window !== 'undefined') {
-      try {
-        const savedTheme = localStorage.getItem('themeMode')
-        if (savedTheme === 'light' || savedTheme === 'dark') {
-          return savedTheme
-        }
-      } catch (_error) {
-        // ignore localStorage read errors
-      }
+function readStoredThemeMode(): ThemeMode {
+  if (typeof window === 'undefined') return 'light'
+  try {
+    const savedTheme = localStorage.getItem('themeMode')
+    if (savedTheme === 'light' || savedTheme === 'dark') {
+      return savedTheme
     }
-    return 'light'
+  } catch {
+    // ignore localStorage read errors
   }
+  return 'light'
+}
 
-  const getInitialNeoBrutalism = (): boolean => {
-    if (typeof window !== 'undefined') {
-      try {
-        return localStorage.getItem('neoBrutalism') === 'on'
-      } catch (_error) {
-        // ignore localStorage read errors
-      }
+function writeStoredThemeMode(mode: ThemeMode): void {
+  try {
+    localStorage.setItem('themeMode', mode)
+  } catch {
+    // ignore localStorage write errors
+  }
+}
+
+export function ThemeContextProvider({ children }: ThemeContextProviderProps) {
+  const isLoggedIn = useAppStore((s) => Boolean(s.user.data?._id))
+  const themePreference = useAppStore((s) => {
+    const pref = s.user.data?.themePreference
+    return pref === 'light' || pref === 'dark' ? pref : undefined
+  })
+
+  const [themeMode, setThemeMode] = useState<ThemeMode>(readStoredThemeMode)
+  const [neoBrutalism, setNeoBrutalism] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    try {
+      return localStorage.getItem('neoBrutalism') === 'on'
+    } catch {
+      return false
     }
-    return false
-  }
+  })
 
-  const [themeMode, setThemeMode] = useState<ThemeMode>(getInitialThemeMode)
-  const [neoBrutalism, setNeoBrutalism] = useState<boolean>(getInitialNeoBrutalism)
-
-  // Apply dark class to <html> whenever themeMode changes
   useEffect(() => {
     if (themeMode === 'dark') {
       document.documentElement.classList.add('dark')
@@ -73,7 +75,6 @@ export function ThemeContextProvider({
     }
   }, [themeMode])
 
-  // Apply neo-brutalism class to <html> whenever flag changes
   useEffect(() => {
     if (neoBrutalism) {
       document.documentElement.classList.add('neo-brutalism')
@@ -82,70 +83,42 @@ export function ThemeContextProvider({
     }
   }, [neoBrutalism])
 
-  // Update theme when user logs in/out or user preference changes
-  /* eslint-disable react-hooks/set-state-in-effect */
+  // Apply saved preference when login state / server preference changes.
+  // Do NOT depend on themeMode — that caused toggles to snap back to the
+  // last saved preference before Save.
   useEffect(() => {
-    if (isLoggedIn && user?.themePreference) {
-      const userTheme = user.themePreference as ThemeMode
-      if (userTheme === 'light' || userTheme === 'dark') {
-        setThemeMode(userTheme)
-        try {
-          localStorage.setItem('themeMode', userTheme)
-        } catch (_error) {
-          // ignore localStorage write errors
-        }
-      }
-    } else if (!isLoggedIn) {
-      let savedTheme: ThemeMode = 'light'
-      try {
-        const stored = localStorage.getItem('themeMode')
-        if (stored === 'light' || stored === 'dark') {
-          savedTheme = stored
-        }
-      } catch (_error) {
-        // ignore localStorage read errors
-      }
-      setThemeMode(savedTheme)
-    } else if (isLoggedIn && !user?.themePreference) {
-      try {
-        const currentTheme =
-          (localStorage.getItem('themeMode') as ThemeMode) ||
-          themeMode ||
-          'light'
-        if (currentTheme === 'light' || currentTheme === 'dark') {
-          localStorage.setItem('themeMode', currentTheme)
-          setThemeMode(currentTheme)
-        }
-      } catch (_error) {
-        // ignore localStorage sync errors
-      }
+    if (!isLoggedIn) {
+      setThemeMode(readStoredThemeMode())
+      return
     }
-  }, [isLoggedIn, user, themeMode])
-  /* eslint-enable react-hooks/set-state-in-effect */
+    if (themePreference === 'light' || themePreference === 'dark') {
+      setThemeMode(themePreference)
+      writeStoredThemeMode(themePreference)
+    }
+  }, [isLoggedIn, themePreference])
 
   const theme = useMemo<Theme>(
     () => (themeMode === 'dark' ? darkTheme : lightTheme),
     [themeMode]
   )
 
+  const setTheme = useCallback((mode: ThemeMode): void => {
+    setThemeMode(mode)
+    writeStoredThemeMode(mode)
+  }, [])
+
   const toggleTheme = useCallback((): ThemeMode => {
     const newMode: ThemeMode = themeMode === 'light' ? 'dark' : 'light'
-    setThemeMode(newMode)
-    try {
-      // Always update localStorage for immediate persistence
-      localStorage.setItem('themeMode', newMode)
-    } catch (_error) {
-      // ignore localStorage write errors
-    }
+    setTheme(newMode)
     return newMode
-  }, [themeMode])
+  }, [themeMode, setTheme])
 
   const toggleNeoBrutalism = useCallback((): boolean => {
     const next = !neoBrutalism
     setNeoBrutalism(next)
     try {
       localStorage.setItem('neoBrutalism', next ? 'on' : 'off')
-    } catch (_error) {
+    } catch {
       // ignore localStorage write errors
     }
     return next
@@ -155,16 +128,16 @@ export function ThemeContextProvider({
     () => ({
       themeMode,
       theme,
+      setTheme,
       toggleTheme,
       isDarkMode: themeMode === 'dark',
       neoBrutalism,
       toggleNeoBrutalism,
     }),
-    [themeMode, theme, toggleTheme, neoBrutalism, toggleNeoBrutalism]
+    [themeMode, theme, setTheme, toggleTheme, neoBrutalism, toggleNeoBrutalism]
   )
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
 }
 
 export default ThemeContext
-

--- a/quotevote-frontend/src/context/ThemeContext.tsx
+++ b/quotevote-frontend/src/context/ThemeContext.tsx
@@ -86,6 +86,7 @@ export function ThemeContextProvider({ children }: ThemeContextProviderProps) {
   // Apply saved preference when login state / server preference changes.
   // Do NOT depend on themeMode — that caused toggles to snap back to the
   // last saved preference before Save.
+  /* eslint-disable react-hooks/set-state-in-effect -- sync theme from auth/store preference */
   useEffect(() => {
     if (!isLoggedIn) {
       setThemeMode(readStoredThemeMode())
@@ -96,7 +97,7 @@ export function ThemeContextProvider({ children }: ThemeContextProviderProps) {
       writeStoredThemeMode(themePreference)
     }
   }, [isLoggedIn, themePreference])
-
+  /* eslint-enable react-hooks/set-state-in-effect */
   const theme = useMemo<Theme>(
     () => (themeMode === 'dark' ? darkTheme : lightTheme),
     [themeMode]

--- a/quotevote-frontend/src/context/ThemeContext.tsx
+++ b/quotevote-frontend/src/context/ThemeContext.tsx
@@ -83,7 +83,10 @@ export function ThemeContextProvider({ children }: ThemeContextProviderProps) {
     }
   }, [neoBrutalism])
 
-  // Apply saved preference when login state / server preference changes.
+  // Apply saved account preference when login state or preference changes.
+  // Intentionally does NOT follow OS/device color-scheme — only the user's
+  // saved `themePreference` (and localStorage when logged out). Preference is
+  // written to the store on settings Save; we must subscribe so that sync runs.
   // Do NOT depend on themeMode — that caused toggles to snap back to the
   // last saved preference before Save.
   /* eslint-disable react-hooks/set-state-in-effect -- sync theme from auth/store preference */

--- a/quotevote-frontend/src/graphql/mutations.ts
+++ b/quotevote-frontend/src/graphql/mutations.ts
@@ -618,6 +618,7 @@ export const UPDATE_USER = gql`
       username
       email
       name
+      bio
       avatar
       admin
       accountStatus

--- a/quotevote-frontend/src/graphql/queries.ts
+++ b/quotevote-frontend/src/graphql/queries.ts
@@ -534,6 +534,7 @@ export const GET_USER = gql`
       _id
       name
       username
+      bio
       upvotes
       downvotes
       _followingId

--- a/quotevote-frontend/src/hooks/useProfileBackground.ts
+++ b/quotevote-frontend/src/hooks/useProfileBackground.ts
@@ -40,13 +40,21 @@ function readPattern(): ProfileBackgroundPattern {
  * Persisted to localStorage (no backend per migration rules) and kept in sync
  * across hook instances/tabs via a custom event + the native `storage` event,
  * so editing it in Settings is reflected on the profile banner.
+ *
+ * Initial state always uses defaults so SSR and the first client paint match;
+ * persisted values hydrate in an effect after mount.
  */
 export function useProfileBackground(): ProfileBackground {
-  const [color, setColorState] = useState<string>(readColor);
+  const [hydrated, setHydrated] = useState(false);
+  const [color, setColorState] = useState<string>(DEFAULT_PROFILE_BG_COLOR);
   const [pattern, setPatternState] =
-    useState<ProfileBackgroundPattern>(readPattern);
+    useState<ProfileBackgroundPattern>(DEFAULT_PROFILE_BG_PATTERN);
 
   useEffect(() => {
+    setColorState(readColor());
+    setPatternState(readPattern());
+    setHydrated(true);
+
     const sync = () => {
       setColorState(readColor());
       setPatternState(readPattern());
@@ -81,5 +89,5 @@ export function useProfileBackground(): ProfileBackground {
     }
   }, []);
 
-  return { color, pattern, setColor, setPattern };
+  return { color, pattern, setColor, setPattern, hydrated };
 }

--- a/quotevote-frontend/src/hooks/useProfileBackground.ts
+++ b/quotevote-frontend/src/hooks/useProfileBackground.ts
@@ -41,20 +41,15 @@ function readPattern(): ProfileBackgroundPattern {
  * across hook instances/tabs via a custom event + the native `storage` event,
  * so editing it in Settings is reflected on the profile banner.
  *
- * Initial state always uses defaults so SSR and the first client paint match;
- * persisted values hydrate in an effect after mount.
+ * Initialized from localStorage via useState lazy init (same as pre-split main).
+ * `hydrated` is always true after mount so Settings can baseline dirty checks.
  */
 export function useProfileBackground(): ProfileBackground {
-  const [hydrated, setHydrated] = useState(false);
-  const [color, setColorState] = useState<string>(DEFAULT_PROFILE_BG_COLOR);
+  const [color, setColorState] = useState<string>(readColor);
   const [pattern, setPatternState] =
-    useState<ProfileBackgroundPattern>(DEFAULT_PROFILE_BG_PATTERN);
+    useState<ProfileBackgroundPattern>(readPattern);
 
   useEffect(() => {
-    setColorState(readColor());
-    setPatternState(readPattern());
-    setHydrated(true);
-
     const sync = () => {
       setColorState(readColor());
       setPatternState(readPattern());
@@ -89,5 +84,5 @@ export function useProfileBackground(): ProfileBackground {
     }
   }, []);
 
-  return { color, pattern, setColor, setPattern, hydrated };
+  return { color, pattern, setColor, setPattern, hydrated: true };
 }

--- a/quotevote-frontend/src/lib/auth/restLogin.ts
+++ b/quotevote-frontend/src/lib/auth/restLogin.ts
@@ -12,6 +12,10 @@ export interface LoginApiResponse {
     name?: string;
     email?: string;
     admin?: boolean;
+    accountStatus?: string;
+    /** URL string or avataaars qualities object from Mongo (JSON body, not JWT). */
+    avatar?: string | Record<string, unknown> | null;
+    bio?: string;
   };
 }
 

--- a/quotevote-frontend/src/lib/constants/profile.ts
+++ b/quotevote-frontend/src/lib/constants/profile.ts
@@ -1,0 +1,5 @@
+/** Max length for profile About / bio (plain text). */
+export const PROFILE_BIO_MAX_LENGTH = 500
+
+/** Detects HTML / markup — About must remain plain text. */
+export const PROFILE_BIO_HTML_PATTERN = /<\/?[a-z][\s\S]*>/i

--- a/quotevote-frontend/src/types/auth.ts
+++ b/quotevote-frontend/src/types/auth.ts
@@ -4,7 +4,9 @@ export interface AuthUser {
   username: string
   email: string
   name?: string
-  avatar?: string
+  /** URL string or avataaars qualities object from the login/profile payload. */
+  avatar?: string | Record<string, unknown> | null
+  bio?: string
   admin?: boolean
   accountStatus?: string
 }

--- a/quotevote-frontend/src/types/context.ts
+++ b/quotevote-frontend/src/types/context.ts
@@ -46,6 +46,7 @@ export interface AuthModalContextValue {
 export interface ThemeContextValue {
   themeMode: ThemeMode
   theme: Theme
+  setTheme: (mode: ThemeMode) => void
   toggleTheme: () => ThemeMode
   isDarkMode: boolean
   neoBrutalism: boolean

--- a/quotevote-frontend/src/types/profile.ts
+++ b/quotevote-frontend/src/types/profile.ts
@@ -49,6 +49,7 @@ export interface User {
   name?: string;
   username: string;
   email?: string;
+  bio?: string;
   avatar?: string | {
     url?: string;
     [key: string]: unknown;
@@ -65,6 +66,7 @@ export interface User {
 export interface ProfileUser extends User {
   _id: string;
   username: string;
+  bio?: string;
   _followingId?: string[];
   _followersId?: string[];
   avatar?: string | {
@@ -172,5 +174,7 @@ export interface ProfileBackground {
   pattern: ProfileBackgroundPattern;
   setColor: (color: string) => void;
   setPattern: (pattern: ProfileBackgroundPattern) => void;
+  /** True after localStorage values have been read on the client. */
+  hydrated: boolean;
 }
 

--- a/quotevote-frontend/src/types/settings.ts
+++ b/quotevote-frontend/src/types/settings.ts
@@ -12,6 +12,7 @@ export interface SettingsFormValues {
   name: string
   username: string
   email: string
+  bio: string
   password?: string
 }
 
@@ -26,6 +27,7 @@ export interface SettingsMenuProps {
 export interface UserAvatar {
   url?: string
   src?: string
+  [key: string]: unknown
 }
 
 export interface SettingsUserData {
@@ -34,7 +36,8 @@ export interface SettingsUserData {
   username?: string
   email?: string
   name?: string
-  avatar?: UserAvatar | string
+  bio?: string
+  avatar?: UserAvatar | string | Record<string, unknown>
   admin?: boolean
   _followingId?: string[]
   themePreference?: 'light' | 'dark'

--- a/quotevote-frontend/src/types/store.ts
+++ b/quotevote-frontend/src/types/store.ts
@@ -13,7 +13,7 @@ export interface UserState {
     id?: string;
     username?: string;
     email?: string;
-    avatar?: string;
+    avatar?: string | Record<string, unknown>;
     admin?: boolean;
     _followingId?: string[];
     [key: string]: unknown;


### PR DESCRIPTION
## Stack
**Part 1 of 4 — merge this first.**

| Order | Branch | PR |
| --- | --- | --- |
| 1 | `profile-bio` | **this PR** (#434) |
| 2 | `avatar-consistency` | #435 |
| 3 | `presence-persist` | #436 |
| 4 | `api-wiring` | #437 |

Related issue: #362

## Summary
- Backend `updateUser` / `updateUserAvatar` with bio validation (plain text, max length)
- Profile About tab + Edit Profile → settings
- Settings: About field, theme toggle fix, profile background Save dirty state, toast close on the right
- Login response includes `bio` (and `avatar` for later stack parts)

## CI follow-ups (on this branch)
- Lint: `set-state-in-effect` in theme / profile background hooks
- Types: unused `@ts-expect-error`, staged-chat avatar coercion, settings avatar URL parse

## Test plan
- [ ] Edit About in settings → save → appears on profile About tab
- [ ] HTML in About is rejected
- [ ] Dark mode toggles both ways and stays until Save
- [ ] Changing only banner color/pattern enables Save Changes
- [ ] Toast close button appears on the right