### PR TITLE
feat(api): notifications/activities wiring and guest auth (4/4)

### DIFF
--- a/quotevote-backend/__tests__/unit/resolvers/activityResolver.test.ts
+++ b/quotevote-backend/__tests__/unit/resolvers/activityResolver.test.ts
@@ -1,0 +1,136 @@
+import mongoose from 'mongoose';
+import { GraphQLError } from 'graphql';
+import { activityResolver } from '~/data/resolvers/activityResolver';
+import Activity from '~/data/models/Activity';
+import User from '~/data/models/User';
+import type { GraphQLContext } from '~/types/graphql';
+
+jest.mock('~/data/models/Activity');
+jest.mock('~/data/models/User');
+
+const actorId = '60d5ec49ad414d7a8d5464a0';
+const profileId = '60d5ec49ad414d7a8d5464a1';
+
+function mockContext(overrides: Partial<NonNullable<GraphQLContext['user']>> = {}): GraphQLContext {
+  return {
+    req: {} as GraphQLContext['req'],
+    res: {} as GraphQLContext['res'],
+    pubsub: {} as GraphQLContext['pubsub'],
+    user: {
+      _id: actorId,
+      username: 'alice',
+      email: 'alice@example.com',
+      admin: false,
+      ...overrides,
+    } as NonNullable<GraphQLContext['user']>,
+  };
+}
+
+describe('activityResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Query.activities', () => {
+    it('requires authentication', async () => {
+      await expect(
+        activityResolver.Query.activities(
+          null,
+          {
+            user_id: profileId,
+            limit: 10,
+            offset: 0,
+            searchKey: '',
+            activityEvent: ['VOTED'],
+          },
+          { ...mockContext(), user: null }
+        )
+      ).rejects.toThrow(GraphQLError);
+    });
+
+    it('returns paginated activities for a user', async () => {
+      const activityId = new mongoose.Types.ObjectId();
+      (Activity.countDocuments as jest.Mock).mockResolvedValue(1);
+      (Activity.find as jest.Mock).mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          skip: jest.fn().mockReturnValue({
+            limit: jest.fn().mockReturnValue({
+              lean: jest.fn().mockResolvedValue([
+                {
+                  _id: activityId,
+                  userId: new mongoose.Types.ObjectId(profileId),
+                  postId: new mongoose.Types.ObjectId(),
+                  activityType: 'VOTED',
+                  content: 'voted',
+                  created: new Date('2024-01-01T00:00:00Z'),
+                },
+              ]),
+            }),
+          }),
+        }),
+      });
+
+      const result = await activityResolver.Query.activities(
+        null,
+        {
+          user_id: profileId,
+          limit: 15,
+          offset: 0,
+          searchKey: '',
+          activityEvent: ['VOTED'],
+        },
+        mockContext()
+      );
+
+      expect(Activity.countDocuments).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: profileId,
+          activityType: { $in: ['VOTED'] },
+        })
+      );
+      expect(result.pagination).toEqual({ total_count: 1, limit: 15, offset: 0 });
+      expect(result.entities).toHaveLength(1);
+      expect(result.entities[0].activityType).toBe('VOTED');
+      expect(result.entities[0]._id).toBe(activityId.toString());
+    });
+
+    it('falls back to following feed when user_id is omitted', async () => {
+      const followingId = '60d5ec49ad414d7a8d5464a2';
+      (User.findById as jest.Mock).mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({
+            _followingId: [new mongoose.Types.ObjectId(followingId)],
+          }),
+        }),
+      });
+      (Activity.countDocuments as jest.Mock).mockResolvedValue(0);
+      (Activity.find as jest.Mock).mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          skip: jest.fn().mockReturnValue({
+            limit: jest.fn().mockReturnValue({
+              lean: jest.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+      });
+
+      await activityResolver.Query.activities(
+        null,
+        {
+          user_id: '',
+          limit: 10,
+          offset: 0,
+          searchKey: '',
+          activityEvent: [],
+        },
+        mockContext()
+      );
+
+      expect(Activity.countDocuments).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: { $in: [followingId] },
+        })
+      );
+    });
+  });
+});

--- a/quotevote-backend/__tests__/unit/resolvers/activityResolver.test.ts
+++ b/quotevote-backend/__tests__/unit/resolvers/activityResolver.test.ts
@@ -1,12 +1,19 @@
 import mongoose from 'mongoose';
 import { GraphQLError } from 'graphql';
-import { activityResolver } from '~/data/resolvers/activityResolver';
+import { activityResolver, normalizeActivityEvents } from '~/data/resolvers/activityResolver';
 import Activity from '~/data/models/Activity';
 import User from '~/data/models/User';
 import type { GraphQLContext } from '~/types/graphql';
 
 jest.mock('~/data/models/Activity');
 jest.mock('~/data/models/User');
+jest.mock('~/data/utils/logger', () => ({
+  logger: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}));
 
 const actorId = '60d5ec49ad414d7a8d5464a0';
 const profileId = '60d5ec49ad414d7a8d5464a1';
@@ -25,6 +32,20 @@ function mockContext(overrides: Partial<NonNullable<GraphQLContext['user']>> = {
     } as NonNullable<GraphQLContext['user']>,
   };
 }
+
+describe('normalizeActivityEvents', () => {
+  it('accepts ActivityEventType arrays', () => {
+    expect(normalizeActivityEvents(['VOTED', 'POSTED'])).toEqual(['VOTED', 'POSTED']);
+  });
+
+  it('parses legacy JSON array strings', () => {
+    expect(normalizeActivityEvents('["COMMENTED"]')).toEqual(['COMMENTED']);
+  });
+
+  it('drops unknown event strings', () => {
+    expect(normalizeActivityEvents(['VOTED', 'NOT_A_REAL_EVENT'] as string[])).toEqual(['VOTED']);
+  });
+});
 
 describe('activityResolver', () => {
   beforeEach(() => {
@@ -92,6 +113,41 @@ describe('activityResolver', () => {
       expect(result.entities).toHaveLength(1);
       expect(result.entities[0].activityType).toBe('VOTED');
       expect(result.entities[0]._id).toBe(activityId.toString());
+      expect(result.entities[0].userId).toBe(profileId);
+    });
+
+    it('rejects activities missing userId', async () => {
+      (Activity.countDocuments as jest.Mock).mockResolvedValue(1);
+      (Activity.find as jest.Mock).mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          skip: jest.fn().mockReturnValue({
+            limit: jest.fn().mockReturnValue({
+              lean: jest.fn().mockResolvedValue([
+                {
+                  _id: new mongoose.Types.ObjectId(),
+                  userId: null,
+                  activityType: 'VOTED',
+                  created: new Date(),
+                },
+              ]),
+            }),
+          }),
+        }),
+      });
+
+      await expect(
+        activityResolver.Query.activities(
+          null,
+          {
+            user_id: profileId,
+            limit: 10,
+            offset: 0,
+            searchKey: '',
+            activityEvent: ['VOTED'],
+          },
+          mockContext()
+        )
+      ).rejects.toThrow(/missing required userId/);
     });
 
     it('falls back to following feed when user_id is omitted', async () => {

--- a/quotevote-backend/__tests__/unit/resolvers/notificationResolver.test.ts
+++ b/quotevote-backend/__tests__/unit/resolvers/notificationResolver.test.ts
@@ -1,0 +1,54 @@
+import Notification from '~/data/models/Notification';
+import { notificationResolver } from '~/data/resolvers/notificationResolver';
+import type { GraphQLContext } from '~/types/graphql';
+
+jest.mock('~/data/models/Notification');
+
+const userId = '60d5ec49ad414d7a8d5464a0';
+
+function mockContext(user: GraphQLContext['user'] = null): GraphQLContext {
+  return {
+    req: {} as GraphQLContext['req'],
+    res: {} as GraphQLContext['res'],
+    pubsub: {} as GraphQLContext['pubsub'],
+    user,
+  };
+}
+
+describe('notificationResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Query.notifications', () => {
+    it('requires authentication', async () => {
+      await expect(
+        notificationResolver.Query.notifications(null, {}, mockContext(null))
+      ).rejects.toThrow(/Authentication required/);
+    });
+
+    it('returns an empty list when the user has no notifications', async () => {
+      (Notification.find as jest.Mock).mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await notificationResolver.Query.notifications(
+        null,
+        {},
+        mockContext({
+          _id: userId,
+          username: 'alice',
+          email: 'alice@example.com',
+        } as NonNullable<GraphQLContext['user']>)
+      );
+
+      expect(Notification.find).toHaveBeenCalledWith({
+        userId,
+        status: 'new',
+      });
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/quotevote-backend/__tests__/unit/resolvers/notificationResolver.test.ts
+++ b/quotevote-backend/__tests__/unit/resolvers/notificationResolver.test.ts
@@ -28,11 +28,10 @@ describe('notificationResolver', () => {
     });
 
     it('returns an empty list when the user has no notifications', async () => {
-      (Notification.find as jest.Mock).mockReturnValue({
-        sort: jest.fn().mockReturnValue({
-          lean: jest.fn().mockResolvedValue([]),
-        }),
-      });
+      const lean = jest.fn().mockResolvedValue([]);
+      const limit = jest.fn().mockReturnValue({ lean });
+      const sort = jest.fn().mockReturnValue({ limit });
+      (Notification.find as jest.Mock).mockReturnValue({ sort });
 
       const result = await notificationResolver.Query.notifications(
         null,
@@ -48,7 +47,27 @@ describe('notificationResolver', () => {
         userId,
         status: 'new',
       });
+      expect(limit).toHaveBeenCalledWith(50);
       expect(result).toEqual([]);
+    });
+
+    it('clamps limit to a maximum of 100', async () => {
+      const lean = jest.fn().mockResolvedValue([]);
+      const limit = jest.fn().mockReturnValue({ lean });
+      const sort = jest.fn().mockReturnValue({ limit });
+      (Notification.find as jest.Mock).mockReturnValue({ sort });
+
+      await notificationResolver.Query.notifications(
+        null,
+        { limit: 500 },
+        mockContext({
+          _id: userId,
+          username: 'alice',
+          email: 'alice@example.com',
+        } as NonNullable<GraphQLContext['user']>)
+      );
+
+      expect(limit).toHaveBeenCalledWith(100);
     });
   });
 });

--- a/quotevote-backend/app/data/models/Activity.ts
+++ b/quotevote-backend/app/data/models/Activity.ts
@@ -16,6 +16,9 @@ const ActivitySchema = new Schema<ActivityDocument, ActivityModel>(
   { timestamps: true }
 );
 
+// Supports activities feed: filter by user, sort newest-first with skip/limit.
+ActivitySchema.index({ userId: 1, created: -1 });
+
 const Activity =
   (mongoose.models.Activity as ActivityModel) ||
   mongoose.model<ActivityDocument, ActivityModel>('Activity', ActivitySchema);

--- a/quotevote-backend/app/data/resolvers/activityResolver.ts
+++ b/quotevote-backend/app/data/resolvers/activityResolver.ts
@@ -1,0 +1,121 @@
+import { GraphQLError } from 'graphql';
+import Activity from '../models/Activity';
+import User from '../models/User';
+import type * as Common from '~/types/common';
+import type { ActivityQueryArgs, GraphQLContext } from '~/types/graphql';
+
+type ActivityFilter = Record<string, unknown>;
+
+function normalizeActivityEvents(
+  activityEvent: ActivityQueryArgs['activityEvent'] | string | null | undefined
+): Common.ActivityEventType[] {
+  if (activityEvent == null) return [];
+
+  let parsed: unknown = activityEvent;
+  if (typeof activityEvent === 'string') {
+    try {
+      parsed = JSON.parse(activityEvent);
+    } catch {
+      return [];
+    }
+  }
+
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter((v): v is Common.ActivityEventType => typeof v === 'string');
+}
+
+function toActivityEntity(doc: {
+  _id: { toString(): string };
+  userId?: { toString(): string } | string | null;
+  postId?: { toString(): string } | string | null;
+  voteId?: { toString(): string } | string | null;
+  commentId?: { toString(): string } | string | null;
+  quoteId?: { toString(): string } | string | null;
+  activityType: string;
+  content?: string | null;
+  created?: Date | string | null;
+}): Common.Activity {
+  const toId = (value: { toString(): string } | string | null | undefined): string | undefined => {
+    if (value == null) return undefined;
+    return typeof value === 'string' ? value : value.toString();
+  };
+
+  return {
+    _id: doc._id.toString(),
+    userId: toId(doc.userId) ?? '',
+    postId: toId(doc.postId),
+    voteId: toId(doc.voteId),
+    commentId: toId(doc.commentId),
+    quoteId: toId(doc.quoteId),
+    activityType: doc.activityType as Common.ActivityEventType,
+    content: doc.content ?? undefined,
+    created: doc.created ?? new Date(),
+  };
+}
+
+export const activityResolver = {
+  Query: {
+    /**
+     * Paginated activity feed for a user (or the caller's following list).
+     * Matches legacy getUserActivities return shape: { entities, pagination }.
+     */
+    activities: async (
+      _parent: unknown,
+      args: ActivityQueryArgs,
+      context: GraphQLContext
+    ): Promise<Common.PaginatedResult<Common.Activity>> => {
+      if (!context.user?._id) {
+        throw new GraphQLError('Authentication required', {
+          extensions: { code: 'UNAUTHENTICATED' },
+        });
+      }
+
+      const limit = typeof args.limit === 'number' && args.limit > 0 ? args.limit : 10;
+      const offset = typeof args.offset === 'number' && args.offset >= 0 ? args.offset : 0;
+
+      const searchArgs: ActivityFilter = {};
+
+      const searchKey = args.searchKey?.trim();
+      if (searchKey) {
+        searchArgs.$text = {
+          $search: searchKey,
+          $caseSensitive: false,
+        };
+      }
+
+      const events = normalizeActivityEvents(args.activityEvent);
+      if (events.length > 0) {
+        searchArgs.activityType = { $in: events };
+      }
+
+      if (args.user_id) {
+        searchArgs.userId = args.user_id;
+      } else {
+        const viewer = await User.findById(context.user._id).select('_followingId').lean();
+        const followingIds = (viewer?._followingId ?? []).map((id) => id.toString());
+        searchArgs.userId = { $in: followingIds };
+      }
+
+      if (args.startDateRange && args.endDateRange) {
+        searchArgs.created = {
+          $gte: new Date(args.startDateRange),
+          $lte: new Date(args.endDateRange),
+        };
+      }
+
+      const [total, activitiesResult] = await Promise.all([
+        Activity.countDocuments(searchArgs),
+        Activity.find(searchArgs).sort({ created: -1 }).skip(offset).limit(limit).lean(),
+      ]);
+
+      return {
+        entities: activitiesResult.map((doc) => toActivityEntity(doc)),
+        pagination: {
+          total_count: total,
+          limit,
+          offset,
+        },
+      };
+    },
+  },
+};

--- a/quotevote-backend/app/data/resolvers/activityResolver.ts
+++ b/quotevote-backend/app/data/resolvers/activityResolver.ts
@@ -1,13 +1,21 @@
 import { GraphQLError } from 'graphql';
 import Activity from '../models/Activity';
 import User from '../models/User';
+import { logger } from '../utils/logger';
+import { ActivityEventTypeValues } from '../utils/constants';
 import type * as Common from '~/types/common';
 import type { ActivityQueryArgs, GraphQLContext } from '~/types/graphql';
 
 type ActivityFilter = Record<string, unknown>;
 
-function normalizeActivityEvents(
-  activityEvent: ActivityQueryArgs['activityEvent'] | string | null | undefined
+const ALLOWED_ACTIVITY_EVENTS = new Set<string>(Object.values(ActivityEventTypeValues));
+
+/**
+ * Normalize activityEvent filter from GraphQL.
+ * Prefer `[ActivityEventType!]`; still accepts a legacy JSON-encoded array string.
+ */
+export function normalizeActivityEvents(
+  activityEvent: ActivityQueryArgs['activityEvent'] | string | string[] | null | undefined
 ): Common.ActivityEventType[] {
   if (activityEvent == null) return [];
 
@@ -15,13 +23,26 @@ function normalizeActivityEvents(
   if (typeof activityEvent === 'string') {
     try {
       parsed = JSON.parse(activityEvent);
-    } catch {
+    } catch (err) {
+      logger.warn('activities.activityEvent JSON parse failed; ignoring filter', {
+        raw: activityEvent.slice(0, 200),
+        error: err instanceof Error ? err.message : String(err),
+      });
       return [];
     }
   }
 
-  if (!Array.isArray(parsed)) return [];
-  return parsed.filter((v): v is Common.ActivityEventType => typeof v === 'string');
+  if (!Array.isArray(parsed)) {
+    logger.warn('activities.activityEvent is not an array; ignoring filter', {
+      receivedType: typeof parsed,
+    });
+    return [];
+  }
+
+  return parsed.filter(
+    (v): v is Common.ActivityEventType =>
+      typeof v === 'string' && ALLOWED_ACTIVITY_EVENTS.has(v)
+  );
 }
 
 function toActivityEntity(doc: {
@@ -40,9 +61,19 @@ function toActivityEntity(doc: {
     return typeof value === 'string' ? value : value.toString();
   };
 
+  const userId = toId(doc.userId);
+  if (!userId) {
+    throw new GraphQLError('Activity document is missing required userId', {
+      extensions: {
+        code: 'INTERNAL_SERVER_ERROR',
+        activityId: doc._id.toString(),
+      },
+    });
+  }
+
   return {
     _id: doc._id.toString(),
-    userId: toId(doc.userId) ?? '',
+    userId,
     postId: toId(doc.postId),
     voteId: toId(doc.voteId),
     commentId: toId(doc.commentId),

--- a/quotevote-backend/app/data/resolvers/notificationResolver.ts
+++ b/quotevote-backend/app/data/resolvers/notificationResolver.ts
@@ -1,0 +1,40 @@
+import { GraphQLError } from 'graphql';
+import Notification from '../models/Notification';
+import type * as Common from '~/types/common';
+import type { GraphQLContext } from '~/types/graphql';
+
+export const notificationResolver = {
+  Query: {
+    /**
+     * Returns unread notifications for the authenticated user.
+     * Matches legacy getNotifications behavior (status: 'new', newest first).
+     */
+    notifications: async (
+      _parent: unknown,
+      _args: unknown,
+      context: GraphQLContext
+    ): Promise<Common.Notification[]> => {
+      if (!context.user?._id) {
+        throw new GraphQLError('Authentication required', {
+          extensions: { code: 'UNAUTHENTICATED' },
+        });
+      }
+
+      const userId = context.user._id.toString();
+      const notifications = await Notification.find({
+        userId,
+        status: 'new',
+      })
+        .sort({ created: -1 })
+        .lean();
+
+      return notifications.map((n) => ({
+        ...n,
+        _id: n._id.toString(),
+        userId: n.userId?.toString?.() ?? String(n.userId),
+        userIdBy: n.userIdBy?.toString?.() ?? String(n.userIdBy),
+        postId: n.postId ? n.postId.toString() : undefined,
+      })) as unknown as Common.Notification[];
+    },
+  },
+};

--- a/quotevote-backend/app/data/resolvers/notificationResolver.ts
+++ b/quotevote-backend/app/data/resolvers/notificationResolver.ts
@@ -3,15 +3,19 @@ import Notification from '../models/Notification';
 import type * as Common from '~/types/common';
 import type { GraphQLContext } from '~/types/graphql';
 
+const DEFAULT_NOTIFICATION_LIMIT = 50;
+const MAX_NOTIFICATION_LIMIT = 100;
+
 export const notificationResolver = {
   Query: {
     /**
      * Returns unread notifications for the authenticated user.
-     * Matches legacy getNotifications behavior (status: 'new', newest first).
+     * Matches legacy getNotifications behavior (status: 'new', newest first),
+     * with an optional limit to avoid unbounded reads.
      */
     notifications: async (
       _parent: unknown,
-      _args: unknown,
+      args: { limit?: number | null },
       context: GraphQLContext
     ): Promise<Common.Notification[]> => {
       if (!context.user?._id) {
@@ -20,12 +24,17 @@ export const notificationResolver = {
         });
       }
 
+      const requested =
+        typeof args.limit === 'number' && Number.isFinite(args.limit) ? Math.floor(args.limit) : DEFAULT_NOTIFICATION_LIMIT;
+      const limit = Math.min(Math.max(requested, 1), MAX_NOTIFICATION_LIMIT);
+
       const userId = context.user._id.toString();
       const notifications = await Notification.find({
         userId,
         status: 'new',
       })
         .sort({ created: -1 })
+        .limit(limit)
         .lean();
 
       return notifications.map((n) => ({

--- a/quotevote-backend/app/server.ts
+++ b/quotevote-backend/app/server.ts
@@ -13,6 +13,8 @@ import { groupResolver } from './data/resolvers/groupResolver';
 import { chatResolver } from './data/resolvers/chatResolver';
 import { rosterResolver } from './data/resolvers/rosterResolver';
 import { quoteResolver } from './data/resolvers/quoteResolver';
+import { notificationResolver } from './data/resolvers/notificationResolver';
+import { activityResolver } from './data/resolvers/activityResolver';
 import { heartbeatResolver } from './data/resolvers/heartbeatResolver';
 import { domainTypeDefs } from './data/types';
 import type { GraphQLContext, PubSub } from './types/graphql';
@@ -121,6 +123,20 @@ async function startServer() {
         
         # Token verification
         verifyUserPasswordResetToken(token: String!): Boolean
+
+        # Notifications (auth required)
+        notifications: [Notification!]!
+
+        # Activity feed (auth required)
+        activities(
+          offset: Int
+          limit: Int
+          searchKey: String
+          startDateRange: String
+          endDateRange: String
+          user_id: String
+          activityEvent: JSON
+        ): Activities
       }
 
       type Mutation {
@@ -181,6 +197,8 @@ async function startServer() {
       chatResolver,
       rosterResolver,
       quoteResolver,
+      notificationResolver,
+      activityResolver,
       heartbeatResolver,
     ],
   });

--- a/quotevote-backend/app/server.ts
+++ b/quotevote-backend/app/server.ts
@@ -124,8 +124,8 @@ async function startServer() {
         # Token verification
         verifyUserPasswordResetToken(token: String!): Boolean
 
-        # Notifications (auth required)
-        notifications: [Notification!]!
+        # Notifications (auth required); limit defaults to 50 (max 100) in the resolver
+        notifications(limit: Int): [Notification!]!
 
         # Activity feed (auth required)
         activities(
@@ -135,7 +135,7 @@ async function startServer() {
           startDateRange: String
           endDateRange: String
           user_id: String
-          activityEvent: JSON
+          activityEvent: [ActivityEventType!]
         ): Activities
       }
 

--- a/quotevote-backend/app/types/graphql.ts
+++ b/quotevote-backend/app/types/graphql.ts
@@ -131,7 +131,7 @@ export interface QueryResolvers {
   activities: ResolverFn<Common.PaginatedResult<Common.Activity>, unknown, ActivityQueryArgs>;
 
   // Notification queries
-  notifications: ResolverFn<Common.Notification[]>;
+  notifications: ResolverFn<Common.Notification[], unknown, { limit?: number | null }>;
 
   // Message queries
   messages: ResolverFn<Common.Message[], unknown, { messageRoomId: string }>;
@@ -399,7 +399,7 @@ export interface ActivityQueryArgs {
   searchKey?: string;
   startDateRange?: string;
   endDateRange?: string;
-  activityEvent: Common.ActivityEventType[];
+  activityEvent?: Common.ActivityEventType[] | null;
 }
 
 // ============================================================================

--- a/quotevote-frontend/src/__tests__/utils/auth.test.ts
+++ b/quotevote-frontend/src/__tests__/utils/auth.test.ts
@@ -1,19 +1,34 @@
-import { isAuthenticated, requireAuth } from '@/lib/utils/auth'
+import { isAuthenticated, hasActiveSession, requireAuth } from '@/lib/utils/auth'
+import { useAppStore } from '@/store/useAppStore'
 
 beforeEach(() => {
-    localStorage.clear()
+  localStorage.clear()
+  useAppStore.getState().logout()
 })
 
 describe('auth utils', () => {
-    it('isAuthenticated returns false when no token', () => {
-        expect(isAuthenticated()).toBe(false)
-    })
+  it('isAuthenticated returns false when no token', () => {
+    expect(isAuthenticated()).toBe(false)
+  })
 
-    it('requireAuth prevents action execution when not authenticated', () => {
-        const action = jest.fn((s: string) => s)
-        const guarded = requireAuth(action)
-        guarded('x')
-        expect(action).not.toHaveBeenCalled()
-        // Redirect side-effect is environment-specific; ensure no action execution
-    })
+  it('hasActiveSession is true when store has a user even without a token', () => {
+    useAppStore.getState().setUserData({ _id: 'user-1', username: 'alice' })
+    expect(isAuthenticated()).toBe(false)
+    expect(hasActiveSession()).toBe(true)
+  })
+
+  it('requireAuth prevents action execution when not authenticated', () => {
+    const action = jest.fn((s: string) => s)
+    const guarded = requireAuth(action)
+    guarded('x')
+    expect(action).not.toHaveBeenCalled()
+  })
+
+  it('requireAuth allows action when store session exists', () => {
+    useAppStore.getState().setUserData({ _id: 'user-1', username: 'alice' })
+    const action = jest.fn((s: string) => s)
+    const guarded = requireAuth(action)
+    guarded('x')
+    expect(action).toHaveBeenCalledWith('x')
+  })
 })

--- a/quotevote-frontend/src/__tests__/utils/getServerUrl.test.ts
+++ b/quotevote-frontend/src/__tests__/utils/getServerUrl.test.ts
@@ -1,4 +1,4 @@
-import { getBaseServerUrl, getGraphqlServerUrl, getGraphqlWsServerUrl } from '@/lib/utils/getServerUrl'
+import { getBaseServerUrl, getGraphqlServerUrl, getGraphqlWsServerUrl, areGraphqlSubscriptionsEnabled } from '@/lib/utils/getServerUrl'
 
 describe('getServerUrl', () => {
     const OLD_ENV = process.env
@@ -42,5 +42,15 @@ describe('getServerUrl', () => {
     it('builds websocket urls for localhost', () => {
         process.env.NEXT_PUBLIC_SERVER_URL = 'http://localhost:4000'
         expect(getGraphqlWsServerUrl()).toBe('ws://localhost:4000/graphql')
+    })
+
+    it('disables subscriptions on localhost', () => {
+        process.env.NEXT_PUBLIC_SERVER_URL = 'http://localhost:4000'
+        expect(areGraphqlSubscriptionsEnabled()).toBe(false)
+    })
+
+    it('enables subscriptions on hosted APIs', () => {
+        process.env.NEXT_PUBLIC_SERVER_URL = 'https://api.quote.vote'
+        expect(areGraphqlSubscriptionsEnabled()).toBe(true)
     })
 })

--- a/quotevote-frontend/src/graphql/queries.ts
+++ b/quotevote-frontend/src/graphql/queries.ts
@@ -710,7 +710,7 @@ export const GET_USER_ACTIVITY = gql`
     $searchKey: String!
     $startDateRange: String
     $endDateRange: String
-    $activityEvent: JSON!
+    $activityEvent: [ActivityEventType!]
   ) {
     activities(
       user_id: $user_id
@@ -807,8 +807,8 @@ export const GET_USER_ACTIVITY = gql`
  * Get notifications query
  */
 export const GET_NOTIFICATIONS = gql`
-  query notifications {
-    notifications {
+  query notifications($limit: Int) {
+    notifications(limit: $limit) {
       _id
       userId
       userIdBy

--- a/quotevote-frontend/src/hooks/useGuestGuard.ts
+++ b/quotevote-frontend/src/hooks/useGuestGuard.ts
@@ -1,19 +1,26 @@
 import { useCallback } from 'react'
-import { isAuthenticated } from '@/lib/utils/auth'
+import { hasActiveSession } from '@/lib/utils/auth'
 import { useAuthModal } from '@/context/AuthModalContext'
+import { useAppStore } from '@/store/useAppStore'
 
 /**
  * Guard guest interactions by showing the auth modal instead of redirecting.
  * Returns a function that resolves to false when not authenticated.
+ *
+ * Uses the Zustand session (same signal as the dashboard chrome) in addition to
+ * the JWT check, so a persisted logged-in user is not treated as a guest when
+ * the access token is briefly missing/expired.
  */
 export default function useGuestGuard() {
-    const { openAuthModal } = useAuthModal()
+  const { openAuthModal } = useAuthModal()
+  // Re-subscribe so the guard updates when login/logout changes store state.
+  useAppStore((state) => state.user.data._id || state.user.data.id)
 
-    return useCallback(() => {
-        if (!isAuthenticated()) {
-            openAuthModal({ view: 'login' })
-            return false
-        }
-        return true
-    }, [openAuthModal])
+  return useCallback(() => {
+    if (hasActiveSession()) {
+      return true
+    }
+    openAuthModal({ view: 'login' })
+    return false
+  }, [openAuthModal])
 }

--- a/quotevote-frontend/src/lib/apollo/apollo-client.ts
+++ b/quotevote-frontend/src/lib/apollo/apollo-client.ts
@@ -5,13 +5,14 @@ import { ErrorLink } from '@apollo/client/link/error';
 import { getMainDefinition } from '@apollo/client/utilities';
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
 import { createClient } from 'graphql-ws';
-import { map } from 'rxjs';
+import { map, Observable } from 'rxjs';
 import { toast } from 'sonner';
 import { env } from '@/config/env';
-import { getGraphqlWsServerUrl } from '@/lib/utils/getServerUrl';
+import { getGraphqlWsServerUrl, areGraphqlSubscriptionsEnabled } from '@/lib/utils/getServerUrl';
 import { serializeObjectIds } from '@/lib/utils/objectIdSerializer';
 import { getToken, removeToken } from '@/lib/auth';
 import { triggerAuthGate } from '@/lib/auth-gate';
+import { useAppStore } from '@/store/useAppStore';
 
 /**
  * Get the GraphQL endpoint URL from validated environment configuration
@@ -77,6 +78,11 @@ function createAuthLink() {
 function createWsLink(): GraphQLWsLink | null {
   // WebSocket links only work in the browser
   if (typeof window === 'undefined') {
+    return null;
+  }
+
+  // Local backend has no subscription transport — avoid noisy reconnect loops.
+  if (!areGraphqlSubscriptionsEnabled()) {
     return null;
   }
 
@@ -192,7 +198,19 @@ function createErrorLink() {
         if (code === 'UNAUTHENTICATED') {
           if (typeof window !== 'undefined') {
             removeToken();
-            triggerAuthGate({ view: 'login' });
+            // Keep UI auth state in sync with the cleared token.
+            useAppStore.getState().logout();
+
+            // Background queries (notifications, rooms, activities) must not
+            // pop the invite/login modal while the user still looks signed in.
+            // Interactive mutations still open the login gate.
+            const definition = getMainDefinition(operation.query);
+            const isMutation =
+              definition.kind === 'OperationDefinition' &&
+              definition.operation === 'mutation';
+            if (isMutation) {
+              triggerAuthGate({ view: 'login' });
+            }
           }
           return;
         }
@@ -259,6 +277,17 @@ function createObjectIdSerializationLink() {
 }
 
 /**
+ * Local backends have no graphql-ws transport. Completing immediately keeps
+ * useSubscription callers quiet instead of sending subscriptions over HTTP
+ * (which produces INTERNAL_SERVER_ERROR / validation noise).
+ */
+function createNoopSubscriptionLink(): ApolloLink {
+  return new ApolloLink(() => new Observable((subscriber) => {
+    subscriber.complete();
+  }));
+}
+
+/**
  * Create and configure Apollo Client instance
  * This is SSR-aware and safe to use in both server and client components
  * 
@@ -281,23 +310,25 @@ function createApolloClient(): ApolloClientType {
     httpLink,
   ]);
 
-  // Split link: subscriptions go to WebSocket, queries/mutations go to HTTP
-  // On server, only use HTTP link (no WebSocket support)
-  // Note: Type assertion needed due to pnpm dependency resolution creating
-  // separate instances of ApolloLink types from different packages
-  const link = typeof window !== 'undefined' && wsLink
-    ? (split(
-        ({ query }) => {
-          const definition = getMainDefinition(query);
-          return (
-            definition.kind === 'OperationDefinition' &&
-            definition.operation === 'subscription'
-          );
-        },
-        wsLink as unknown as ApolloLink,
-        httpLinkChain
-      ) as ApolloLink)
-    : httpLinkChain;
+  // Split link: subscriptions go to WebSocket (or a no-op on localhost),
+  // queries/mutations go to HTTP. On the server, only use HTTP.
+  const subscriptionLink =
+    (wsLink as unknown as ApolloLink | null) ?? createNoopSubscriptionLink();
+
+  const link =
+    typeof window !== 'undefined'
+      ? (split(
+          ({ query }) => {
+            const definition = getMainDefinition(query);
+            return (
+              definition.kind === 'OperationDefinition' &&
+              definition.operation === 'subscription'
+            );
+          },
+          subscriptionLink,
+          httpLinkChain
+        ) as ApolloLink)
+      : httpLinkChain;
 
   return new ApolloClient({
     link,

--- a/quotevote-frontend/src/lib/utils/auth.ts
+++ b/quotevote-frontend/src/lib/utils/auth.ts
@@ -1,6 +1,7 @@
 import { jwtDecode } from 'jwt-decode'
 import { DecodedToken } from '@/types/store'
 import { triggerAuthGate } from '@/lib/auth-gate'
+import { useAppStore } from '@/store/useAppStore'
 
 export function isAuthenticated(): boolean {
   const token = localStorage.getItem('token')
@@ -17,9 +18,17 @@ export function isAuthenticated(): boolean {
   }
 }
 
+/** True when JWT is valid or the persisted session user is present (dashboard chrome). */
+export function hasActiveSession(): boolean {
+  if (typeof window === 'undefined') return false
+  const data = useAppStore.getState().user.data
+  if (data._id || data.id) return true
+  return isAuthenticated()
+}
+
 export function requireAuth<Args extends unknown[], R>(action: (...args: Args) => R) {
   return (...args: Args): R | void => {
-    if (!isAuthenticated()) {
+    if (!hasActiveSession()) {
       triggerAuthGate({ view: 'login' })
       return
     }

--- a/quotevote-frontend/src/lib/utils/getServerUrl.ts
+++ b/quotevote-frontend/src/lib/utils/getServerUrl.ts
@@ -49,3 +49,13 @@ export const getGraphqlWsServerUrl = (): string => {
   const replacedUrl = baseUrl.replace('https://', 'wss://').replace('http://', 'ws://')
   return `${replacedUrl}/graphql`
 }
+
+/**
+ * Local quotevote-backend is HTTP-only (no graphql-ws). Skip the Apollo WS
+ * link on localhost/127.0.0.1 so the console is not flooded with connection errors.
+ * Hosted APIs still use subscriptions over WSS.
+ */
+export const areGraphqlSubscriptionsEnabled = (): boolean => {
+  const baseUrl = getBaseServerUrl()
+  return !baseUrl.includes('localhost') && !baseUrl.includes('127.0.0.1')
+}


### PR DESCRIPTION
## Stack
**Part 4 of 4 — merge last, after Part 3 (#436 / `presence-persist`).**

| Order | Branch | PR |
| --- | --- | --- |
| 1 | `profile-bio` | #434 |
| 2 | `avatar-consistency` | #435 |
| 3 | `presence-persist` | #436 |
| 4 | `api-wiring` | **this PR** (#437; base = Part 3) |

After Part 3 merges, retarget this PR’s base to `main` (or rebase onto `main`).

Related issue: #362

## Summary
- Register `notificationResolver` and `activityResolver` in the GraphQL server
- Guest / Apollo UNAUTHENTICATED handling and related auth URL helpers

## Test plan
- [ ] Notifications query works when authenticated
- [ ] Activities query works when authenticated
- [ ] Guest session does not hard-crash on protected GraphQL ops