### PR TITLE
Fix stale Support button state after vote mutation

### DIFF
--- a/quotevote-frontend/src/__tests__/components/Post/PostCard.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Post/PostCard.test.tsx
@@ -4,10 +4,11 @@
  * Basic tests for the PostCard component
  */
 
-import { render } from '../../utils/test-utils'
+import { fireEvent, render, screen, waitFor } from '../../utils/test-utils'
 // @ts-expect-error - MockedProvider may not have types in this version
 import { MockedProvider } from '@apollo/client/testing'
 import PostCard from '../../../components/Post/PostCard'
+import { APPROVE_POST } from '@/graphql/mutations'
 import type { PostCardProps } from '@/types/post'
 
 // Mock useRouter
@@ -21,9 +22,11 @@ jest.mock('next/navigation', () => ({
 // Mock Zustand store
 const mockSetSelectedPost = jest.fn()
 jest.mock('@/store', () => ({
-  useAppStore: () => ({
-    setSelectedPost: mockSetSelectedPost,
-  }),
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      setSelectedPost: mockSetSelectedPost,
+      user: { data: { _id: 'current-user' } },
+    }),
 }))
 
 // Mock useGuestGuard
@@ -70,6 +73,43 @@ describe('PostCard Component', () => {
       data: undefined,
       loading: false,
       error: undefined,
+    })
+  })
+
+  it('reconciles the selected Support state from the completed mutation response', async () => {
+    const approvePostMock = {
+      request: {
+        query: APPROVE_POST,
+        variables: {
+          postId: 'post1',
+          userId: 'current-user',
+          remove: true,
+        },
+      },
+      result: {
+        data: {
+          approvePost: {
+            _id: 'post1',
+            // Intentionally differs from the optimistic removal to prove the response wins.
+            approvedBy: ['current-user'],
+            rejectedBy: [],
+          },
+        },
+      },
+    }
+
+    render(
+      <PostCard
+        {...mockPostCardProps}
+        approvedBy={['current-user']}
+      />,
+      { mocks: [approvePostMock] }
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove support' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Remove support' })).toBeInTheDocument()
     })
   })
 

--- a/quotevote-frontend/src/__tests__/components/Post/PostCard.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Post/PostCard.test.tsx
@@ -83,15 +83,15 @@ describe('PostCard Component', () => {
         variables: {
           postId: 'post1',
           userId: 'current-user',
-          remove: true,
+          remove: false,
         },
       },
       result: {
         data: {
           approvePost: {
             _id: 'post1',
-            // Intentionally differs from the optimistic removal to prove the response wins.
-            approvedBy: ['current-user'],
+            // Intentionally differs from the optimistic addition to prove the response wins.
+            approvedBy: [],
             rejectedBy: [],
           },
         },
@@ -99,17 +99,16 @@ describe('PostCard Component', () => {
     }
 
     render(
-      <PostCard
-        {...mockPostCardProps}
-        approvedBy={['current-user']}
-      />,
+      <PostCard {...mockPostCardProps} />,
       { mocks: [approvePostMock] }
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Remove support' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Support this post' }))
+
+    expect(screen.getByRole('button', { name: 'Remove support' })).toBeInTheDocument()
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Remove support' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Support this post' })).toBeInTheDocument()
     })
   })
 

--- a/quotevote-frontend/src/components/Post/PostCard.tsx
+++ b/quotevote-frontend/src/components/Post/PostCard.tsx
@@ -39,6 +39,20 @@ const CARD_THEMES = {
   },
 } as const
 
+type VoteStateMutationPost = {
+  _id: string
+  approvedBy?: string[]
+  rejectedBy?: string[]
+}
+
+type ApprovePostMutationData = {
+  approvePost?: VoteStateMutationPost
+}
+
+type RejectPostMutationData = {
+  rejectPost?: VoteStateMutationPost
+}
+
 function stringLimit(text: string, limit: number): string {
   if (!text || text.length <= limit) return text
   return text.slice(0, limit) + '...'
@@ -73,8 +87,10 @@ function PostCardComponent({
   ) as string | undefined
 
   const [updateBookmark] = useMutation(UPDATE_POST_BOOKMARK)
-  const [approvePost, { loading: approvingPost }] = useMutation(APPROVE_POST)
-  const [rejectPost, { loading: rejectingPost }] = useMutation(REJECT_POST)
+  const [approvePost, { loading: approvingPost }] =
+    useMutation<ApprovePostMutationData>(APPROVE_POST)
+  const [rejectPost, { loading: rejectingPost }] =
+    useMutation<RejectPostMutationData>(REJECT_POST)
 
   // Local optimistic state — updates immediately on vote so color reflects right away
   const [localApprovedBy, setLocalApprovedBy] = useState<string[]>(() => approvedBy || [])
@@ -132,9 +148,7 @@ function PostCardComponent({
       const { data } = await approvePost({
         variables: { postId: _id, userId, remove: hasApproved },
       })
-      const updatedPost = (data as {
-        approvePost?: { approvedBy?: string[]; rejectedBy?: string[] }
-      } | undefined)?.approvePost
+      const updatedPost = data?.approvePost
       if (updatedPost) {
         // The optimistic update is only immediate feedback; the completed mutation is authoritative.
         setLocalApprovedBy(updatedPost.approvedBy || [])
@@ -162,9 +176,7 @@ function PostCardComponent({
       const { data } = await rejectPost({
         variables: { postId: _id, userId, remove: hasRejected },
       })
-      const updatedPost = (data as {
-        rejectPost?: { approvedBy?: string[]; rejectedBy?: string[] }
-      } | undefined)?.rejectPost
+      const updatedPost = data?.rejectPost
       if (updatedPost) {
         // Reconcile both arrays because rejecting can also remove an existing approval.
         setLocalApprovedBy(updatedPost.approvedBy || [])

--- a/quotevote-frontend/src/components/Post/PostCard.tsx
+++ b/quotevote-frontend/src/components/Post/PostCard.tsx
@@ -129,7 +129,17 @@ function PostCardComponent({
       setLocalRejectedBy((prev) => prev.filter((id) => id !== userId))
     }
     try {
-      await approvePost({ variables: { postId: _id, userId, remove: hasApproved } })
+      const { data } = await approvePost({
+        variables: { postId: _id, userId, remove: hasApproved },
+      })
+      const updatedPost = (data as {
+        approvePost?: { approvedBy?: string[]; rejectedBy?: string[] }
+      } | undefined)?.approvePost
+      if (updatedPost) {
+        // The optimistic update is only immediate feedback; the completed mutation is authoritative.
+        setLocalApprovedBy(updatedPost.approvedBy || [])
+        setLocalRejectedBy(updatedPost.rejectedBy || [])
+      }
     } catch {
       setLocalApprovedBy(approvedBy || [])
       setLocalRejectedBy(rejectedBy || [])
@@ -149,7 +159,17 @@ function PostCardComponent({
       setLocalApprovedBy((prev) => prev.filter((id) => id !== userId))
     }
     try {
-      await rejectPost({ variables: { postId: _id, userId, remove: hasRejected } })
+      const { data } = await rejectPost({
+        variables: { postId: _id, userId, remove: hasRejected },
+      })
+      const updatedPost = (data as {
+        rejectPost?: { approvedBy?: string[]; rejectedBy?: string[] }
+      } | undefined)?.rejectPost
+      if (updatedPost) {
+        // Reconcile both arrays because rejecting can also remove an existing approval.
+        setLocalApprovedBy(updatedPost.approvedBy || [])
+        setLocalRejectedBy(updatedPost.rejectedBy || [])
+      }
     } catch {
       setLocalApprovedBy(approvedBy || [])
       setLocalRejectedBy(rejectedBy || [])


### PR DESCRIPTION
## Summary

Fixes RC1-018 by reconciling the optimistic Support/Disagree state with the authoritative GraphQL mutation response.

Previously, `PostCard` updated `approvedBy` and `rejectedBy` optimistically, but ignored the arrays returned by the completed mutation. This could leave the Support button in a stale selected state.

## Changes

- Reconcile `localApprovedBy` and `localRejectedBy` after `approvePost`
- Apply the same reconciliation after `rejectPost`
- Add a regression test covering stale Support state after mutation completion

## Testing

- PostCard test suite passes
- TypeScript type-check passes
- ESLint passes with no new errors

Closes #370