### PR TITLE
feat(profile): update activity filter taxonomy and support multi-select filtering (RC1-006, RC1-007)

### DIFF
--- a/quotevote-frontend/src/__tests__/components/Profile/ProfileView.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/ProfileView.test.tsx
@@ -5,7 +5,8 @@
  * - Rendering with profile data
  * - Loading state
  * - Empty/invalid user state
- * - Component composition with tabs
+ * - RC1-006: Taxonomy & Labels (All, Posts, Voted, Commented, Quoted, About)
+ * - RC1-007: Multi-select activity filters, union filtering, All reset
  */
 
 import { render, screen, act, waitFor } from '../../utils/test-utils';
@@ -34,15 +35,14 @@ jest.mock('@/components/LoadingSpinner', () => ({
   LoadingSpinner: () => <div data-testid="loading-spinner">Loading...</div>,
 }));
 
-jest.mock('@/components/UserPosts', () => ({
-  UserPosts: ({ userId }: { userId: string }) => (
-    <div data-testid="user-posts">Posts for {userId}</div>
-  ),
-}));
-
 jest.mock('@/components/Activity/PaginatedActivityList', () => ({
-  PaginatedActivityList: ({ activityEvent }: { activityEvent: string[] }) => (
-    <div data-testid="paginated-activity-list">{activityEvent.join(',')}</div>
+  PaginatedActivityList: ({ activityEvent = [] }: { activityEvent?: string[] }) => (
+    <div
+      data-testid="paginated-activity-list"
+      data-events={activityEvent.join(',')}
+    >
+      {activityEvent.length === 0 ? 'ALL' : activityEvent.join(',')}
+    </div>
   ),
 }));
 
@@ -98,7 +98,7 @@ describe('ProfileView', () => {
     });
   });
 
-  describe('Valid Profile', () => {
+  describe('Valid Profile - RC1-006 Filter Taxonomy & RC1-007 Multi-Select', () => {
     it('renders profile header', async () => {
       await act(async () => {
         render(<ProfileView profileUser={mockProfileUser} />);
@@ -109,12 +109,13 @@ describe('ProfileView', () => {
       expect(screen.getByText(/Header for testuser/)).toBeInTheDocument();
     });
 
-    it('renders tabs with All Posts, Voted, Commented, Quoted, and About', async () => {
+    it('renders all six filter buttons with expected labels: All, Posts, Voted, Commented, Quoted, About', async () => {
       await act(async () => {
         render(<ProfileView profileUser={mockProfileUser} />);
       });
       await waitFor(() => {
-        expect(screen.getByRole('tab', { name: 'All Posts' })).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'All' })).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'Posts' })).toBeInTheDocument();
         expect(screen.getByRole('tab', { name: 'Voted' })).toBeInTheDocument();
         expect(screen.getByRole('tab', { name: 'Commented' })).toBeInTheDocument();
         expect(screen.getByRole('tab', { name: 'Quoted' })).toBeInTheDocument();
@@ -122,30 +123,165 @@ describe('ProfileView', () => {
       });
     });
 
-    it('shows Posts tab content by default', async () => {
+    it('shows All activity by default with All button active', async () => {
       await act(async () => {
         render(<ProfileView profileUser={mockProfileUser} />);
       });
       await waitFor(() => {
-        expect(screen.getByTestId('user-posts')).toBeInTheDocument();
+        const allButton = screen.getByRole('tab', { name: 'All' });
+        expect(allButton).toHaveAttribute('aria-selected', 'true');
+        expect(allButton).toHaveAttribute('data-state', 'active');
+        expect(screen.getByTestId('paginated-activity-list')).toHaveTextContent('ALL');
       });
     });
 
-    it('shows reputation display when About tab is clicked', async () => {
+    it('filters by single activity type when Posts is clicked', async () => {
       const user = userEvent.setup();
       await act(async () => {
         render(<ProfileView profileUser={mockProfileUser} />);
       });
-      const aboutTab = screen.getByRole('tab', { name: 'About' });
-      await user.click(aboutTab);
+      const postsButton = screen.getByRole('tab', { name: 'Posts' });
+      await user.click(postsButton);
+
       await waitFor(() => {
-        expect(screen.getByTestId('reputation-display')).toBeInTheDocument();
+        expect(postsButton).toHaveAttribute('aria-selected', 'true');
+        expect(postsButton).toHaveAttribute('data-state', 'active');
+        expect(screen.getByRole('tab', { name: 'All' })).toHaveAttribute('aria-selected', 'false');
+        expect(screen.getByTestId('paginated-activity-list')).toHaveTextContent('POSTED');
       });
-      expect(screen.getByText('Reputation')).toBeInTheDocument();
-      expect(screen.getByText('No about text yet')).toBeInTheDocument();
     });
 
-    it('shows bio text on About tab when present', async () => {
+    it('filters by single activity type when Voted, Commented, and Quoted are clicked', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<ProfileView profileUser={mockProfileUser} />);
+      });
+
+      const votedButton = screen.getByRole('tab', { name: 'Voted' });
+      await user.click(votedButton);
+      await waitFor(() => {
+        expect(votedButton).toHaveAttribute('aria-selected', 'true');
+        expect(screen.getByTestId('paginated-activity-list')).toHaveTextContent('VOTED');
+      });
+
+      const allButton = screen.getByRole('tab', { name: 'All' });
+      await user.click(allButton);
+      await waitFor(() => {
+        expect(allButton).toHaveAttribute('aria-selected', 'true');
+        expect(screen.getByTestId('paginated-activity-list')).toHaveTextContent('ALL');
+      });
+
+      const commentedButton = screen.getByRole('tab', { name: 'Commented' });
+      await user.click(commentedButton);
+      await waitFor(() => {
+        expect(commentedButton).toHaveAttribute('aria-selected', 'true');
+        expect(screen.getByTestId('paginated-activity-list')).toHaveTextContent('COMMENTED');
+      });
+    });
+
+    it('supports selecting multiple filters simultaneously (union of Posts and Commented)', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<ProfileView profileUser={mockProfileUser} />);
+      });
+
+      const postsButton = screen.getByRole('tab', { name: 'Posts' });
+      const commentedButton = screen.getByRole('tab', { name: 'Commented' });
+
+      await user.click(postsButton);
+      await user.click(commentedButton);
+
+      await waitFor(() => {
+        expect(postsButton).toHaveAttribute('aria-selected', 'true');
+        expect(commentedButton).toHaveAttribute('aria-selected', 'true');
+        expect(screen.getByRole('tab', { name: 'All' })).toHaveAttribute('aria-selected', 'false');
+        expect(screen.getByRole('tab', { name: 'Voted' })).toHaveAttribute('aria-selected', 'false');
+        expect(screen.getByRole('tab', { name: 'Quoted' })).toHaveAttribute('aria-selected', 'false');
+        expect(screen.getByTestId('paginated-activity-list')).toHaveAttribute(
+          'data-events',
+          'POSTED,COMMENTED'
+        );
+      });
+    });
+
+    it('toggles off a selected filter and updates union query', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<ProfileView profileUser={mockProfileUser} />);
+      });
+
+      const postsButton = screen.getByRole('tab', { name: 'Posts' });
+      const commentedButton = screen.getByRole('tab', { name: 'Commented' });
+
+      await user.click(postsButton);
+      await user.click(commentedButton);
+      await waitFor(() => {
+        expect(screen.getByTestId('paginated-activity-list')).toHaveAttribute(
+          'data-events',
+          'POSTED,COMMENTED'
+        );
+      });
+
+      // Untoggle Posts
+      await user.click(postsButton);
+      await waitFor(() => {
+        expect(postsButton).toHaveAttribute('aria-selected', 'false');
+        expect(commentedButton).toHaveAttribute('aria-selected', 'true');
+        expect(screen.getByTestId('paginated-activity-list')).toHaveAttribute(
+          'data-events',
+          'COMMENTED'
+        );
+      });
+    });
+
+    it('reverts to All when all specific active filters are unchecked', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<ProfileView profileUser={mockProfileUser} />);
+      });
+
+      const postsButton = screen.getByRole('tab', { name: 'Posts' });
+      await user.click(postsButton);
+      await waitFor(() => {
+        expect(postsButton).toHaveAttribute('aria-selected', 'true');
+      });
+
+      // Uncheck Posts
+      await user.click(postsButton);
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: 'All' })).toHaveAttribute('aria-selected', 'true');
+        expect(screen.getByTestId('paginated-activity-list')).toHaveTextContent('ALL');
+      });
+    });
+
+    it('resets multi-selection to All when All button is clicked', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<ProfileView profileUser={mockProfileUser} />);
+      });
+
+      const postsButton = screen.getByRole('tab', { name: 'Posts' });
+      const votedButton = screen.getByRole('tab', { name: 'Voted' });
+      const allButton = screen.getByRole('tab', { name: 'All' });
+
+      await user.click(postsButton);
+      await user.click(votedButton);
+
+      await waitFor(() => {
+        expect(postsButton).toHaveAttribute('aria-selected', 'true');
+        expect(votedButton).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await user.click(allButton);
+      await waitFor(() => {
+        expect(allButton).toHaveAttribute('aria-selected', 'true');
+        expect(postsButton).toHaveAttribute('aria-selected', 'false');
+        expect(votedButton).toHaveAttribute('aria-selected', 'false');
+        expect(screen.getByTestId('paginated-activity-list')).toHaveTextContent('ALL');
+      });
+    });
+
+    it('shows reputation display and bio when About tab is clicked', async () => {
       const user = userEvent.setup();
       const userWithBio: ProfileUser = {
         ...mockProfileUser,
@@ -157,20 +293,11 @@ describe('ProfileView', () => {
       const aboutTab = screen.getByRole('tab', { name: 'About' });
       await user.click(aboutTab);
       await waitFor(() => {
+        expect(aboutTab).toHaveAttribute('aria-selected', 'true');
+        expect(screen.getByTestId('reputation-display')).toBeInTheDocument();
         expect(screen.getByText('I care about thoughtful dialogue.')).toBeInTheDocument();
-      });
-      expect(screen.getByRole('heading', { name: 'About', level: 3 })).toBeInTheDocument();
-    });
-
-    it('shows voted activity list when Voted tab is clicked', async () => {
-      const user = userEvent.setup();
-      await act(async () => {
-        render(<ProfileView profileUser={mockProfileUser} />);
-      });
-      const votedTab = screen.getByRole('tab', { name: 'Voted' });
-      await user.click(votedTab);
-      await waitFor(() => {
-        expect(screen.getByTestId('paginated-activity-list')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'About', level: 3 })).toBeInTheDocument();
+        expect(screen.queryByTestId('paginated-activity-list')).not.toBeInTheDocument();
       });
     });
 
@@ -191,15 +318,24 @@ describe('ProfileView', () => {
       });
     });
 
-    it('renders user posts placeholder', async () => {
+    it('switches back from About view to Activity view when an activity filter is clicked', async () => {
+      const user = userEvent.setup();
       await act(async () => {
         render(<ProfileView profileUser={mockProfileUser} />);
       });
-      // UserPosts component is now rendered (not a placeholder)
+
+      const aboutTab = screen.getByRole('tab', { name: 'About' });
+      await user.click(aboutTab);
       await waitFor(() => {
-        expect(
-          screen.queryByText(/User posts will be displayed here/)
-        ).not.toBeInTheDocument();
+        expect(screen.getByTestId('profile-about-section')).toBeInTheDocument();
+      });
+
+      const quotedButton = screen.getByRole('tab', { name: 'Quoted' });
+      await user.click(quotedButton);
+      await waitFor(() => {
+        expect(screen.getByTestId('profile-activity-section')).toBeInTheDocument();
+        expect(quotedButton).toHaveAttribute('aria-selected', 'true');
+        expect(screen.getByTestId('paginated-activity-list')).toHaveTextContent('QUOTED');
       });
     });
   });
@@ -269,20 +405,10 @@ describe('ProfileView', () => {
         expect(screen.queryByTestId('reputation-display')).not.toBeInTheDocument();
       });
     });
-
-    it('renders UserPosts component with correct userId', async () => {
-      await act(async () => {
-        render(<ProfileView profileUser={mockProfileUser} />);
-      });
-      await waitFor(() => {
-        expect(screen.getByTestId('user-posts')).toBeInTheDocument();
-        expect(screen.getByText('Posts for user1')).toBeInTheDocument();
-      });
-    });
   });
 
   describe('Component Integration', () => {
-    it('renders profile header and tabs together', async () => {
+    it('renders profile header and tablist together', async () => {
       await act(async () => {
         render(<ProfileView profileUser={mockProfileUser} />);
       });

--- a/quotevote-frontend/src/components/Profile/ProfileView.tsx
+++ b/quotevote-frontend/src/components/Profile/ProfileView.tsx
@@ -1,19 +1,63 @@
 'use client';
 
+import { useState, useCallback } from 'react';
 import Link from 'next/link';
 import type { ProfileViewProps } from '@/types/profile';
 import { ProfileHeader } from './ProfileHeader';
 import { ReputationDisplay } from './ReputationDisplay';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
 import { Card, CardContent } from '@/components/ui/card';
-import { UserPosts } from '@/components/UserPosts';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { PaginatedActivityList } from '@/components/Activity/PaginatedActivityList';
+import { cn } from '@/lib/utils';
+
+export type ProfileActivityType = 'POSTED' | 'VOTED' | 'COMMENTED' | 'QUOTED';
+
+export const ACTIVITY_FILTERS: Array<{
+  id: ProfileActivityType;
+  label: string;
+}> = [
+  { id: 'POSTED', label: 'Posts' },
+  { id: 'VOTED', label: 'Voted' },
+  { id: 'COMMENTED', label: 'Commented' },
+  { id: 'QUOTED', label: 'Quoted' },
+];
+
+export const ALL_ACTIVITY_TYPES: ProfileActivityType[] = [
+  'POSTED',
+  'VOTED',
+  'COMMENTED',
+  'QUOTED',
+];
 
 export function ProfileView({
   profileUser,
   loading,
 }: ProfileViewProps) {
+  const [activeTab, setActiveTab] = useState<'activity' | 'about'>('activity');
+  const [selectedFilters, setSelectedFilters] = useState<ProfileActivityType[]>([]);
+
+  const handleSelectAll = useCallback(() => {
+    setActiveTab('activity');
+    setSelectedFilters([]);
+  }, []);
+
+  const handleToggleFilter = useCallback((filterId: ProfileActivityType) => {
+    setActiveTab('activity');
+    setSelectedFilters((prev) => {
+      if (prev.length === 0 || prev.length === ALL_ACTIVITY_TYPES.length) {
+        return [filterId];
+      }
+      if (prev.includes(filterId)) {
+        return prev.filter((id) => id !== filterId);
+      }
+      return [...prev, filterId];
+    });
+  }, []);
+
+  const handleSelectAbout = useCallback(() => {
+    setActiveTab('about');
+  }, []);
+
   if (loading) return <LoadingSpinner />;
 
   if (!profileUser) {
@@ -31,74 +75,122 @@ export function ProfileView({
     );
   }
 
+  const isAllActive =
+    activeTab === 'activity' &&
+    (selectedFilters.length === 0 || selectedFilters.length === ALL_ACTIVITY_TYPES.length);
+
+  const isAboutActive = activeTab === 'about';
+
   return (
     <div className="w-full pb-8">
       <ProfileHeader profileUser={profileUser} />
 
-      <Tabs defaultValue="all-posts" className="w-full mt-3">
-        <TabsList className="sticky top-0 z-10 w-full h-11 rounded-none border-b border-border bg-background/95 backdrop-blur-sm px-0">
-          <TabsTrigger value="all-posts" className="flex-1 h-full rounded-none text-xs sm:text-sm font-medium data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:shadow-none">All Posts</TabsTrigger>
-          <TabsTrigger value="voted" className="flex-1 h-full rounded-none text-xs sm:text-sm font-medium data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:shadow-none">Voted</TabsTrigger>
-          <TabsTrigger value="commented" className="flex-1 h-full rounded-none text-xs sm:text-sm font-medium data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:shadow-none">Commented</TabsTrigger>
-          <TabsTrigger value="quoted" className="flex-1 h-full rounded-none text-xs sm:text-sm font-medium data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:shadow-none">Quoted</TabsTrigger>
-          <TabsTrigger value="about" className="flex-1 h-full rounded-none text-xs sm:text-sm font-medium data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:shadow-none">About</TabsTrigger>
-        </TabsList>
+      <div className="w-full mt-3">
+        <div
+          role="tablist"
+          aria-label="Profile activity filters"
+          className="sticky top-0 z-10 w-full h-11 border-b border-border bg-background/95 backdrop-blur-sm px-0 flex items-center justify-between overflow-x-auto"
+        >
+          {/* All Filter */}
+          <button
+            type="button"
+            role="tab"
+            aria-selected={isAllActive}
+            data-state={isAllActive ? 'active' : 'inactive'}
+            onClick={handleSelectAll}
+            className={cn(
+              'flex-1 h-full min-w-[50px] inline-flex items-center justify-center whitespace-nowrap px-1 sm:px-3 text-xs sm:text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 border-b-2',
+              isAllActive
+                ? 'border-primary text-foreground font-semibold'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            All
+          </button>
 
-        <TabsContent value="all-posts" className="mt-4">
-          <UserPosts userId={profileUser._id} />
-        </TabsContent>
+          {/* Activity Filters: Posts, Voted, Commented, Quoted */}
+          {ACTIVITY_FILTERS.map(({ id, label }) => {
+            const isActive =
+              activeTab === 'activity' &&
+              !isAllActive &&
+              selectedFilters.includes(id);
 
-        <TabsContent value="voted" className="mt-4">
-          <PaginatedActivityList
-            userId={profileUser._id}
-            activityEvent={['VOTED']}
-            defaultPageSize={15}
-            maxVisiblePages={5}
-          />
-        </TabsContent>
+            return (
+              <button
+                key={id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                data-state={isActive ? 'active' : 'inactive'}
+                onClick={() => handleToggleFilter(id)}
+                className={cn(
+                  'flex-1 h-full min-w-[60px] inline-flex items-center justify-center whitespace-nowrap px-1 sm:px-3 text-xs sm:text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 border-b-2',
+                  isActive
+                    ? 'border-primary text-foreground font-semibold'
+                    : 'border-transparent text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {label}
+              </button>
+            );
+          })}
 
-        <TabsContent value="commented" className="mt-4">
-          <PaginatedActivityList
-            userId={profileUser._id}
-            activityEvent={['COMMENTED']}
-            defaultPageSize={15}
-            maxVisiblePages={5}
-          />
-        </TabsContent>
+          {/* About Filter */}
+          <button
+            type="button"
+            role="tab"
+            aria-selected={isAboutActive}
+            data-state={isAboutActive ? 'active' : 'inactive'}
+            onClick={handleSelectAbout}
+            className={cn(
+              'flex-1 h-full min-w-[50px] inline-flex items-center justify-center whitespace-nowrap px-1 sm:px-3 text-xs sm:text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 border-b-2',
+              isAboutActive
+                ? 'border-primary text-foreground font-semibold'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            About
+          </button>
+        </div>
 
-        <TabsContent value="quoted" className="mt-4">
-          <PaginatedActivityList
-            userId={profileUser._id}
-            activityEvent={['QUOTED']}
-            defaultPageSize={15}
-            maxVisiblePages={5}
-          />
-        </TabsContent>
-
-        <TabsContent value="about" className="mt-4 space-y-4">
-          <Card>
-            <CardContent className="pt-6 space-y-2">
-              <h3 className="text-sm font-semibold text-foreground">About</h3>
-              {profileUser.bio?.trim() ? (
-                <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
-                  {profileUser.bio.trim()}
-                </p>
-              ) : (
-                <p className="text-muted-foreground text-sm py-2">
-                  No about text yet
-                </p>
-              )}
-            </CardContent>
-          </Card>
-
-          {profileUser.reputation ? (
-            <ReputationDisplay
-              reputation={profileUser.reputation}
-              onRefresh={() => window.location.reload()}
+        {/* Content Section */}
+        {activeTab === 'activity' && (
+          <div className="mt-4" data-testid="profile-activity-section">
+            <PaginatedActivityList
+              userId={profileUser._id}
+              activityEvent={isAllActive ? [] : selectedFilters}
+              defaultPageSize={15}
+              maxVisiblePages={5}
             />
-          ) : null}
-        </TabsContent>
-      </Tabs>
+          </div>
+        )}
+
+        {activeTab === 'about' && (
+          <div className="mt-4 space-y-4" data-testid="profile-about-section">
+            <Card>
+              <CardContent className="pt-6 space-y-2">
+                <h3 className="text-sm font-semibold text-foreground">About</h3>
+                {profileUser.bio?.trim() ? (
+                  <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+                    {profileUser.bio.trim()}
+                  </p>
+                ) : (
+                  <p className="text-muted-foreground text-sm py-2">
+                    No about text yet
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+
+            {profileUser.reputation ? (
+              <ReputationDisplay
+                reputation={profileUser.reputation}
+                onRefresh={() => window.location.reload()}
+              />
+            ) : null}
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Resolves **RC1-006** (Update profile activity filter buttons) and **RC1-007** (Allow multiple profile activity filters to be selected).
  
- **Taxonomy & Buttons (RC1-006)**:
   - Updated profile activity filter buttons in ProfileView.tsx to: `All`, `Posts`, `Voted`, `Commented`, `Quoted`, and `About`.
   - `All` shows full profile activity across all activity types.
   - `About` displays profile bio and reputation section.
- **Multi-Select & Union Filtering (RC1-007)**:
   - Converted single-select tab bar into a multi-select button group with visual active states.
   - Passes union of selected filter types (`['POSTED', 'COMMENTED']`, etc.) to PaginatedActivityList.tsx.
   - Clicking `All` resets active filters to full activity. Unchecking all active filters returns to `All`.
   - Switching between `About` and activity filters transitions state cleanly.
  
## Test Plan
- Run unit tests: `npm test -- src/__tests__/components/Profile/ProfileView.test.tsx` (22/22 passed).
- Run full frontend test suite: `npm test` (159 passed, 1901 tests passed, 0 failures).
- Verified responsive layout across desktop and mobile.
