### PR TITLE
fix(avatar): consistent avataaars rendering (2/4)

### DIFF
--- a/quotevote-frontend/src/__tests__/hooks/useSyncCurrentUserProfile.test.tsx
+++ b/quotevote-frontend/src/__tests__/hooks/useSyncCurrentUserProfile.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook, waitFor } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing/react'
+import type { ReactNode } from 'react'
+import { useSyncCurrentUserProfile } from '@/hooks/useSyncCurrentUserProfile'
+import { GET_USER } from '@/graphql/queries'
+import { useAppStore } from '@/store/useAppStore'
+import { resetStore } from '@/__tests__/utils/test-utils'
+
+const qualities = { topType: 'LongHairStraight', hairColor: 'Brown' }
+
+function makeGetUserMock(
+  presence?: {
+    status: string
+    statusMessage: string
+    preferredStatus?: string
+    preferredStatusMessage?: string
+  } | null
+) {
+  return {
+    request: {
+      query: GET_USER,
+      variables: { username: 'alice' },
+    },
+    result: {
+      data: {
+        user: {
+          _id: 'user-1',
+          name: 'Alice',
+          username: 'alice',
+          bio: 'About me',
+          upvotes: 0,
+          downvotes: 0,
+          _followingId: [],
+          _followersId: [],
+          avatar: qualities,
+          contributorBadge: false,
+          presence:
+            presence === undefined
+              ? { status: 'away', statusMessage: 'In a meeting', preferredStatus: 'away', preferredStatusMessage: 'In a meeting' }
+              : presence,
+          reputation: null,
+        },
+      },
+    },
+  }
+}
+
+describe('useSyncCurrentUserProfile', () => {
+  beforeEach(() => {
+    resetStore()
+    useAppStore.getState().setUserData({
+      _id: 'user-1',
+      username: 'alice',
+      name: 'Alice',
+      // No avatar in store — mirrors login response before avatar was included
+    })
+  })
+
+  it('copies avatar from GET_USER into the store for nav/account menu', async () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <MockedProvider mocks={[makeGetUserMock()]}>{children}</MockedProvider>
+    )
+    renderHook(() => useSyncCurrentUserProfile(), { wrapper })
+
+    await waitFor(() => {
+      expect(useAppStore.getState().user.data.avatar).toEqual(qualities)
+    })
+  })
+
+  it('restores status and status message from GET_USER presence', async () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <MockedProvider mocks={[makeGetUserMock()]}>{children}</MockedProvider>
+    )
+    renderHook(() => useSyncCurrentUserProfile(), { wrapper })
+
+    await waitFor(() => {
+      expect(useAppStore.getState().chat.userStatus).toBe('away')
+      expect(useAppStore.getState().chat.userStatusMessage).toBe('In a meeting')
+    })
+  })
+
+  it('maps offline presence to online when rehydrating own session', async () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <MockedProvider
+        mocks={[makeGetUserMock({ status: 'offline', statusMessage: 'Back soon' })]}
+      >
+        {children}
+      </MockedProvider>
+    )
+    renderHook(() => useSyncCurrentUserProfile(), { wrapper })
+
+    await waitFor(() => {
+      expect(useAppStore.getState().chat.userStatus).toBe('online')
+      expect(useAppStore.getState().chat.userStatusMessage).toBe('Back soon')
+    })
+  })
+
+  it('restores preferredStatus when cleanup marked the user offline', async () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <MockedProvider
+        mocks={[
+          makeGetUserMock({
+            status: 'offline',
+            statusMessage: '',
+            preferredStatus: 'dnd',
+            preferredStatusMessage: 'Heads down',
+          }),
+        ]}
+      >
+        {children}
+      </MockedProvider>
+    )
+    renderHook(() => useSyncCurrentUserProfile(), { wrapper })
+
+    await waitFor(() => {
+      expect(useAppStore.getState().chat.userStatus).toBe('dnd')
+      expect(useAppStore.getState().chat.userStatusMessage).toBe('Heads down')
+    })
+  })
+})

--- a/quotevote-frontend/src/__tests__/hooks/useSyncCurrentUserProfile.test.tsx
+++ b/quotevote-frontend/src/__tests__/hooks/useSyncCurrentUserProfile.test.tsx
@@ -5,21 +5,17 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing/react'
 import type { ReactNode } from 'react'
-import { useSyncCurrentUserProfile } from '@/hooks/useSyncCurrentUserProfile'
+import {
+  resolveOwnStatus,
+  useSyncCurrentUserProfile,
+} from '@/hooks/useSyncCurrentUserProfile'
 import { GET_USER } from '@/graphql/queries'
 import { useAppStore } from '@/store/useAppStore'
 import { resetStore } from '@/__tests__/utils/test-utils'
 
 const qualities = { topType: 'LongHairStraight', hairColor: 'Brown' }
 
-function makeGetUserMock(
-  presence?: {
-    status: string
-    statusMessage: string
-    preferredStatus?: string
-    preferredStatusMessage?: string
-  } | null
-) {
+function makeGetUserMock(presence?: { status: string; statusMessage: string } | null) {
   return {
     request: {
       query: GET_USER,
@@ -40,7 +36,7 @@ function makeGetUserMock(
           contributorBadge: false,
           presence:
             presence === undefined
-              ? { status: 'away', statusMessage: 'In a meeting', preferredStatus: 'away', preferredStatusMessage: 'In a meeting' }
+              ? { status: 'away', statusMessage: 'In a meeting' }
               : presence,
           reputation: null,
         },
@@ -48,6 +44,37 @@ function makeGetUserMock(
     },
   }
 }
+
+describe('resolveOwnStatus', () => {
+  it('defaults to online when status is missing', () => {
+    expect(resolveOwnStatus({})).toEqual({ status: 'online', statusMessage: '' })
+  })
+
+  it('keeps an explicit non-offline status', () => {
+    expect(resolveOwnStatus({ status: 'away', statusMessage: 'BRB' })).toEqual({
+      status: 'away',
+      statusMessage: 'BRB',
+    })
+  })
+
+  it('maps offline → online for the active session', () => {
+    expect(resolveOwnStatus({ status: 'offline', statusMessage: 'Back soon' })).toEqual({
+      status: 'online',
+      statusMessage: 'Back soon',
+    })
+  })
+
+  it('favors preferredStatus over status (e.g. cleanup marked offline)', () => {
+    expect(
+      resolveOwnStatus({
+        status: 'offline',
+        statusMessage: '',
+        preferredStatus: 'dnd',
+        preferredStatusMessage: 'Heads down',
+      })
+    ).toEqual({ status: 'dnd', statusMessage: 'Heads down' })
+  })
+})
 
 describe('useSyncCurrentUserProfile', () => {
   beforeEach(() => {
@@ -96,29 +123,6 @@ describe('useSyncCurrentUserProfile', () => {
     await waitFor(() => {
       expect(useAppStore.getState().chat.userStatus).toBe('online')
       expect(useAppStore.getState().chat.userStatusMessage).toBe('Back soon')
-    })
-  })
-
-  it('restores preferredStatus when cleanup marked the user offline', async () => {
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <MockedProvider
-        mocks={[
-          makeGetUserMock({
-            status: 'offline',
-            statusMessage: '',
-            preferredStatus: 'dnd',
-            preferredStatusMessage: 'Heads down',
-          }),
-        ]}
-      >
-        {children}
-      </MockedProvider>
-    )
-    renderHook(() => useSyncCurrentUserProfile(), { wrapper })
-
-    await waitFor(() => {
-      expect(useAppStore.getState().chat.userStatus).toBe('dnd')
-      expect(useAppStore.getState().chat.userStatusMessage).toBe('Heads down')
     })
   })
 })

--- a/quotevote-frontend/src/__tests__/utils/avatar.test.ts
+++ b/quotevote-frontend/src/__tests__/utils/avatar.test.ts
@@ -1,0 +1,27 @@
+import { coerceAvatarValue, parseAvatarToUrl, buildAvatarUrl } from '@/lib/avatar'
+
+describe('coerceAvatarValue', () => {
+  it('returns strings and plain objects', () => {
+    expect(coerceAvatarValue('https://example.com/a.png')).toBe('https://example.com/a.png')
+    expect(coerceAvatarValue({ topType: 'Hat' })).toEqual({ topType: 'Hat' })
+  })
+
+  it('returns null for nullish and unexpected shapes', () => {
+    expect(coerceAvatarValue(null)).toBeNull()
+    expect(coerceAvatarValue(undefined)).toBeNull()
+    expect(coerceAvatarValue(42)).toBeNull()
+    expect(coerceAvatarValue([{ topType: 'Hat' }])).toBeNull()
+    expect(coerceAvatarValue(true)).toBeNull()
+  })
+})
+
+describe('parseAvatarToUrl', () => {
+  it('builds an avataaars URL from qualities', () => {
+    const url = parseAvatarToUrl({ topType: 'Hat', hairColor: 'Brown' })
+    expect(url).toBe(buildAvatarUrl({ topType: 'Hat', hairColor: 'Brown' }))
+  })
+
+  it('passes through plain URL strings', () => {
+    expect(parseAvatarToUrl('https://cdn.example/a.png')).toBe('https://cdn.example/a.png')
+  })
+})

--- a/quotevote-frontend/src/app/dashboard/layout.tsx
+++ b/quotevote-frontend/src/app/dashboard/layout.tsx
@@ -30,6 +30,7 @@ import { routeHasPersistentChatPanel } from '@/lib/utils/chatLayout';
 import { usePresenceHeartbeat } from '@/hooks/usePresenceHeartbeat';
 import { usePresenceSubscription } from '@/hooks/usePresenceSubscription';
 import { useRosterManagement } from '@/hooks/useRosterManagement';
+import { useSyncCurrentUserProfile } from '@/hooks/useSyncCurrentUserProfile';
 import ChatContent from '@/components/Chat/ChatContent';
 import { GET_NOTIFICATIONS, GET_CHAT_ROOMS } from '@/graphql/queries';
 import { DisplayAvatar } from '@/components/DisplayAvatar';
@@ -64,6 +65,7 @@ function DashboardClient() {
   usePresenceHeartbeat();
   usePresenceSubscription();
   useRosterManagement();
+  useSyncCurrentUserProfile();
   return null;
 }
 

--- a/quotevote-frontend/src/app/dashboard/profile/[username]/avatar/page.tsx
+++ b/quotevote-frontend/src/app/dashboard/profile/[username]/avatar/page.tsx
@@ -12,14 +12,15 @@
  * redirects back to the user's profile page.
  */
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useMutation } from '@apollo/client/react';
 import { toast } from 'sonner';
 import { Dices, Save, ArrowLeft, Loader2 } from 'lucide-react';
 import { useAppStore } from '@/store';
 import { UPDATE_USER_AVATAR } from '@/graphql/mutations';
-import { buildAvatarUrl, type AvatarQualities } from '@/lib/avatar';
+import { GET_USER } from '@/graphql/queries';
+import { buildAvatarUrl, getDefaultAvatar, type AvatarQualities } from '@/lib/avatar';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import {
@@ -333,7 +334,7 @@ interface UpdateUserAvatarData {
     username: string;
     name: string;
     email: string;
-    avatar: string;
+    avatar: string | Record<string, unknown>;
   };
 }
 
@@ -348,16 +349,30 @@ export default function AvatarEditorPage(): React.ReactNode {
   const updateStoreAvatar = useAppStore((state) => state.updateAvatar);
   const userId = (userData._id || userData.id) as string | undefined;
 
-  // Initialise avatar state from the store or random values
-  const initialAvatar = useMemo(() => {
+  // Deterministic default so SSR and the first client paint match.
+  // Persist-rehydrated store avatar is applied after mount.
+  const [avatar, setAvatar] = useState<AvatarQualities>(() =>
+    getDefaultAvatar('avatar-editor')
+  );
+  const seededFromStore = useRef(false);
+
+  useEffect(() => {
+    if (seededFromStore.current) return;
+
     const stored = parseStoredAvatar(
       userData.avatar as string | Record<string, unknown> | undefined
     );
-    return stored ?? getRandomAvatar();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (stored) {
+      setAvatar(stored);
+      seededFromStore.current = true;
+      return;
+    }
 
-  const [avatar, setAvatar] = useState<AvatarQualities>(initialAvatar);
+    // Store finished rehydrating (user id present) with no editable avatar — keep default.
+    if (userId) {
+      seededFromStore.current = true;
+    }
+  }, [userData.avatar, userId]);
 
   const [updateUserAvatar, { loading: saving }] = useMutation<UpdateUserAvatarData>(UPDATE_USER_AVATAR);
 
@@ -380,15 +395,25 @@ export default function AvatarEditorPage(): React.ReactNode {
       return;
     }
 
+    const username = typeof userData.username === 'string' ? userData.username : undefined;
+
     try {
       const result = await updateUserAvatar({
         variables: { user_id: userId, avatarQualities: avatar },
+        refetchQueries: username
+          ? [{ query: GET_USER, variables: { username } }]
+          : [],
+        awaitRefetchQueries: Boolean(username),
       });
 
       const returnedAvatar = result.data?.updateUserAvatar?.avatar;
-      if (returnedAvatar) {
-        updateStoreAvatar(returnedAvatar);
-      }
+      // Prefer the qualities we just saved so the store keeps a parseable object
+      // even if the API returns a serialized/odd shape.
+      updateStoreAvatar(
+        returnedAvatar && typeof returnedAvatar === 'object'
+          ? returnedAvatar
+          : avatar
+      );
 
       toast.success('Avatar updated successfully!');
       router.back();
@@ -397,7 +422,7 @@ export default function AvatarEditorPage(): React.ReactNode {
         err instanceof Error ? err.message : 'Failed to update avatar.';
       toast.error(message);
     }
-  }, [userId, avatar, updateUserAvatar, updateStoreAvatar, router]);
+  }, [userId, avatar, updateUserAvatar, updateStoreAvatar, router, userData.username]);
 
   const handleBack = useCallback(() => {
     router.back();

--- a/quotevote-frontend/src/components/Avatar.tsx
+++ b/quotevote-frontend/src/components/Avatar.tsx
@@ -5,24 +5,13 @@ import { useState, useMemo } from 'react';
 import { User } from 'lucide-react';
 import type { AvatarProps } from '@/types/components';
 import { cn } from '@/lib/utils';
+import { parseAvatarToUrl } from '@/lib/avatar';
 
 /**
  * Avatar Component
- * 
- * A fully typed, reusable Avatar component that displays user profile images
- * with fallback support for missing images. Supports initials or a default icon
- * as fallback content.
- * 
- * @param src - URL of the avatar image
- * @param alt - Alt text for the image (required for accessibility)
- * @param fallback - Fallback text (typically user initials) or React node
- * @param size - Size variant: 'sm', 'md', 'lg', or a custom number in pixels
- * @param className - Additional CSS classes
- * @param onClick - Optional click handler
- * 
- * @example
- * <Avatar src="/avatar.jpg" alt="John Doe" size="md" />
- * <Avatar alt="Jane Smith" fallback="JS" size="lg" />
+ *
+ * Displays a user profile image with fallback support. Accepts URL strings or
+ * avataaars qualities objects (resolved via `parseAvatarToUrl`).
  */
 export default function Avatar({
   src,
@@ -33,8 +22,10 @@ export default function Avatar({
   onClick,
   ...props
 }: AvatarProps) {
-  const [imageError, setImageError] = useState(false);
-  const [imageLoaded, setImageLoaded] = useState(false);
+  const resolvedSrc = useMemo(
+    () => parseAvatarToUrl(src ?? undefined) ?? (typeof src === 'string' ? src : undefined),
+    [src]
+  );
 
   // Calculate size classes and dimensions
   const sizeConfig = useMemo(() => {
@@ -76,9 +67,6 @@ export default function Avatar({
     return null;
   }, [alt, fallback]);
 
-  const showImage = !!src && typeof src === 'string' && !imageError;
-  const showFallback = !showImage;
-
   const baseClasses = cn(
     'relative inline-flex items-center justify-center',
     'rounded-full overflow-hidden',
@@ -117,52 +105,80 @@ export default function Avatar({
       }
       {...props}
     >
-      {showImage && (
-        <Image
-          src={src}
-          alt={alt || 'User avatar'}
-          width={sizeConfig.dimension}
-          height={sizeConfig.dimension}
-          loading="lazy"
-          className={cn(
-            'object-cover w-full h-full',
-            !imageLoaded && 'opacity-0'
-          )}
-          onError={() => setImageError(true)}
-          onLoad={() => setImageLoaded(true)}
-          {...(src?.startsWith('data:') || src?.startsWith('blob:') || src?.includes('avataaars.io')
-            ? { unoptimized: true }
-            : {})}
-        />
-      )}
-
-      {showFallback && (
-        <div
-          className={cn(
-            'w-full h-full flex items-center justify-center',
-            'bg-[var(--color-primary)] text-[var(--color-primary-contrast)]',
-            sizeConfig.textSize,
-            'font-medium'
-          )}
-          aria-hidden="true"
-        >
-          {fallbackContent ? (
-            <span>{fallbackContent}</span>
-          ) : (
-            <User
-              className={cn(
-                sizeConfig.dimension <= 32
-                  ? 'w-4 h-4'
-                  : sizeConfig.dimension <= 40
-                  ? 'w-5 h-5'
-                  : 'w-6 h-6'
-              )}
-              aria-hidden="true"
-            />
-          )}
-        </div>
-      )}
+      {/* Keyed by src so load/error state resets when the avatar changes */}
+      <AvatarMedia
+        key={resolvedSrc ?? 'fallback'}
+        resolvedSrc={resolvedSrc}
+        alt={alt}
+        dimension={sizeConfig.dimension}
+        textSize={sizeConfig.textSize}
+        fallbackContent={fallbackContent}
+      />
     </div>
   );
 }
 
+function AvatarMedia({
+  resolvedSrc,
+  alt,
+  dimension,
+  textSize,
+  fallbackContent,
+}: {
+  resolvedSrc?: string;
+  alt?: string;
+  dimension: number;
+  textSize: string;
+  fallbackContent: string | React.ReactNode | null;
+}) {
+  const [imageError, setImageError] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  const showImage = !!resolvedSrc && !imageError;
+
+  if (showImage && resolvedSrc) {
+    return (
+      <Image
+        src={resolvedSrc}
+        alt={alt || 'User avatar'}
+        width={dimension}
+        height={dimension}
+        loading="lazy"
+        className={cn(
+          'object-cover w-full h-full',
+          !imageLoaded && 'opacity-0'
+        )}
+        onError={() => setImageError(true)}
+        onLoad={() => setImageLoaded(true)}
+        {...(resolvedSrc.startsWith('data:') ||
+        resolvedSrc.startsWith('blob:') ||
+        resolvedSrc.includes('avataaars.io')
+          ? { unoptimized: true }
+          : {})}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'w-full h-full flex items-center justify-center',
+        'bg-[var(--color-primary)] text-[var(--color-primary-contrast)]',
+        textSize,
+        'font-medium'
+      )}
+      aria-hidden="true"
+    >
+      {fallbackContent ? (
+        <span>{fallbackContent}</span>
+      ) : (
+        <User
+          className={cn(
+            dimension <= 32 ? 'w-4 h-4' : dimension <= 40 ? 'w-5 h-5' : 'w-6 h-6'
+          )}
+          aria-hidden="true"
+        />
+      )}
+    </div>
+  );
+}

--- a/quotevote-frontend/src/components/BuddyList/BuddyItemList.tsx
+++ b/quotevote-frontend/src/components/BuddyList/BuddyItemList.tsx
@@ -101,7 +101,7 @@ export default function BuddyItemList({ buddyList, className }: BuddyItemListPro
                     const staged: StagedChatRoom = {
                         _id: null,
                         title: item.user.name || item.user.username || 'Chat',
-                        avatar: typeof item.user.avatar === 'string' ? item.user.avatar : null,
+                        avatar: (item.user.avatar as string | Record<string, unknown> | null | undefined) ?? null,
                         messageType: 'USER',
                         users: [currentUser._id!.toString(), item.user._id],
                         username: item.user.username,

--- a/quotevote-frontend/src/components/BuddyList/BuddyItemList.tsx
+++ b/quotevote-frontend/src/components/BuddyList/BuddyItemList.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/tooltip';
 import { BuddyItem, BuddyItemListProps, PresenceStatus } from '@/types/buddylist';
 import { ChatRoom, StagedChatRoom } from '@/types/chat';
+import { coerceAvatarValue } from '@/lib/avatar';
 
 
 
@@ -101,7 +102,7 @@ export default function BuddyItemList({ buddyList, className }: BuddyItemListPro
                     const staged: StagedChatRoom = {
                         _id: null,
                         title: item.user.name || item.user.username || 'Chat',
-                        avatar: (item.user.avatar as string | Record<string, unknown> | null | undefined) ?? null,
+                        avatar: coerceAvatarValue(item.user.avatar),
                         messageType: 'USER',
                         users: [currentUser._id!.toString(), item.user._id],
                         username: item.user.username,
@@ -153,7 +154,7 @@ function BuddyItemRow({ item, onClick }: { item: BuddyItem; onClick: () => void 
     // index.jsx maps item.messageType to item.type.
     const itemType = item.type || item.messageType || (item.user ? 'USER' : 'POST');
 
-    const rawAvatar = item.avatar || item.user?.avatar || item.room?.avatar;
+    const rawAvatar = coerceAvatarValue(item.avatar || item.user?.avatar || item.room?.avatar);
 
     return (
         <li
@@ -170,7 +171,7 @@ function BuddyItemRow({ item, onClick }: { item: BuddyItem; onClick: () => void 
         >
             <div className="relative">
                 <DisplayAvatar
-                    avatar={rawAvatar as string | Record<string, unknown> | undefined}
+                    avatar={rawAvatar}
                     username={itemText}
                     size={40}
                     className="border-2 border-white shadow-sm"

--- a/quotevote-frontend/src/components/Chat/AddBuddyDialog.tsx
+++ b/quotevote-frontend/src/components/Chat/AddBuddyDialog.tsx
@@ -101,7 +101,7 @@ const AddBuddyDialog = ({ open, onClose }: AddBuddyDialogProps) => {
             >
               <div className="relative">
                 <Avatar
-                  src={typeof user.avatar === 'string' ? user.avatar : undefined}
+                  src={user.avatar}
                   alt={user.name || user.username}
                   size={40}
                 />

--- a/quotevote-frontend/src/components/Chat/MessageItemList.tsx
+++ b/quotevote-frontend/src/components/Chat/MessageItemList.tsx
@@ -140,7 +140,7 @@ export default function MessageItemList({ room }: MessageItemListProps) {
         id: postCreator._id,
         username: postCreator.username || '',
         name: postCreator.name || undefined,
-        avatar: typeof postCreator.avatar === 'string' ? postCreator.avatar : undefined,
+        avatar: postCreator.avatar as string | Record<string, unknown> | undefined,
         contributorBadge: postCreator.contributorBadge || undefined,
       }
     : null

--- a/quotevote-frontend/src/components/Chat/QuoteHeaderMessage.tsx
+++ b/quotevote-frontend/src/components/Chat/QuoteHeaderMessage.tsx
@@ -39,7 +39,7 @@ const QuoteHeaderMessage: FC<QuoteHeaderMessageProps> = ({
           <div className="flex items-center gap-3">
             {postCreator && (
               <Avatar
-                src={typeof postCreator.avatar === 'string' ? postCreator.avatar : undefined}
+                src={postCreator.avatar}
                 alt={authorName}
                 size={40}
                 className="h-10 w-10 border-2 border-background shadow-sm"

--- a/quotevote-frontend/src/components/Chat/UserSearchResults.tsx
+++ b/quotevote-frontend/src/components/Chat/UserSearchResults.tsx
@@ -149,7 +149,7 @@ const UserSearchResults: FC<UserSearchResultsProps> = ({ searchQuery }) => {
             className="flex items-center gap-3 rounded-xl border bg-card px-3 py-2.5 text-sm shadow-sm transition hover:bg-accent/40"
           >
             <Avatar
-              src={typeof user.avatar === 'string' ? user.avatar : undefined}
+              src={user.avatar}
               alt={user.name || user.username}
               size={40}
               className="flex-shrink-0"

--- a/quotevote-frontend/src/components/Comment/Comment.tsx
+++ b/quotevote-frontend/src/components/Comment/Comment.tsx
@@ -7,7 +7,7 @@ import { Reference } from '@apollo/client'
 import { Link as LinkIcon, Trash2 } from 'lucide-react'
 import CommentReactions from './CommentReactions'
 import { Button } from '@/components/ui/button'
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { DisplayAvatar } from '@/components/DisplayAvatar'
 import { parseCommentDate } from '@/lib/utils/momentUtils'
 import { useAppStore } from '@/store/useAppStore'
 import { toast } from 'sonner'
@@ -99,12 +99,12 @@ export default function Comment({ comment, postUrl, selected }: CommentProps) {
         className="flex-shrink-0 mt-0.5"
         onClick={() => router.push(`/dashboard/profile/${username}`)}
       >
-        <Avatar className="size-8 ring-1 ring-border/50">
-          <AvatarImage src={typeof avatar === 'string' ? avatar : undefined} alt={username} />
-          <AvatarFallback className="text-[11px] bg-muted font-semibold">
-            {(name || username || '').slice(0, 2).toUpperCase()}
-          </AvatarFallback>
-        </Avatar>
+        <DisplayAvatar
+          avatar={avatar as string | Record<string, unknown> | undefined}
+          username={name || username}
+          size={32}
+          className="ring-1 ring-border/50"
+        />
       </button>
 
       {/* Content */}

--- a/quotevote-frontend/src/components/Comment/CommentInput.tsx
+++ b/quotevote-frontend/src/components/Comment/CommentInput.tsx
@@ -6,7 +6,7 @@ import { useMutation } from '@apollo/client/react'
 import { gql } from '@apollo/client'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { DisplayAvatar } from '@/components/DisplayAvatar'
 import { ADD_COMMENT } from '@/graphql/mutations'
 import { useAppStore } from '@/store/useAppStore'
 import { toast } from 'sonner'
@@ -41,7 +41,6 @@ export default function CommentInput({
   const userData = useAppStore((state) => state.user.data)
   const ensureAuth = useGuestGuard()
 
-  const avatarSrc = typeof userData.avatar === 'string' ? userData.avatar : undefined
   const displayName = (userData.name as string) || (userData.username as string) || ''
 
   const [addComment, { loading }] = useMutation<AddCommentData>(ADD_COMMENT, {
@@ -109,12 +108,12 @@ export default function CommentInput({
     <div className="flex gap-3">
       {/* User avatar */}
       <div className="flex-shrink-0 mt-1">
-        <Avatar className="size-8 ring-1 ring-border/50">
-          <AvatarImage src={avatarSrc} />
-          <AvatarFallback className="text-[11px] bg-primary/8 text-primary font-semibold">
-            {displayName.slice(0, 2).toUpperCase() || 'U'}
-          </AvatarFallback>
-        </Avatar>
+        <DisplayAvatar
+          avatar={userData.avatar as string | Record<string, unknown> | undefined}
+          username={displayName}
+          size={32}
+          className="ring-1 ring-border/50"
+        />
       </div>
 
       {/* Input area */}

--- a/quotevote-frontend/src/components/PostChat/PostChatSend.tsx
+++ b/quotevote-frontend/src/components/PostChat/PostChatSend.tsx
@@ -78,7 +78,7 @@ export default function PostChatSend({ messageRoomId, title, postId }: PostChatS
             _id: ((user._id || user.id) as string) || '',
             name: (user.name as string) || '',
             username: (user.username as string) || '',
-            avatar: typeof user.avatar === 'string' ? user.avatar : '',
+            avatar: user.avatar as string | Record<string, unknown> | undefined,
           },
         },
       },

--- a/quotevote-frontend/src/components/ui/ActivityCard.tsx
+++ b/quotevote-frontend/src/components/ui/ActivityCard.tsx
@@ -5,7 +5,7 @@ import moment from 'moment'
 import { isEmpty } from 'lodash'
 import { Bookmark, BookmarkCheck } from 'lucide-react'
 import { Card, CardContent, CardFooter } from '@/components/ui/card'
-import Avatar from '@/components/Avatar'
+import { DisplayAvatar } from '@/components/DisplayAvatar'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import type { ActivityCardProps } from '@/types/activity'
@@ -62,7 +62,7 @@ function ActivityContent({
 }: {
   date: string | number
   content: string
-  avatar?: string | { src?: string; alt?: string }
+  avatar?: string | Record<string, unknown> | { src?: string; alt?: string }
   width?: 'lg' | 'md' | 'sm' | 'xl' | 'xs' | number
   handleRedirectToProfile?: (username: string) => void
   username: string
@@ -73,24 +73,32 @@ function ActivityContent({
   const contentLength = numericWidth > 500 ? 1000 : 500
   const isPosted = activityType?.toUpperCase() === 'POSTED'
   const title = post?.title ? (isPosted ? post.title : post.title.substring(0, 100)) : ''
-  
-  const avatarSrc = typeof avatar === 'string' ? avatar : avatar?.src
-  const avatarAlt = typeof avatar === 'string' ? undefined : avatar?.alt || username
+
+  // Legacy ActivityCard shape used `{ src, alt }`; API avatars are URLs or qualities objects.
+  const isLegacyAvatarShape =
+    typeof avatar === 'object' &&
+    avatar !== null &&
+    ('src' in avatar || 'alt' in avatar) &&
+    !('topType' in avatar) &&
+    !('url' in avatar)
+  const avatarValue = isLegacyAvatarShape
+    ? (avatar as { src?: string }).src
+    : (avatar as string | Record<string, unknown> | undefined)
 
   return (
     <div className="flex gap-4 min-h-[130px]">
-      <Avatar
-        src={avatarSrc}
-        alt={avatarAlt || username}
-        size={40}
-        className="cursor-pointer shrink-0"
+      <button
+        type="button"
+        className="cursor-pointer shrink-0 rounded-full"
         onClick={(e) => {
           e.stopPropagation()
           if (handleRedirectToProfile) {
             handleRedirectToProfile(username)
           }
         }}
-      />
+      >
+        <DisplayAvatar avatar={avatarValue} username={username} size={40} />
+      </button>
       <div className="flex-1 min-w-0">
         <ActivityHeader
           name={username}

--- a/quotevote-frontend/src/graphql/queries.ts
+++ b/quotevote-frontend/src/graphql/queries.ts
@@ -541,6 +541,10 @@ export const GET_USER = gql`
       _followersId
       avatar
       contributorBadge
+      presence {
+        status
+        statusMessage
+      }
       reputation {
         _id
         overallScore

--- a/quotevote-frontend/src/hooks/useSyncCurrentUserProfile.ts
+++ b/quotevote-frontend/src/hooks/useSyncCurrentUserProfile.ts
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useQuery } from '@apollo/client/react'
+import { GET_USER } from '@/graphql/queries'
+import { useAppStore } from '@/store/useAppStore'
+
+type SyncedPresence = {
+  status?: string | null
+  statusMessage?: string | null
+  preferredStatus?: string | null
+  preferredStatusMessage?: string | null
+}
+
+type SyncedUserFields = {
+  avatar?: string | Record<string, unknown> | null
+  name?: string | null
+  bio?: string | null
+  email?: string | null
+  contributorBadge?: boolean | null
+  presence?: SyncedPresence | null
+}
+
+const PRESENCE_STATUSES = new Set(['online', 'away', 'dnd', 'invisible', 'offline'])
+
+function resolveOwnStatus(presence: SyncedPresence): { status: string; statusMessage: string } {
+  const preferred =
+    typeof presence.preferredStatus === 'string' && PRESENCE_STATUSES.has(presence.preferredStatus)
+      ? presence.preferredStatus
+      : null
+  const raw = preferred ?? presence.status ?? 'online'
+  // You're actively loading the app — don't show yourself as offline.
+  const status = raw === 'offline' ? 'online' : raw
+  const fromPreferred =
+    typeof presence.preferredStatusMessage === 'string' ? presence.preferredStatusMessage : null
+  const fromCurrent =
+    typeof presence.statusMessage === 'string' ? presence.statusMessage : null
+  return {
+    status,
+    statusMessage: fromPreferred ?? fromCurrent ?? '',
+  }
+}
+
+/**
+ * Keeps the persisted Zustand user (used by nav / account menu avatars) in sync
+ * with the latest profile from GraphQL. Login historically omitted `avatar`, so
+ * without this sync the nav shows a seeded default while the profile page is correct.
+ *
+ * Also restores presence (status + message) from the server — Zustand defaults to
+ * online/empty on hard reload even though Presence is saved in MongoDB.
+ */
+export function useSyncCurrentUserProfile(): void {
+  const username = useAppStore((state) =>
+    typeof state.user.data.username === 'string' ? state.user.data.username : undefined
+  )
+  const setUserData = useAppStore((state) => state.setUserData)
+  const setUserStatus = useAppStore((state) => state.setUserStatus)
+
+  const { data } = useQuery<{ user: SyncedUserFields | null }>(GET_USER, {
+    variables: { username: username ?? '' },
+    skip: !username,
+    fetchPolicy: 'cache-and-network',
+  })
+
+  useEffect(() => {
+    const fetched = data?.user
+    if (!fetched || !username) return
+
+    const current = useAppStore.getState().user.data
+    const nextAvatar = fetched.avatar ?? undefined
+    const avatarChanged =
+      JSON.stringify(current.avatar ?? null) !== JSON.stringify(nextAvatar ?? null)
+    const nameChanged =
+      typeof fetched.name === 'string' && fetched.name.length > 0 && fetched.name !== current.name
+    const bioChanged =
+      typeof fetched.bio === 'string' && fetched.bio !== (current.bio as string | undefined)
+    const emailChanged =
+      typeof fetched.email === 'string' &&
+      fetched.email.length > 0 &&
+      fetched.email !== current.email
+    const badgeChanged =
+      typeof fetched.contributorBadge === 'boolean' &&
+      fetched.contributorBadge !== current.contributorBadge
+
+    if (avatarChanged || nameChanged || bioChanged || emailChanged || badgeChanged) {
+      setUserData({
+        ...current,
+        ...(avatarChanged ? { avatar: nextAvatar ?? undefined } : {}),
+        ...(nameChanged && typeof fetched.name === 'string' ? { name: fetched.name } : {}),
+        ...(bioChanged && typeof fetched.bio === 'string' ? { bio: fetched.bio } : {}),
+        ...(emailChanged && typeof fetched.email === 'string' ? { email: fetched.email } : {}),
+        ...(badgeChanged && typeof fetched.contributorBadge === 'boolean'
+          ? { contributorBadge: fetched.contributorBadge }
+          : {}),
+      })
+    }
+
+    const presence = fetched.presence
+    if (!presence?.status && !presence?.preferredStatus) return
+    if (presence.status && !PRESENCE_STATUSES.has(presence.status) && !presence.preferredStatus) {
+      return
+    }
+
+    const { status, statusMessage } = resolveOwnStatus(presence)
+    const chat = useAppStore.getState().chat
+    if (chat.userStatus === status && chat.userStatusMessage === statusMessage) return
+
+    setUserStatus(status, statusMessage)
+  }, [data?.user, username, setUserData, setUserStatus])
+}

--- a/quotevote-frontend/src/hooks/useSyncCurrentUserProfile.ts
+++ b/quotevote-frontend/src/hooks/useSyncCurrentUserProfile.ts
@@ -5,9 +5,10 @@ import { useQuery } from '@apollo/client/react'
 import { GET_USER } from '@/graphql/queries'
 import { useAppStore } from '@/store/useAppStore'
 
-type SyncedPresence = {
+export type SyncedPresence = {
   status?: string | null
   statusMessage?: string | null
+  /** Optional; not yet exposed on GET_USER / Presence GraphQL type. */
   preferredStatus?: string | null
   preferredStatusMessage?: string | null
 }
@@ -23,7 +24,15 @@ type SyncedUserFields = {
 
 const PRESENCE_STATUSES = new Set(['online', 'away', 'dnd', 'invisible', 'offline'])
 
-function resolveOwnStatus(presence: SyncedPresence): { status: string; statusMessage: string } {
+/**
+ * Resolve the status the current user should see for themselves after rehydrate.
+ * Prefers `preferredStatus` when present (survives cleanup marking status offline).
+ * Maps leftover `offline` → `online` since the user is actively in the app.
+ */
+export function resolveOwnStatus(presence: SyncedPresence): {
+  status: string
+  statusMessage: string
+} {
   const preferred =
     typeof presence.preferredStatus === 'string' && PRESENCE_STATUSES.has(presence.preferredStatus)
       ? presence.preferredStatus
@@ -33,8 +42,7 @@ function resolveOwnStatus(presence: SyncedPresence): { status: string; statusMes
   const status = raw === 'offline' ? 'online' : raw
   const fromPreferred =
     typeof presence.preferredStatusMessage === 'string' ? presence.preferredStatusMessage : null
-  const fromCurrent =
-    typeof presence.statusMessage === 'string' ? presence.statusMessage : null
+  const fromCurrent = typeof presence.statusMessage === 'string' ? presence.statusMessage : null
   return {
     status,
     statusMessage: fromPreferred ?? fromCurrent ?? '',
@@ -46,6 +54,9 @@ function resolveOwnStatus(presence: SyncedPresence): { status: string; statusMes
  * with the latest profile from GraphQL. Login historically omitted `avatar`, so
  * without this sync the nav shows a seeded default while the profile page is correct.
  *
+ * Uses cache-first so dashboard remounts reuse Apollo cache instead of re-hitting
+ * the network on every page. Misses (post-login, hard reload) still fetch once.
+ *
  * Also restores presence (status + message) from the server — Zustand defaults to
  * online/empty on hard reload even though Presence is saved in MongoDB.
  */
@@ -56,10 +67,12 @@ export function useSyncCurrentUserProfile(): void {
   const setUserData = useAppStore((state) => state.setUserData)
   const setUserStatus = useAppStore((state) => state.setUserStatus)
 
+  // cache-first: fill gaps after login / hard reload; avoid re-fetching on every
+  // dashboard navigation. Avatar/settings mutations update Apollo cache + Zustand.
   const { data } = useQuery<{ user: SyncedUserFields | null }>(GET_USER, {
     variables: { username: username ?? '' },
     skip: !username,
-    fetchPolicy: 'cache-and-network',
+    fetchPolicy: 'cache-first',
   })
 
   useEffect(() => {

--- a/quotevote-frontend/src/lib/avatar.ts
+++ b/quotevote-frontend/src/lib/avatar.ts
@@ -63,6 +63,21 @@ export function getDefaultAvatar(seed: string): AvatarQualities {
   );
 }
 
+export type AvatarValue = string | Record<string, unknown>;
+
+/**
+ * Runtime-narrow unknown avatar payloads (GraphQL JSON / loosely typed maps)
+ * to string | Record | null. Rejects numbers, arrays, and other unexpected shapes.
+ */
+export function coerceAvatarValue(value: unknown): AvatarValue | null {
+  if (value == null) return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
 /**
  * Converts any stored avatar value to a renderable URL:
  *  - avataaars qualities object → avataaars.io URL

--- a/quotevote-frontend/src/store/useAppStore.ts
+++ b/quotevote-frontend/src/store/useAppStore.ts
@@ -77,7 +77,7 @@ interface AppStore extends AppState {
   setUserLoading: (loading: boolean) => void;
   setLoginError: (error: string | null) => void;
   logout: () => void;
-  updateAvatar: (avatar: string) => void;
+  updateAvatar: (avatar: string | Record<string, unknown>) => void;
   updateFollowing: (followingId: string[]) => void;
 
   // UI actions

--- a/quotevote-frontend/src/types/activity.ts
+++ b/quotevote-frontend/src/types/activity.ts
@@ -14,7 +14,7 @@ export interface ActivityUser {
   _id: string
   name?: string
   username: string
-  avatar?: string
+  avatar?: string | Record<string, unknown>
   contributorBadge?: boolean
 }
 
@@ -164,7 +164,7 @@ export type ActivityEmptyListProps = Record<string, never>
 
 // ActivityCard props
 export interface ActivityCardProps {
-  avatar?: string | { src?: string; alt?: string }
+  avatar?: string | Record<string, unknown> | { src?: string; alt?: string }
   cardColor?: string
   name?: string
   username: string

--- a/quotevote-frontend/src/types/buddylist.ts
+++ b/quotevote-frontend/src/types/buddylist.ts
@@ -12,7 +12,7 @@ export interface BuddyUser {
     _id: string;
     name?: string;
     username?: string;
-    avatar?: string | null;
+    avatar?: string | Record<string, unknown> | null;
 }
 
 export interface Buddy {
@@ -31,7 +31,7 @@ export interface BuddyItem {
     Text?: string;
     messageType?: 'USER' | 'POST';
     type?: 'USER' | 'POST';
-    avatar?: string | { url: string } | null;
+    avatar?: string | Record<string, unknown> | { url: string } | null;
     unreadMessages?: number;
     presence?: Presence;
     statusMessage?: string;

--- a/quotevote-frontend/src/types/chat.ts
+++ b/quotevote-frontend/src/types/chat.ts
@@ -79,8 +79,8 @@ export interface ChatRoom {
     messageType?: string | null
     /** Room title (for groups or resolved DM display) */
     title?: string | null
-    /** Optional avatar URL resolved by backend */
-    avatar?: string | null
+    /** Optional avatar URL or avataaars qualities resolved by backend */
+    avatar?: string | Record<string, unknown> | null
     /** ISO timestamp when room was created */
     created: string
     /** ISO timestamp of last message */
@@ -185,7 +185,7 @@ export interface TypingUser {
 export interface StagedChatRoom {
   _id: null;
   title: string;
-  avatar: string | null;
+  avatar: string | Record<string, unknown> | null;
   messageType: 'USER';
   users: string[];
   username?: string;

--- a/quotevote-frontend/src/types/components.ts
+++ b/quotevote-frontend/src/types/components.ts
@@ -14,9 +14,10 @@ export interface LoadingSpinnerProps {
 
 export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
-   * URL of the avatar image
+   * Avatar image URL, avataaars qualities object, or JSON-encoded qualities.
+   * Objects are resolved via `parseAvatarToUrl`.
    */
-  src?: string;
+  src?: string | Record<string, unknown> | null;
   /**
    * Alt text for the image (required for accessibility)
    */
@@ -521,7 +522,7 @@ export interface ProfileHeaderProps {
     username: string;
     _followingId?: string[];
     _followersId?: string[];
-    avatar?: string;
+    avatar?: string | Record<string, unknown>;
     contributorBadge?: boolean;
     [key: string]: unknown;
   };
@@ -937,7 +938,7 @@ export interface SearchCreatorResult {
   _id: string;
   name: string;
   username?: string;
-  avatar?: string;
+  avatar?: string | Record<string, unknown>;
   __typename?: string;
 }
 
@@ -966,7 +967,7 @@ export interface UsernameSearchUser {
   _id: string;
   username: string;
   name: string;
-  avatar?: string;
+  avatar?: string | Record<string, unknown>;
   contributorBadge?: boolean;
 }
 

--- a/quotevote-frontend/src/types/postChat.ts
+++ b/quotevote-frontend/src/types/postChat.ts
@@ -127,7 +127,7 @@ export interface CreateMessageData {
       _id: string
       name: string
       username: string
-      avatar: string
+      avatar?: string | Record<string, unknown>
     }
   }
 }


### PR DESCRIPTION
## Stack
**Part 2 of 4 — merge after Part 1 (#434 / `profile-bio`).**

| Order | Branch | PR |
| --- | --- | --- |
| 1 | `profile-bio` | #434 (merge first) |
| 2 | `avatar-consistency` | **this PR** (#435; base = Part 1) |
| 3 | `presence-persist` | #436 |
| 4 | `api-wiring` | #437 |

After Part 1 merges to `main`, retarget this PR’s base to `main` (or rebase onto `main`).

Related issue: #362

## Summary
- `Avatar` parses qualities objects vs URL strings
- Chat / comments / activity / search pass raw avatar values
- `useSyncCurrentUserProfile` keeps nav/account avatar in sync with GET_USER
- Store + login avatar typing for object avatars

## Test plan
- [ ] Profile, nav, comments, and chat show the same custom avatar
- [ ] Hard reload still shows correct nav avatar when logged in
- [ ] Avatar editor save updates profile and nav