### PR TITLE
feat(presence): persist status across reload (3/4)

### DIFF
--- a/quotevote-backend/__tests__/unit/resolvers/heartbeatResolver.test.ts
+++ b/quotevote-backend/__tests__/unit/resolvers/heartbeatResolver.test.ts
@@ -1,0 +1,166 @@
+import { GraphQLError } from 'graphql';
+import { heartbeatResolver } from '~/data/resolvers/heartbeatResolver';
+import Presence from '~/data/models/Presence';
+import { pubsub } from '~/data/utils/pubsub';
+import { SUBSCRIPTION_EVENTS } from '~/types/graphql';
+import type { GraphQLContext } from '~/types/graphql';
+
+jest.mock('~/data/models/Presence');
+jest.mock('~/data/utils/pubsub', () => ({
+  pubsub: {
+    publish: jest.fn().mockResolvedValue(undefined),
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+    asyncIterableIterator: jest.fn(),
+  },
+}));
+
+const actorId = '60d5ec49ad414d7a8d5464a0';
+
+function mockContext(overrides: Partial<NonNullable<GraphQLContext['user']>> = {}): GraphQLContext {
+  return {
+    req: {} as GraphQLContext['req'],
+    res: {} as GraphQLContext['res'],
+    pubsub: {} as GraphQLContext['pubsub'],
+    user: {
+      _id: actorId,
+      username: 'alice',
+      email: 'alice@example.com',
+      admin: false,
+      ...overrides,
+    } as NonNullable<GraphQLContext['user']>,
+  };
+}
+
+describe('heartbeatResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Mutation.heartbeat', () => {
+    it('requires authentication', async () => {
+      await expect(
+        heartbeatResolver.Mutation.heartbeat(null, {}, { ...mockContext(), user: null })
+      ).rejects.toThrow(GraphQLError);
+    });
+
+    it('updates heartbeat and returns success', async () => {
+      (Presence.updateHeartbeat as jest.Mock).mockResolvedValue({
+        lastHeartbeat: new Date('2024-01-15T12:00:00.000Z'),
+        status: 'away',
+        statusMessage: 'In a meeting',
+      });
+
+      const result = await heartbeatResolver.Mutation.heartbeat(null, {}, mockContext());
+
+      expect(Presence.updateHeartbeat).toHaveBeenCalledWith(actorId);
+      expect(result).toEqual({
+        success: true,
+        timestamp: '2024-01-15T12:00:00.000Z',
+        status: 'away',
+        statusMessage: 'In a meeting',
+      });
+    });
+  });
+
+  describe('Mutation.updatePresence', () => {
+    it('requires authentication', async () => {
+      await expect(
+        heartbeatResolver.Mutation.updatePresence(
+          null,
+          { presence: { status: 'away', statusMessage: 'BRB' } },
+          { ...mockContext(), user: null }
+        )
+      ).rejects.toThrow(GraphQLError);
+    });
+
+    it('rejects invalid status', async () => {
+      await expect(
+        heartbeatResolver.Mutation.updatePresence(
+          null,
+          { presence: { status: 'busy' } },
+          mockContext()
+        )
+      ).rejects.toThrow(/status must be one of/);
+      expect(Presence.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('upserts presence and publishes update', async () => {
+      const now = new Date('2024-01-15T12:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(now);
+
+      (Presence.findOneAndUpdate as jest.Mock).mockResolvedValue({
+        _id: { toString: () => 'presence-1' },
+        userId: { toString: () => actorId },
+        status: 'away',
+        statusMessage: 'In a meeting',
+        preferredStatus: 'away',
+        preferredStatusMessage: 'In a meeting',
+        lastHeartbeat: now,
+        lastSeen: now,
+      });
+
+      const result = await heartbeatResolver.Mutation.updatePresence(
+        null,
+        { presence: { status: 'away', statusMessage: '  In a meeting  ' } },
+        mockContext()
+      );
+
+      expect(Presence.findOneAndUpdate).toHaveBeenCalledWith(
+        { userId: actorId },
+        {
+          $set: {
+            status: 'away',
+            statusMessage: 'In a meeting',
+            preferredStatus: 'away',
+            preferredStatusMessage: 'In a meeting',
+            lastHeartbeat: now,
+            lastSeen: now,
+          },
+        },
+        { upsert: true, new: true, setDefaultsOnInsert: true }
+      );
+      expect(pubsub.publish).toHaveBeenCalledWith(SUBSCRIPTION_EVENTS.PRESENCE_UPDATED, {
+        presence: {
+          userId: actorId,
+          status: 'away',
+          statusMessage: 'In a meeting',
+          lastSeen: now,
+        },
+      });
+      expect(result).toEqual({
+        _id: 'presence-1',
+        userId: actorId,
+        status: 'away',
+        statusMessage: 'In a meeting',
+        lastHeartbeat: now,
+        lastSeen: now,
+      });
+
+      jest.useRealTimers();
+    });
+
+    it('truncates status messages over 200 characters', async () => {
+      const longMessage = 'x'.repeat(250);
+      (Presence.findOneAndUpdate as jest.Mock).mockResolvedValue({
+        _id: { toString: () => 'presence-1' },
+        userId: { toString: () => actorId },
+        status: 'online',
+        statusMessage: 'x'.repeat(200),
+        lastHeartbeat: new Date(),
+        lastSeen: new Date(),
+      });
+
+      await heartbeatResolver.Mutation.updatePresence(
+        null,
+        { presence: { status: 'online', statusMessage: longMessage } },
+        mockContext()
+      );
+
+      const updateArg = (Presence.findOneAndUpdate as jest.Mock).mock.calls[0][1] as {
+        $set: { statusMessage: string };
+      };
+      expect(updateArg.$set.statusMessage).toHaveLength(200);
+    });
+  });
+});

--- a/quotevote-backend/app/data/models/Presence.ts
+++ b/quotevote-backend/app/data/models/Presence.ts
@@ -1,47 +1,91 @@
 import mongoose, { Schema } from 'mongoose';
 import type { PresenceDocument, PresenceModel } from '../../types/mongoose';
+import type { PresenceStatus } from '../../types/common';
+
+const STATUS_ENUM = ['online', 'away', 'dnd', 'offline', 'invisible'] as const;
 
 const PresenceSchema = new Schema<PresenceDocument, PresenceModel>(
-    {
-        userId: { type: Schema.Types.ObjectId, ref: 'User', required: true, unique: true },
-        status: {
-            type: String,
-            enum: ['online', 'away', 'dnd', 'offline', 'invisible'],
-            default: 'offline'
-        },
-        statusMessage: { type: String },
-        lastHeartbeat: { type: Date, default: Date.now },
-        lastSeen: { type: Date, default: Date.now },
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true, unique: true },
+    status: {
+      type: String,
+      enum: STATUS_ENUM,
+      default: 'offline',
     },
-    {
-        timestamps: true,
-        toJSON: { virtuals: true },
-        toObject: { virtuals: true },
-    }
+    statusMessage: { type: String },
+    // Survives stale cleanup (which sets status to offline) so refresh can restore
+    // the user's chosen status + message.
+    preferredStatus: {
+      type: String,
+      enum: STATUS_ENUM,
+    },
+    preferredStatusMessage: { type: String },
+    lastHeartbeat: { type: Date, default: Date.now },
+    lastSeen: { type: Date, default: Date.now },
+  },
+  {
+    timestamps: true,
+    toJSON: { virtuals: true },
+    toObject: { virtuals: true },
+  }
 );
 
-// Indexes
 PresenceSchema.index({ status: 1 });
 PresenceSchema.index({ lastHeartbeat: 1 });
 
-// Static method: findByUserId
 PresenceSchema.statics.findByUserId = function (userId: string) {
-    return this.findOne({ userId });
+  return this.findOne({ userId });
 };
 
-// Static method: updateHeartbeat
-PresenceSchema.statics.updateHeartbeat = async function (userId: string) {
+/**
+ * Refresh liveness only. Do not overwrite a user-chosen status/message.
+ * If stale cleanup marked the user offline, restore their preferred status.
+ */
+async function updateHeartbeatImpl(
+  this: PresenceModel,
+  userId: string
+): Promise<PresenceDocument> {
+  const now = new Date();
+  const existing = await this.findOne({ userId });
+
+  if (!existing) {
     return this.findOneAndUpdate(
-        { userId },
-        { 
-            lastHeartbeat: new Date(),
-            status: 'online'
+      { userId },
+      {
+        $set: { lastHeartbeat: now, lastSeen: now },
+        $setOnInsert: {
+          status: 'online',
+          preferredStatus: 'online',
+          preferredStatusMessage: '',
         },
-        { upsert: true, new: true, setDefaultsOnInsert: true }
+      },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
     );
-};
+  }
 
-// Check if model already exists
-const Presence = (mongoose.models.Presence as PresenceModel) || mongoose.model<PresenceDocument, PresenceModel>('Presence', PresenceSchema);
+  existing.lastHeartbeat = now;
+  existing.lastSeen = now;
+
+  if (existing.status === 'offline') {
+    const preferred = existing.preferredStatus;
+    const restore =
+      preferred && preferred !== 'offline' ? (preferred as PresenceStatus) : 'online';
+    existing.status = restore;
+    if (typeof existing.preferredStatusMessage === 'string') {
+      existing.statusMessage = existing.preferredStatusMessage;
+    }
+  }
+
+  return existing.save();
+}
+
+PresenceSchema.statics.updateHeartbeat = updateHeartbeatImpl;
+
+// Always bind the latest statics — mongoose.models.Presence may already exist after hot reload.
+const Presence =
+  (mongoose.models.Presence as PresenceModel) ||
+  mongoose.model<PresenceDocument, PresenceModel>('Presence', PresenceSchema);
+
+Presence.updateHeartbeat = updateHeartbeatImpl.bind(Presence);
 
 export default Presence;

--- a/quotevote-backend/app/data/models/Presence.ts
+++ b/quotevote-backend/app/data/models/Presence.ts
@@ -33,9 +33,9 @@ const PresenceSchema = new Schema<PresenceDocument, PresenceModel>(
 PresenceSchema.index({ status: 1 });
 PresenceSchema.index({ lastHeartbeat: 1 });
 
-PresenceSchema.statics.findByUserId = function (userId: string) {
+function findByUserIdImpl(this: PresenceModel, userId: string) {
   return this.findOne({ userId });
-};
+}
 
 /**
  * Refresh liveness only. Do not overwrite a user-chosen status/message.
@@ -79,13 +79,27 @@ async function updateHeartbeatImpl(
   return existing.save();
 }
 
+PresenceSchema.statics.findByUserId = findByUserIdImpl;
 PresenceSchema.statics.updateHeartbeat = updateHeartbeatImpl;
 
-// Always bind the latest statics — mongoose.models.Presence may already exist after hot reload.
-const Presence =
-  (mongoose.models.Presence as PresenceModel) ||
-  mongoose.model<PresenceDocument, PresenceModel>('Presence', PresenceSchema);
+/**
+ * Re-bind every schema static onto the live model.
+ *
+ * Under ts-node-dev / hot reload, `mongoose.models.Presence` often already exists
+ * from a previous module evaluation. In that case `mongoose.model(...)` is skipped
+ * and schema.statics assigned above never replace the stale methods on the cached
+ * model. Binding here (for *all* statics, not just one) keeps call sites on the
+ * latest implementation when new statics are added later.
+ */
+function bindPresenceStatics(model: PresenceModel): PresenceModel {
+  model.findByUserId = findByUserIdImpl.bind(model);
+  model.updateHeartbeat = updateHeartbeatImpl.bind(model);
+  return model;
+}
 
-Presence.updateHeartbeat = updateHeartbeatImpl.bind(Presence);
+const Presence = bindPresenceStatics(
+  (mongoose.models.Presence as PresenceModel) ||
+    mongoose.model<PresenceDocument, PresenceModel>('Presence', PresenceSchema)
+);
 
 export default Presence;

--- a/quotevote-backend/app/data/resolvers/heartbeatResolver.ts
+++ b/quotevote-backend/app/data/resolvers/heartbeatResolver.ts
@@ -1,14 +1,57 @@
 import { GraphQLError } from 'graphql';
 import Presence from '../models/Presence';
+import { pubsub } from '../utils/pubsub';
+import { SUBSCRIPTION_EVENTS } from '../../types/graphql';
 import type { GraphQLContext } from '~/types/graphql';
+import type * as Common from '~/types/common';
+
+const ALLOWED_STATUSES: ReadonlySet<Common.PresenceStatus> = new Set([
+  'online',
+  'away',
+  'dnd',
+  'offline',
+  'invisible',
+]);
+
+const STATUS_MESSAGE_MAX_LENGTH = 200;
+
+type UpdatePresenceArgs = {
+  presence: {
+    status: string;
+    statusMessage?: string | null;
+  };
+};
+
+function toPublicPresence(doc: {
+  _id: { toString(): string };
+  userId: { toString(): string };
+  status: Common.PresenceStatus;
+  statusMessage?: string | null;
+  lastHeartbeat?: Date | string | number;
+  lastSeen?: Date | string | number | null;
+}): Common.Presence {
+  return {
+    _id: doc._id.toString(),
+    userId: doc.userId.toString(),
+    status: doc.status,
+    statusMessage: doc.statusMessage ?? undefined,
+    lastHeartbeat: doc.lastHeartbeat,
+    lastSeen: doc.lastSeen ?? undefined,
+  };
+}
 
 export const heartbeatResolver = {
   Mutation: {
     heartbeat: async (
       _parent: unknown,
       _args: unknown,
-      context: GraphQLContext,
-    ): Promise<{ success: boolean; timestamp: string }> => {
+      context: GraphQLContext
+    ): Promise<{
+      success: boolean;
+      timestamp: string;
+      status: string;
+      statusMessage: string;
+    }> => {
       const { user } = context;
       if (!user) {
         throw new GraphQLError('Authentication required', {
@@ -21,7 +64,69 @@ export const heartbeatResolver = {
       return {
         success: true,
         timestamp: new Date(presence.lastHeartbeat).toISOString(),
+        status: presence.status,
+        statusMessage: presence.statusMessage ?? '',
       };
+    },
+
+    updatePresence: async (
+      _parent: unknown,
+      args: UpdatePresenceArgs,
+      context: GraphQLContext
+    ): Promise<Common.Presence> => {
+      if (!context.user?._id) {
+        throw new GraphQLError('Authentication required', {
+          extensions: { code: 'UNAUTHENTICATED' },
+        });
+      }
+
+      const status = args.presence?.status?.trim();
+      if (!status || !ALLOWED_STATUSES.has(status as Common.PresenceStatus)) {
+        throw new GraphQLError(
+          'status must be one of: online, away, dnd, offline, invisible',
+          { extensions: { code: 'BAD_USER_INPUT' } }
+        );
+      }
+
+      const rawMessage = args.presence.statusMessage ?? '';
+      const statusMessage =
+        typeof rawMessage === 'string' ? rawMessage.trim().slice(0, STATUS_MESSAGE_MAX_LENGTH) : '';
+
+      const userId = context.user._id.toString();
+      const now = new Date();
+
+      const preferredStatus = status === 'offline' ? 'online' : status;
+      const updated = await Presence.findOneAndUpdate(
+        { userId },
+        {
+          $set: {
+            status,
+            statusMessage,
+            preferredStatus,
+            preferredStatusMessage: statusMessage,
+            lastHeartbeat: now,
+            lastSeen: now,
+          },
+        },
+        { upsert: true, new: true, setDefaultsOnInsert: true }
+      );
+
+      if (!updated) {
+        throw new GraphQLError('Failed to update presence', {
+          extensions: { code: 'INTERNAL_SERVER_ERROR' },
+        });
+      }
+
+      await pubsub.publish(SUBSCRIPTION_EVENTS.PRESENCE_UPDATED, {
+        presence: {
+          userId,
+          status: updated.status,
+          statusMessage: updated.statusMessage ?? '',
+          lastSeen: updated.lastSeen,
+        },
+      });
+
+      return toPublicPresence(updated);
     },
   },
 };

--- a/quotevote-backend/app/data/types/Presence.ts
+++ b/quotevote-backend/app/data/types/Presence.ts
@@ -28,6 +28,8 @@ export const PresenceType: GraphQLObjectType<PresenceShape, GraphQLContext> = ne
     userId: { type: new GraphQLNonNull(GraphQLString) },
     status: { type: new GraphQLNonNull(PresenceStatusEnum) },
     statusMessage: { type: GraphQLString },
+    preferredStatus: { type: PresenceStatusEnum },
+    preferredStatusMessage: { type: GraphQLString },
     lastHeartbeat: { type: new GraphQLNonNull(DateScalar) },
     lastSeen: { type: DateScalar },
     user: {
@@ -59,6 +61,8 @@ export const PresenceUpdateType: GraphQLObjectType<PresenceUpdateShape, GraphQLC
 interface HeartbeatResponseShape {
   success: boolean;
   timestamp: Date | string | number;
+  status?: string;
+  statusMessage?: string;
 }
 
 export const HeartbeatResponseType: GraphQLObjectType<HeartbeatResponseShape, GraphQLContext> =
@@ -68,6 +72,8 @@ export const HeartbeatResponseType: GraphQLObjectType<HeartbeatResponseShape, Gr
     fields: (): GraphQLFieldConfigMap<HeartbeatResponseShape, GraphQLContext> => ({
       success: { type: new GraphQLNonNull(GraphQLBoolean) },
       timestamp: { type: new GraphQLNonNull(DateScalar) },
+      status: { type: PresenceStatusEnum },
+      statusMessage: { type: GraphQLString },
     }),
   });
 

--- a/quotevote-backend/app/data/utils/presence/cleanupStalePresence.ts
+++ b/quotevote-backend/app/data/utils/presence/cleanupStalePresence.ts
@@ -19,12 +19,18 @@ export const cleanupStalePresence = async (): Promise<void> => {
     });
 
     for (const presence of stalePresences) {
-      // Update to offline
+      // Mark offline for peers, but keep preferredStatus / preferredStatusMessage
+      // (and statusMessage) so a refresh can restore the user's chosen status.
+      if (!presence.preferredStatus) {
+        presence.preferredStatus = presence.status;
+      }
+      if (presence.preferredStatusMessage === undefined) {
+        presence.preferredStatusMessage = presence.statusMessage ?? '';
+      }
       presence.status = 'offline';
       presence.lastSeen = new Date();
       await presence.save();
 
-      // Publish offline event
       await pubsub.publish(SUBSCRIPTION_EVENTS.PRESENCE_UPDATED, {
         presence: {
           userId: presence.userId.toString(),

--- a/quotevote-backend/app/server.ts
+++ b/quotevote-backend/app/server.ts
@@ -13,6 +13,7 @@ import { groupResolver } from './data/resolvers/groupResolver';
 import { chatResolver } from './data/resolvers/chatResolver';
 import { rosterResolver } from './data/resolvers/rosterResolver';
 import { quoteResolver } from './data/resolvers/quoteResolver';
+import { heartbeatResolver } from './data/resolvers/heartbeatResolver';
 import { domainTypeDefs } from './data/types';
 import type { GraphQLContext, PubSub } from './types/graphql';
 import { requireAuth } from './data/utils/requireAuth';
@@ -130,6 +131,7 @@ async function startServer() {
           solidPushPortableState(input: PortableStateInput!): Boolean
           solidAppendActivityEvent(input: ActivityEventInput!): Boolean
           heartbeat: HeartbeatResponse
+          updatePresence(presence: PresenceInput!): Presence
           updateUser(user: UserInput!): User
           updateUserAvatar(user_id: String!, avatarQualities: JSON): User
       }
@@ -179,6 +181,7 @@ async function startServer() {
       chatResolver,
       rosterResolver,
       quoteResolver,
+      heartbeatResolver,
     ],
   });
 

--- a/quotevote-backend/app/types/common.ts
+++ b/quotevote-backend/app/types/common.ts
@@ -327,6 +327,9 @@ export interface Presence {
   userId: string;
   status: PresenceStatus;
   statusMessage?: string;
+  /** Chosen status that survives stale cleanup marking the user offline. */
+  preferredStatus?: PresenceStatus;
+  preferredStatusMessage?: string;
   lastHeartbeat?: Date | string | number;
   lastSeen?: Date | string | number;
 }

--- a/quotevote-frontend/src/graphql/mutations.ts
+++ b/quotevote-frontend/src/graphql/mutations.ts
@@ -8,6 +8,8 @@ export const HEARTBEAT = gql`
     heartbeat {
       success
       timestamp
+      status
+      statusMessage
     }
   }
 `

--- a/quotevote-frontend/src/graphql/queries.ts
+++ b/quotevote-frontend/src/graphql/queries.ts
@@ -544,6 +544,8 @@ export const GET_USER = gql`
       presence {
         status
         statusMessage
+        preferredStatus
+        preferredStatusMessage
       }
       reputation {
         _id

--- a/quotevote-frontend/src/hooks/usePresenceHeartbeat.ts
+++ b/quotevote-frontend/src/hooks/usePresenceHeartbeat.ts
@@ -4,83 +4,102 @@ import { useEffect, useRef } from 'react'
 import { useMutation } from '@apollo/client/react'
 import { HEARTBEAT } from '@/graphql/mutations'
 import { isAuthenticated } from '@/lib/utils/auth'
+import { useAppStore } from '@/store/useAppStore'
 import type { UsePresenceHeartbeatReturn } from '@/types/hooks'
+
+type HeartbeatResult = {
+  heartbeat?: {
+    success: boolean
+    timestamp?: string
+    status?: string | null
+    statusMessage?: string | null
+  } | null
+}
+
+const PRESENCE_STATUSES = new Set(['online', 'away', 'dnd', 'invisible'])
 
 /**
  * Custom hook to send periodic heartbeat to keep presence alive
  * @param interval - Heartbeat interval in milliseconds (default: 45000 = 45 seconds)
  */
 export const usePresenceHeartbeat = (interval: number = 45000): UsePresenceHeartbeatReturn => {
-    const [heartbeat, { error }] = useMutation(HEARTBEAT)
-    const retryCountRef = useRef<number>(0)
-    const maxRetries = 3
-    const backoffMultiplier = 2
+  const [heartbeat, { error }] = useMutation<HeartbeatResult>(HEARTBEAT)
+  const setUserStatus = useAppStore((state) => state.setUserStatus)
+  const retryCountRef = useRef<number>(0)
+  const maxRetries = 3
+  const backoffMultiplier = 2
 
-    useEffect(() => {
-        if (!isAuthenticated()) {
-            return
+  useEffect(() => {
+    if (!isAuthenticated()) {
+      return
+    }
+
+    const getRetryDelay = (attempt: number): number => {
+      return Math.min(interval * Math.pow(backoffMultiplier, attempt), 300000)
+    }
+
+    const applyPresenceFromHeartbeat = (payload: HeartbeatResult['heartbeat']): void => {
+      if (!payload?.status || !PRESENCE_STATUSES.has(payload.status)) return
+      const statusMessage = typeof payload.statusMessage === 'string' ? payload.statusMessage : ''
+      const chat = useAppStore.getState().chat
+      if (chat.userStatus === payload.status && chat.userStatusMessage === statusMessage) return
+      setUserStatus(payload.status, statusMessage)
+    }
+
+    const sendHeartbeat = async (): Promise<void> => {
+      try {
+        const result = await heartbeat()
+        retryCountRef.current = 0
+        applyPresenceFromHeartbeat(result.data?.heartbeat)
+      } catch {
+        if (retryCountRef.current < maxRetries) {
+          retryCountRef.current += 1
+          const delay = getRetryDelay(retryCountRef.current)
+          setTimeout(() => {
+            void sendHeartbeat()
+          }, delay)
+        } else {
+          setTimeout(() => {
+            retryCountRef.current = 0
+          }, interval * 5)
         }
+      }
+    }
 
-        const getRetryDelay = (attempt: number): number => {
-            return Math.min(interval * Math.pow(backoffMultiplier, attempt), 300000)
-        }
+    let timer: ReturnType<typeof setInterval> | null = null
 
-        const sendHeartbeat = async (): Promise<void> => {
-            try {
-                await heartbeat()
-                retryCountRef.current = 0
-            } catch {
-                if (retryCountRef.current < maxRetries) {
-                    retryCountRef.current += 1
-                    const delay = getRetryDelay(retryCountRef.current)
-                    setTimeout(() => {
-                        sendHeartbeat()
-                    }, delay)
-                } else {
-                    setTimeout(() => {
-                        retryCountRef.current = 0
-                    }, interval * 5)
-                }
-            }
-        }
+    const startHeartbeat = () => {
+      void sendHeartbeat()
+      timer = setInterval(() => {
+        void sendHeartbeat()
+      }, interval)
+    }
 
-        let timer: ReturnType<typeof setInterval> | null = null
+    const stopHeartbeat = () => {
+      if (timer) {
+        clearInterval(timer)
+        timer = null
+      }
+    }
 
-        const startHeartbeat = () => {
-            sendHeartbeat()
-            timer = setInterval(() => {
-                sendHeartbeat()
-            }, interval)
-        }
-
-        const stopHeartbeat = () => {
-            if (timer) {
-                clearInterval(timer)
-                timer = null
-            }
-        }
-
-        const handleVisibilityChange = () => {
-            if (document.hidden) {
-                stopHeartbeat()
-            } else {
-                startHeartbeat()
-            }
-        }
-
-        // Start heartbeat immediately
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        stopHeartbeat()
+      } else {
         startHeartbeat()
+      }
+    }
 
-        // Listen for visibility changes to pause/resume
-        document.addEventListener('visibilitychange', handleVisibilityChange)
+    startHeartbeat()
+    document.addEventListener('visibilitychange', handleVisibilityChange)
 
-        return () => {
-            stopHeartbeat()
-            document.removeEventListener('visibilitychange', handleVisibilityChange)
-        }
-    }, [heartbeat, interval])
+    return () => {
+      stopHeartbeat()
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [heartbeat, interval, setUserStatus])
 
-    return { error }
+  return { error }
 }
 
 export default usePresenceHeartbeat

--- a/quotevote-frontend/src/hooks/usePresenceHeartbeat.ts
+++ b/quotevote-frontend/src/hooks/usePresenceHeartbeat.ts
@@ -41,8 +41,11 @@ export const usePresenceHeartbeat = (interval: number = 45000): UsePresenceHeart
     const applyPresenceFromHeartbeat = (payload: HeartbeatResult['heartbeat']): void => {
       if (!payload?.status || !PRESENCE_STATUSES.has(payload.status)) return
       const statusMessage = typeof payload.statusMessage === 'string' ? payload.statusMessage : ''
+      // Store defaults to online/'' — coalesce so a partial rehydrate can't force a no-op miss.
       const chat = useAppStore.getState().chat
-      if (chat.userStatus === payload.status && chat.userStatusMessage === statusMessage) return
+      const currentStatus = chat.userStatus || 'online'
+      const currentMessage = chat.userStatusMessage || ''
+      if (currentStatus === payload.status && currentMessage === statusMessage) return
       setUserStatus(payload.status, statusMessage)
     }
 


### PR DESCRIPTION
## Stack
**Part 3 of 4 — merge after Part 2 (#435 / `avatar-consistency`).**

| Order | Branch | PR |
| --- | --- | --- |
| 1 | `profile-bio` | #434 |
| 2 | `avatar-consistency` | #435 |
| 3 | `presence-persist` | **this PR** (#436; base = Part 2) |
| 4 | `api-wiring` | #437 |

After Part 2 merges, retarget this PR’s base to `main` (or rebase onto `main`).

Related issue: #362

## Summary
- `preferredStatus` / `preferredStatusMessage` survive stale offline cleanup
- Heartbeat restores preferred status; does not clobber away/dnd/invisible
- `updatePresence` mutation wired; client rehydrates from GET_USER + heartbeat

## Test plan
- [ ] Set away + message → hard reload → status and message restore
- [ ] After ~2 minutes idle then return, preferred status comes back
- [ ] Buddies still see offline while you are stale