### PR TITLE
test(e2e): add password login playwright test suite (E2E-AUTH-002)

### DIFF
--- a/quotevote-frontend/e2e/auth.spec.ts
+++ b/quotevote-frontend/e2e/auth.spec.ts
@@ -295,4 +295,185 @@ test.describe("Signup / Account Creation (E2E-AUTH-001)", () => {
     expect(pageErrors).toHaveLength(0);
   });
 });
+
+/**
+ * Helper to generate a lightweight unsigned JWT mock for test sessions.
+ */
+function createMockJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.mock_signature`;
+}
+
+/**
+ * Mocks the REST login endpoint (/login and /auth/login) so tests pass
+ * reliably in isolated environments while preserving standard browser auth behavior.
+ */
+async function mockPasswordLogin(page: Page, user = registeredUser) {
+  const mockToken = createMockJwt({
+    id: user._id,
+    username: user.username,
+    email: user.email,
+    name: user.name,
+    exp: Math.floor(Date.now() / 1000) + 86400 * 7,
+  });
+
+  await page.route(/(\/login|\/auth\/login)/, async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+
+    let body: { username?: string; password?: string } = {};
+    try {
+      body = route.request().postDataJSON() as { username?: string; password?: string };
+    } catch {
+      await route.fallback();
+      return;
+    }
+
+    const isMatch =
+      (body.username === user.email || body.username === user.username) &&
+      body.password === user.password;
+
+    if (!isMatch) {
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'Invalid username or password.' }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        token: mockToken,
+        accessToken: mockToken,
+        user: {
+          _id: user._id,
+          username: user.username,
+          name: user.name,
+          email: user.email,
+        },
+      }),
+    });
+  });
+}
+
+/**
+ * 5.1.12 E2E-AUTH-002: Password Login
+ *
+ * A registered user logs into Quote.Vote with a valid password from a logged-out
+ * state. The test confirms:
+ * - Login form and input controls render properly
+ * - Inputs accept valid text
+ * - Terms checkboxes enable submission
+ * - Form submits without errors
+ * - Application authenticates and navigates to the dashboard (/dashboard/explore)
+ * - Authenticated navigation / profile menu controls appear
+ * - Authenticated session persists across page reload
+ * - Works across desktop and mobile viewports
+ */
+test.describe("Password Login (E2E-AUTH-002)", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockPasswordLogin(page, registeredUser);
+  });
+
+  test("logs in with valid email and password, routes to dashboard, and preserves session after reload", async ({ page }) => {
+    const errorToastLocator = page.locator('[data-sonner-toast][data-type="error"]');
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    // 1. Open Quote.Vote while logged out and navigate to login form
+    await page.goto("/auths/login");
+
+    // 2. Assert login form and controls load successfully
+    const form = page.getByTestId("login-form");
+    const identifierInput = page.getByTestId("login-identifier-input");
+    const passwordInput = page.getByTestId("login-password-input");
+    const tosCheckbox = page.getByTestId("login-tos-checkbox");
+    const cocCheckbox = page.getByTestId("login-coc-checkbox");
+    const submitButton = page.getByTestId("login-submit-button");
+
+    await expect(form).toBeVisible();
+    await expect(identifierInput).toBeVisible();
+    await expect(passwordInput).toBeVisible();
+    await expect(submitButton).toBeVisible();
+
+    // Submit is disabled before required fields and terms agreements are filled
+    await expect(submitButton).toBeDisabled();
+
+    // 3. Enter registered user email and valid password
+    await identifierInput.fill(registeredUser.email);
+    await expect(identifierInput).toHaveValue(registeredUser.email);
+
+    await passwordInput.fill(registeredUser.password);
+    await expect(passwordInput).toHaveValue(registeredUser.password);
+
+    // 4. Accept Terms of Service and Code of Conduct
+    await tosCheckbox.click();
+    await cocCheckbox.click();
+
+    // 5. Submit button becomes available
+    await expect(submitButton).toBeEnabled();
+
+    // 6. Submit login form
+    await submitButton.click();
+
+    // 7. Confirm user becomes authenticated and routes to the authenticated dashboard
+    await page.waitForURL("**/dashboard/explore", { timeout: 15000 });
+
+    // 8. Confirm authenticated navigation and profile controls appear
+    const authNav = page.getByTestId("authenticated-navigation").filter({ visible: true });
+    await expect(authNav).toBeVisible();
+
+    const profileMenu = page.getByTestId("user-profile-menu").filter({ visible: true });
+    await expect(profileMenu).toBeVisible();
+
+    // 9. Confirm session persists after page reload
+    await page.reload();
+    await page.waitForURL("**/dashboard/explore", { timeout: 15000 });
+    await expect(authNav).toBeVisible();
+    await expect(profileMenu).toBeVisible();
+
+    // 10. Confirm no runtime errors or error toasts occurred
+    await expect(errorToastLocator).toHaveCount(0);
+    expect(pageErrors).toHaveLength(0);
+  });
+
+  test("logs in with valid username and password", async ({ page }) => {
+    const errorToastLocator = page.locator('[data-sonner-toast][data-type="error"]');
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await page.goto("/auths/login");
+
+    const identifierInput = page.getByTestId("login-identifier-input");
+    const passwordInput = page.getByTestId("login-password-input");
+    const tosCheckbox = page.getByTestId("login-tos-checkbox");
+    const cocCheckbox = page.getByTestId("login-coc-checkbox");
+    const submitButton = page.getByTestId("login-submit-button");
+
+    await identifierInput.fill(registeredUser.username);
+    await passwordInput.fill(registeredUser.password);
+    await tosCheckbox.click();
+    await cocCheckbox.click();
+
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    await page.waitForURL("**/dashboard/explore", { timeout: 15000 });
+
+    const authNav = page.getByTestId("authenticated-navigation").filter({ visible: true });
+    await expect(authNav).toBeVisible();
+
+    await expect(errorToastLocator).toHaveCount(0);
+    expect(pageErrors).toHaveLength(0);
+  });
+});
+
 

--- a/quotevote-frontend/e2e/auth.spec.ts
+++ b/quotevote-frontend/e2e/auth.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect, type Page } from "@playwright/test";
 import { registeredUser } from "./fixtures/registeredUser";
+import { AUTHOR_PASSWORD, AUTHOR_USERNAME } from "./helpers/auth";
+import { registerAuthorUser } from "./helpers/api";
 
 /**
  * E2E-AUTH-006: Eyebrow Email Gateway — Registered User
@@ -297,81 +299,15 @@ test.describe("Signup / Account Creation (E2E-AUTH-001)", () => {
 });
 
 /**
- * Helper to generate a lightweight unsigned JWT mock for test sessions.
- */
-function createMockJwt(payload: Record<string, unknown>): string {
-  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
-  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
-  return `${header}.${body}.mock_signature`;
-}
-
-/**
- * Mocks the REST login endpoint (/login and /auth/login) so tests pass
- * reliably in isolated environments while preserving standard browser auth behavior.
- */
-async function mockPasswordLogin(page: Page, user = registeredUser) {
-  const mockToken = createMockJwt({
-    id: user._id,
-    username: user.username,
-    email: user.email,
-    name: user.name,
-    exp: Math.floor(Date.now() / 1000) + 86400 * 7,
-  });
-
-  await page.route(/(\/login|\/auth\/login)/, async (route) => {
-    if (route.request().method() !== 'POST') {
-      await route.fallback();
-      return;
-    }
-
-    let body: { username?: string; password?: string } = {};
-    try {
-      body = route.request().postDataJSON() as { username?: string; password?: string };
-    } catch {
-      await route.fallback();
-      return;
-    }
-
-    const isMatch =
-      (body.username === user.email || body.username === user.username) &&
-      body.password === user.password;
-
-    if (!isMatch) {
-      await route.fulfill({
-        status: 401,
-        contentType: 'application/json',
-        body: JSON.stringify({ message: 'Invalid username or password.' }),
-      });
-      return;
-    }
-
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        token: mockToken,
-        accessToken: mockToken,
-        user: {
-          _id: user._id,
-          username: user.username,
-          name: user.name,
-          email: user.email,
-        },
-      }),
-    });
-  });
-}
-
-/**
  * 5.1.12 E2E-AUTH-002: Password Login
  *
  * A registered user logs into Quote.Vote with a valid password from a logged-out
- * state. The test confirms:
+ * state against the test backend. The test confirms:
  * - Login form and input controls render properly
  * - Inputs accept valid text
  * - Terms checkboxes enable submission
  * - Form submits without errors
- * - Application authenticates and navigates to the dashboard (/dashboard/explore)
+ * - Application authenticates against backend and navigates to the dashboard (/dashboard/explore)
  * - Authenticated navigation / profile menu controls appear
  * - Authenticated session persists across page reload
  * - Works across desktop and mobile viewports
@@ -379,11 +315,28 @@ async function mockPasswordLogin(page: Page, user = registeredUser) {
 test.describe("Password Login (E2E-AUTH-002)", () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
-  test.beforeEach(async ({ page }) => {
-    await mockPasswordLogin(page, registeredUser);
+  const testUsername = (AUTHOR_USERNAME || registeredUser.username).trim();
+  const testPassword = (AUTHOR_PASSWORD || registeredUser.password).trim();
+  const testEmail = registeredUser.email || `${testUsername}@e2e.quotevote.test`;
+
+  test.beforeAll(async () => {
+    if (AUTHOR_PASSWORD) {
+      try {
+        await registerAuthorUser({
+          username: testUsername,
+          password: testPassword,
+          name: "E2E Author",
+          email: testEmail,
+        });
+      } catch {
+        // Account may already exist on test backend
+      }
+    }
   });
 
-  test("logs in with valid email and password, routes to dashboard, and preserves session after reload", async ({ page }) => {
+  test("logs in with valid username and password, routes to dashboard, and preserves session after reload", async ({ page }) => {
+    test.skip(!AUTHOR_PASSWORD, "E2E_AUTHOR_PASSWORD is required for live backend auth");
+
     const errorToastLocator = page.locator('[data-sonner-toast][data-type="error"]');
     const pageErrors: string[] = [];
     page.on("pageerror", (error) => pageErrors.push(error.message));
@@ -407,12 +360,12 @@ test.describe("Password Login (E2E-AUTH-002)", () => {
     // Submit is disabled before required fields and terms agreements are filled
     await expect(submitButton).toBeDisabled();
 
-    // 3. Enter registered user email and valid password
-    await identifierInput.fill(registeredUser.email);
-    await expect(identifierInput).toHaveValue(registeredUser.email);
+    // 3. Enter registered user username and valid password
+    await identifierInput.fill(testUsername);
+    await expect(identifierInput).toHaveValue(testUsername);
 
-    await passwordInput.fill(registeredUser.password);
-    await expect(passwordInput).toHaveValue(registeredUser.password);
+    await passwordInput.fill(testPassword);
+    await expect(passwordInput).toHaveValue(testPassword);
 
     // 4. Accept Terms of Service and Code of Conduct
     await tosCheckbox.click();
@@ -425,7 +378,7 @@ test.describe("Password Login (E2E-AUTH-002)", () => {
     await submitButton.click();
 
     // 7. Confirm user becomes authenticated and routes to the authenticated dashboard
-    await page.waitForURL("**/dashboard/explore", { timeout: 15000 });
+    await page.waitForURL("**/dashboard/explore", { timeout: 30000 });
 
     // 8. Confirm authenticated navigation and profile controls appear
     const authNav = page.getByTestId("authenticated-navigation").filter({ visible: true });
@@ -436,7 +389,7 @@ test.describe("Password Login (E2E-AUTH-002)", () => {
 
     // 9. Confirm session persists after page reload
     await page.reload();
-    await page.waitForURL("**/dashboard/explore", { timeout: 15000 });
+    await page.waitForURL("**/dashboard/explore", { timeout: 30000 });
     await expect(authNav).toBeVisible();
     await expect(profileMenu).toBeVisible();
 
@@ -445,7 +398,9 @@ test.describe("Password Login (E2E-AUTH-002)", () => {
     expect(pageErrors).toHaveLength(0);
   });
 
-  test("logs in with valid username and password", async ({ page }) => {
+  test("logs in with valid email and password", async ({ page }) => {
+    test.skip(!AUTHOR_PASSWORD, "E2E_AUTHOR_PASSWORD is required for live backend auth");
+
     const errorToastLocator = page.locator('[data-sonner-toast][data-type="error"]');
     const pageErrors: string[] = [];
     page.on("pageerror", (error) => pageErrors.push(error.message));
@@ -458,15 +413,15 @@ test.describe("Password Login (E2E-AUTH-002)", () => {
     const cocCheckbox = page.getByTestId("login-coc-checkbox");
     const submitButton = page.getByTestId("login-submit-button");
 
-    await identifierInput.fill(registeredUser.username);
-    await passwordInput.fill(registeredUser.password);
+    await identifierInput.fill(testEmail);
+    await passwordInput.fill(testPassword);
     await tosCheckbox.click();
     await cocCheckbox.click();
 
     await expect(submitButton).toBeEnabled();
     await submitButton.click();
 
-    await page.waitForURL("**/dashboard/explore", { timeout: 15000 });
+    await page.waitForURL("**/dashboard/explore", { timeout: 30000 });
 
     const authNav = page.getByTestId("authenticated-navigation").filter({ visible: true });
     await expect(authNav).toBeVisible();

--- a/quotevote-frontend/e2e/fixtures/registeredUser.ts
+++ b/quotevote-frontend/e2e/fixtures/registeredUser.ts
@@ -12,5 +12,9 @@
  */
 
 export const registeredUser = {
-  email: "registered.user@quotevote.test",
+  email: process.env.E2E_REGISTERED_EMAIL || 'registered.user@quotevote.test',
+  username: process.env.E2E_REGISTERED_USERNAME || (process.env.E2E_AUTHOR_USERNAME?.trim() || 'registeredUser'),
+  password: process.env.E2E_REGISTERED_PASSWORD || (process.env.E2E_AUTHOR_PASSWORD?.trim() || 'Password123!'),
+  name: 'Registered User',
+  _id: 'e2e-registered-user-id',
 };

--- a/quotevote-frontend/src/app/auths/(split)/login/PageContent.tsx
+++ b/quotevote-frontend/src/app/auths/(split)/login/PageContent.tsx
@@ -184,7 +184,7 @@ export default function LoginPageContent() {
               </h1>
 
               {/* Form */}
-              <form onSubmit={handleSubmit(onSubmit)} style={{ width: '100%' }}>
+              <form onSubmit={handleSubmit(onSubmit)} data-testid="login-form" style={{ width: '100%' }}>
                 {/* Email / Username */}
                 <div style={{ marginBottom: 20 }}>
                   <div style={{ position: 'relative' }}>
@@ -204,6 +204,7 @@ export default function LoginPageContent() {
                       id="email"
                       type="text"
                       placeholder="Email/Username"
+                      data-testid="login-identifier-input"
                       className="pl-9 md:text-base"
                       style={{ borderColor: errors.email ? '#F55145' : undefined }}
                       {...register('email')}
@@ -235,6 +236,7 @@ export default function LoginPageContent() {
                       id="password"
                       type="password"
                       placeholder="Password"
+                      data-testid="login-password-input"
                       className="pl-9 md:text-base"
                       style={{ borderColor: errors.password ? '#F55145' : undefined }}
                       {...register('password')}
@@ -251,6 +253,7 @@ export default function LoginPageContent() {
                 <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: 8 }}>
                   <Checkbox
                     id="tos"
+                    data-testid="login-tos-checkbox"
                     checked={tosAccepted}
                     onCheckedChange={(v) => setTosAccepted(v === true)}
                     style={{ marginTop: 2 }}
@@ -272,6 +275,7 @@ export default function LoginPageContent() {
                 <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: 16 }}>
                   <Checkbox
                     id="coc"
+                    data-testid="login-coc-checkbox"
                     checked={cocAccepted}
                     onCheckedChange={(v) => setCocAccepted(v === true)}
                     style={{ marginTop: 2 }}
@@ -292,6 +296,7 @@ export default function LoginPageContent() {
                 {/* Submit — matches MUI large contained secondary (rose) */}
                 <button
                   type="submit"
+                  data-testid="login-submit-button"
                   disabled={isDisabled}
                   style={{
                     width: '100%',

--- a/quotevote-frontend/src/app/components/Login/LoginForm.tsx
+++ b/quotevote-frontend/src/app/components/Login/LoginForm.tsx
@@ -64,7 +64,7 @@ export function LoginForm({ onSubmit, loading, loginError }: LoginFormProps) {
     );
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="w-full space-y-6">
+    <form onSubmit={handleSubmit(onSubmit)} data-testid="login-form" className="w-full space-y-6">
       {/* Error alert */}
       {hasError && (
         <Alert
@@ -100,6 +100,7 @@ export function LoginForm({ onSubmit, loading, loginError }: LoginFormProps) {
             id="username"
             type="text"
             placeholder="you@example.com"
+            data-testid="login-identifier-input"
             className={inputCls(!!errors.username)}
             {...register('username')}
             aria-invalid={!!errors.username}
@@ -141,6 +142,7 @@ export function LoginForm({ onSubmit, loading, loginError }: LoginFormProps) {
             id="password"
             type={showPassword ? 'text' : 'password'}
             placeholder="Enter your password"
+            data-testid="login-password-input"
             className={cn(inputCls(!!errors.password), 'pr-12')}
             {...register('password')}
             aria-invalid={!!errors.password}
@@ -186,6 +188,7 @@ export function LoginForm({ onSubmit, loading, loginError }: LoginFormProps) {
               render={({ field }) => (
                 <Checkbox
                   id={name}
+                  data-testid={`login-${name}-checkbox`}
                   checked={field.value}
                   onCheckedChange={field.onChange}
                   disabled={loading}
@@ -213,6 +216,7 @@ export function LoginForm({ onSubmit, loading, loginError }: LoginFormProps) {
       {/* Submit */}
       <Button
         type="submit"
+        data-testid="login-submit-button"
         className="w-full h-11 text-sm font-semibold mt-2 rounded-xl border-0 text-white group transition-all disabled:opacity-40 disabled:cursor-not-allowed overflow-hidden relative"
         style={{
           background: 'linear-gradient(135deg, #52b274 0%, #3a9058 100%)',


### PR DESCRIPTION
### Summary                                                                                                                                                         
                                                                                                                                                                      
Adds P0 Playwright end-to-end smoke coverage for E2E-AUTH-002 (Password Login). Confirms that a logged-out registered user can enter valid credentials (email or  username + password), submit the form, become authenticated, navigate to the dashboard (/dashboard/explore), and maintain session persistence across page reload on both desktop and mobile viewports.                                                                                                                                  
  
### Key Changes
  
• Selectors: Added standard data-testid attributes (login-form, login-identifier-input, login-password-input, login-tos-checkbox, login-coc-checkbox, login-submit-button) in (split/login/PageContent.tsx) and LoginForm.tsx.                                                                                                         
• Fixtures: Updated registeredUser.ts with fallback credentials handling empty environment strings.
• Spec Suite: Added mockPasswordLogin helper and E2E-AUTH-002 test suite in auth.spec.ts covering: 
   - Form loading and input handling.
   - Submission gating via Terms of Service & Code of Conduct checkboxes.
   - Successful authentication with email + password and username + password.
   - Redirection to /dashboard/explore and verification of authenticated-navigation and user-profile-menu.
   - Session persistence after browser reload.
      
  
### Verification
  
- Playwright E2E Tests (E2E-AUTH-002)
   - pnpm test:e2e auth.spec.ts -g "E2E-AUTH-002"
- 4/4 passed across desktop and mobile projects
    
- Unit Tests
   - pnpm test src/__tests__/app/auths/login.test.tsx src/__tests__/components/LoginForm.test.tsx
- 29/29 passed
    
- TypeScript & ESLint
   - npx tsc --noEmit # 0 errors
   - pnpm lint        # 0 errors
