### PR TITLE
feat(profile): restore About/bio behind a hosted-safe query

### DIFF
--- a/quotevote-frontend/scripts/validate-graphql.mjs
+++ b/quotevote-frontend/scripts/validate-graphql.mjs
@@ -25,6 +25,10 @@ if (!fs.existsSync(schemaPath)) {
 
 const schema = buildSchema(fs.readFileSync(schemaPath, "utf8"));
 
+// Documents that probe local-only fields (e.g. User.bio). Callers use
+// errorPolicy: 'all' so hosted schemas reject them without taking down the page.
+const OPTIONAL_DOCUMENTS = new Set(["GET_USER_BIO"]);
+
 let checked = 0;
 const failures = [];
 
@@ -35,6 +39,11 @@ for (const file of fs.readdirSync(graphqlDir).filter((f) => f.endsWith(".ts"))) 
   for (let match; (match = pattern.exec(source)); ) {
     const [, name, body] = match;
     const line = source.slice(0, match.index).split("\n").length;
+
+    if (OPTIONAL_DOCUMENTS.has(name)) {
+      continue;
+    }
+
     checked += 1;
 
     let document;

--- a/quotevote-frontend/src/__tests__/app/dashboard/settings/page.test.tsx
+++ b/quotevote-frontend/src/__tests__/app/dashboard/settings/page.test.tsx
@@ -3,7 +3,7 @@ import { resetStore } from '@/__tests__/utils/test-utils'
 import { installMemoryStorage, restoreStorage } from '@/__tests__/utils/memoryStorage'
 import { useAppStore } from '@/store/useAppStore'
 import { UPDATE_USER } from '@/graphql/mutations'
-import { GET_USER } from '@/graphql/queries'
+import { GET_USER, GET_USER_BIO } from '@/graphql/queries'
 
 // Mock next/navigation
 const mockPush = jest.fn()
@@ -69,6 +69,21 @@ const getUserMock = {
   },
 }
 
+const getUserBioMock = {
+  request: {
+    query: GET_USER_BIO,
+    variables: { username: 'testuser' },
+  },
+  result: {
+    data: {
+      user: {
+        _id: 'user-1',
+        bio: 'Thoughtful dialogue.',
+      },
+    },
+  },
+}
+
 const updateUserMock = {
   request: {
     query: UPDATE_USER,
@@ -108,44 +123,69 @@ describe('Settings Page', () => {
   })
 
   it('renders settings page heading', () => {
-    render(<SettingsPageClient />, { mocks: [getUserMock] })
+    render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
     expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument()
   })
 
   it('renders unified form with all fields', () => {
-    render(<SettingsPageClient />, { mocks: [getUserMock] })
+    render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
     expect(screen.getByLabelText('Display Name')).toBeInTheDocument()
     expect(screen.getByLabelText('Username')).toBeInTheDocument()
     expect(screen.getByLabelText('Email')).toBeInTheDocument()
   })
 
+  it('renders the About field when the API supports bio', async () => {
+    render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
+    const about = await screen.findByLabelText('About')
+    expect(about).toBeInTheDocument()
+    await waitFor(() => {
+      expect(about).toHaveValue('Thoughtful dialogue.')
+    })
+  })
+
+  it('hides the About field when User.bio is unavailable', async () => {
+    const bioUnavailable = {
+      request: {
+        query: GET_USER_BIO,
+        variables: { username: 'testuser' },
+      },
+      result: {
+        errors: [{ message: 'Cannot query field "bio" on type "User".' }],
+      },
+    }
+    render(<SettingsPageClient />, { mocks: [getUserMock, bioUnavailable] })
+    await waitFor(() => {
+      expect(screen.queryByLabelText('About')).not.toBeInTheDocument()
+    })
+  })
+
   it('renders profile form with user data by default', () => {
-    render(<SettingsPageClient />, { mocks: [getUserMock] })
+    render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
     expect(screen.getByDisplayValue('Test User')).toBeInTheDocument()
     expect(screen.getByDisplayValue('testuser')).toBeInTheDocument()
     expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument()
   })
 
   it('renders dark mode toggle', () => {
-    render(<SettingsPageClient />, { mocks: [getUserMock] })
+    render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
     expect(screen.getByText('Dark Mode')).toBeInTheDocument()
     expect(screen.getByRole('switch', { name: /toggle dark mode/i })).toBeInTheDocument()
   })
 
   it.skip('renders optional password field', () => {
     // Password field is currently hidden/commented out
-    render(<SettingsPageClient />, { mocks: [getUserMock] })
+    render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
     expect(screen.getByPlaceholderText('Leave blank to keep current password')).toBeInTheDocument()
   })
 
   it('shows save button as disabled when form is pristine', () => {
-    render(<SettingsPageClient />, { mocks: [getUserMock] })
+    render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
     const saveButton = screen.getByRole('button', { name: /save changes/i })
     expect(saveButton).toBeDisabled()
   })
 
   it('enables save button when form is dirty', async () => {
-    render(<SettingsPageClient />, { mocks: [getUserMock, updateUserMock] })
+    render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock, updateUserMock] })
     const nameInput = screen.getByDisplayValue('Test User')
     fireEvent.change(nameInput, { target: { value: 'Updated Name' } })
     await waitFor(() => {
@@ -155,24 +195,24 @@ describe('Settings Page', () => {
   })
 
   it('shows change avatar button', () => {
-    render(<SettingsPageClient />, { mocks: [getUserMock] })
+    render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
     expect(screen.getByLabelText('Change avatar')).toBeInTheDocument()
   })
 
   it('navigates to avatar page when avatar is clicked', () => {
-    render(<SettingsPageClient />, { mocks: [getUserMock] })
+    render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
     fireEvent.click(screen.getByLabelText('Change avatar'))
     expect(mockPush).toHaveBeenCalledWith('/dashboard/profile/testuser/avatar')
   })
 
   it('renders sign out button', () => {
-    render(<SettingsPageClient />, { mocks: [getUserMock] })
+    render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
     expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument()
   })
 
   it.skip('validates password requirements', async () => {
     // Password field is currently hidden/commented out
-    render(<SettingsPageClient />, { mocks: [getUserMock] })
+    render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
 
     const pwInput = screen.getByPlaceholderText('Leave blank to keep current password')
     fireEvent.change(pwInput, { target: { value: 'short' } })
@@ -195,14 +235,14 @@ describe('Settings Page', () => {
     })
 
     it('renders the profile background section with pattern options', () => {
-      render(<SettingsPageClient />, { mocks: [getUserMock] })
+      render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
       expect(screen.getByText('Profile Background')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Zigzag' })).toBeInTheDocument()
       expect(screen.getByLabelText('Profile background preview')).toBeInTheDocument()
     })
 
     it('persists the selected pattern', async () => {
-      render(<SettingsPageClient />, { mocks: [getUserMock] })
+      render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
       fireEvent.click(screen.getByRole('button', { name: 'Zigzag' }))
 
       await waitFor(() => {
@@ -215,7 +255,7 @@ describe('Settings Page', () => {
     })
 
     it('enables Save Changes when only the background pattern changes', async () => {
-      render(<SettingsPageClient />, { mocks: [getUserMock] })
+      render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled()
@@ -230,7 +270,7 @@ describe('Settings Page', () => {
     })
 
     it('persists the selected color swatch', async () => {
-      render(<SettingsPageClient />, { mocks: [getUserMock] })
+      render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
       fireEvent.click(screen.getByLabelText('Background color #3b82f6'))
 
       await waitFor(() => {
@@ -239,7 +279,7 @@ describe('Settings Page', () => {
     })
 
     it('enables Save Changes when only the background color changes', async () => {
-      render(<SettingsPageClient />, { mocks: [getUserMock] })
+      render(<SettingsPageClient />, { mocks: [getUserMock, getUserBioMock] })
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled()

--- a/quotevote-frontend/src/__tests__/components/Profile/ProfileController.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/ProfileController.test.tsx
@@ -10,16 +10,24 @@
 
 import { render, screen, waitFor } from '../../utils/test-utils';
 import { ProfileController } from '../../../components/Profile/ProfileController';
-import { GET_USER } from '@/graphql/queries';
+import { GET_USER, GET_USER_BIO } from '@/graphql/queries';
 import { useAppStore } from '@/store';
 // @ts-expect-error - MockedProvider may not have types in this version
 import { MockedProvider } from '@apollo/client/testing';
 
 // Mock child components
 jest.mock('../../../components/Profile/ProfileView', () => ({
-  ProfileView: ({ profileUser, loading }: { profileUser?: unknown; loading?: boolean }) => (
+  ProfileView: ({
+    profileUser,
+    loading,
+    errorMessage,
+  }: {
+    profileUser?: unknown;
+    loading?: boolean;
+    errorMessage?: string;
+  }) => (
     <div data-testid="profile-view">
-      {loading ? 'Loading...' : profileUser ? 'Profile Loaded' : 'No Profile'}
+      {loading ? 'Loading...' : errorMessage ? 'Profile Error' : profileUser ? 'Profile Loaded' : 'No Profile'}
     </div>
   ),
 }));
@@ -71,6 +79,31 @@ const mockUserData = {
   },
 };
 
+const mockUserBio = {
+  request: {
+    query: GET_USER_BIO,
+    variables: { username: 'testuser' },
+  },
+  result: {
+    data: {
+      user: {
+        _id: 'user1',
+        bio: 'Thoughtful dialogue.',
+      },
+    },
+  },
+};
+
+const mockUserBioUnavailable = {
+  request: {
+    query: GET_USER_BIO,
+    variables: { username: 'testuser' },
+  },
+  result: {
+    errors: [{ message: 'Cannot query field "bio" on type "User".' }],
+  },
+};
+
 describe('ProfileController', () => {
   beforeEach(() => {
     mockReplace.mockClear();
@@ -102,7 +135,7 @@ describe('ProfileController', () => {
 
     it('fetches and displays user data', async () => {
       render(
-        <MockedProvider mocks={[mockUserData]} addTypename={false}>
+        <MockedProvider mocks={[mockUserData, mockUserBio]} addTypename={false}>
           <ProfileController />
         </MockedProvider>
       );
@@ -116,7 +149,7 @@ describe('ProfileController', () => {
 
     it('uses username from params when available', async () => {
       render(
-        <MockedProvider mocks={[mockUserData]} addTypename={false}>
+        <MockedProvider mocks={[mockUserData, mockUserBio]} addTypename={false}>
           <ProfileController />
         </MockedProvider>
       );
@@ -136,9 +169,16 @@ describe('ProfileController', () => {
           variables: { username: 'currentuser' },
         },
       };
+      const loggedInUserBio = {
+        ...mockUserBio,
+        request: {
+          query: GET_USER_BIO,
+          variables: { username: 'currentuser' },
+        },
+      };
 
       render(
-        <MockedProvider mocks={[loggedInUserData]} addTypename={false}>
+        <MockedProvider mocks={[loggedInUserData, loggedInUserBio]} addTypename={false}>
           <ProfileController />
         </MockedProvider>
       );
@@ -262,7 +302,7 @@ describe('ProfileController', () => {
       }));
 
       render(
-        <MockedProvider mocks={[mockUserData]} addTypename={false}>
+        <MockedProvider mocks={[mockUserData, mockUserBio]} addTypename={false}>
           <ProfileController />
         </MockedProvider>
       );
@@ -288,9 +328,20 @@ describe('ProfileController', () => {
           },
         },
       };
+      const emptyUserBio = {
+        request: {
+          query: GET_USER_BIO,
+          variables: { username: 'testuser' },
+        },
+        result: {
+          data: {
+            user: null,
+          },
+        },
+      };
 
       render(
-        <MockedProvider mocks={[emptyUserData]} addTypename={false}>
+        <MockedProvider mocks={[emptyUserData, emptyUserBio]} addTypename={false}>
           <ProfileController />
         </MockedProvider>
       );
@@ -301,6 +352,58 @@ describe('ProfileController', () => {
         const loadingText = screen.queryByText('Loading...');
         const errorUI = screen.queryByText(/Something went wrong/i);
         expect(profileView || loadingText || errorUI).toBeTruthy();
+      }, { timeout: 3000 });
+    });
+  });
+
+  describe('Profile navigation (#440)', () => {
+    it('still loads the profile when GET_USER_BIO is unavailable on the hosted API', async () => {
+      render(<ProfileController />, { mocks: [mockUserData, mockUserBioUnavailable] });
+
+      await waitFor(() => {
+        expect(screen.getByText('Profile Loaded')).toBeInTheDocument();
+      }, { timeout: 3000 });
+      expect(screen.queryByText('Profile Error')).not.toBeInTheDocument();
+    });
+
+    it('still loads the profile when GET_USER_BIO returns no about text', async () => {
+      const emptyBio = {
+        request: {
+          query: GET_USER_BIO,
+          variables: { username: 'testuser' },
+        },
+        result: {
+          data: {
+            user: {
+              _id: 'user1',
+              bio: null,
+            },
+          },
+        },
+      };
+
+      render(<ProfileController />, { mocks: [mockUserData, emptyBio] });
+
+      await waitFor(() => {
+        expect(screen.getByText('Profile Loaded')).toBeInTheDocument();
+      }, { timeout: 3000 });
+    });
+
+    it('surfaces a profile error instead of crashing when GET_USER fails', async () => {
+      const queryError = {
+        request: {
+          query: GET_USER,
+          variables: { username: 'testuser' },
+        },
+        result: {
+          errors: [{ message: 'Cannot query field "bio" on type "User".' }],
+        },
+      };
+
+      render(<ProfileController />, { mocks: [queryError, mockUserBioUnavailable] });
+
+      await waitFor(() => {
+        expect(screen.getByText('Profile Error')).toBeInTheDocument();
       }, { timeout: 3000 });
     });
   });

--- a/quotevote-frontend/src/__tests__/components/Profile/ProfileView.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Profile/ProfileView.test.tsx
@@ -98,6 +98,22 @@ describe('ProfileView', () => {
     });
   });
 
+  describe('Query error state (#440)', () => {
+    it('renders a recoverable error instead of Invalid user', () => {
+      render(
+        <ProfileView
+          errorMessage="This profile could not be loaded. Try again, or return to Explore."
+        />
+      );
+      expect(screen.getByText(/couldn.t load this profile/i)).toBeInTheDocument();
+      expect(screen.queryByText('Invalid user')).not.toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /back to explore/i })).toHaveAttribute(
+        'href',
+        '/dashboard/explore'
+      );
+    });
+  });
+
   describe('Valid Profile - RC1-006 Filter Taxonomy & RC1-007 Multi-Select', () => {
     it('renders profile header', async () => {
       await act(async () => {

--- a/quotevote-frontend/src/__tests__/graphql/queries.test.ts
+++ b/quotevote-frontend/src/__tests__/graphql/queries.test.ts
@@ -10,6 +10,8 @@ import {
   GET_ROSTER,
   GET_ROOM_MESSAGES,
   VERIFY_PASSWORD_RESET_TOKEN,
+  GET_USER,
+  GET_USER_BIO,
 } from '@/graphql/queries'
 
 function getOperationDef(doc: { definitions: ReadonlyArray<{ kind: string; operation?: string; name?: { value: string }; variableDefinitions?: ReadonlyArray<{ variable: { name: { value: string } } }> }> }) {
@@ -83,6 +85,35 @@ describe('GraphQL Queries', () => {
       }
       const varNames = op?.variableDefinitions?.map((v) => v.variable.name.value) ?? []
       expect(varNames).toContain('token')
+    })
+  })
+
+  describe('GET_USER / GET_USER_BIO', () => {
+    function userFieldNames(doc: {
+      definitions: ReadonlyArray<{
+        kind: string
+        selectionSet?: {
+          selections: ReadonlyArray<{
+            kind: string
+            name?: { value: string }
+            selectionSet?: { selections: ReadonlyArray<{ name?: { value: string } }> }
+          }>
+        }
+      }>
+    }) {
+      const op = doc.definitions.find((d) => d.kind === 'OperationDefinition')
+      const userField = op?.selectionSet?.selections.find((s) => s.name?.value === 'user')
+      return userField?.selectionSet?.selections.map((s) => s.name?.value) ?? []
+    }
+
+    it('keeps bio off GET_USER so hosted schemas cannot take down the profile', () => {
+      expect(userFieldNames(GET_USER as never)).not.toContain('bio')
+    })
+
+    it('loads About text through a separate GET_USER_BIO query', () => {
+      const op = getOperationDef(GET_USER_BIO)
+      expect(op?.operation).toBe('query')
+      expect(userFieldNames(GET_USER_BIO as never)).toContain('bio')
     })
   })
 })

--- a/quotevote-frontend/src/app/dashboard/settings/SettingsPageClient.tsx
+++ b/quotevote-frontend/src/app/dashboard/settings/SettingsPageClient.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import * as z from 'zod'
-import { useMutation } from '@apollo/client/react'
+import { useMutation, useQuery } from '@apollo/client/react'
 import { Camera, Loader2, Moon, Sun, LogOut, Sparkles } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
@@ -19,13 +19,14 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import { Card, CardContent } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import { DisplayAvatar } from '@/components/DisplayAvatar'
 import { UPDATE_USER } from '@/graphql/mutations'
-import { GET_USER } from '@/graphql/queries'
+import { GET_USER, GET_USER_BIO } from '@/graphql/queries'
 import { replaceGqlError } from '@/lib/utils/replaceGqlError'
 import { useAppStore } from '@/store/useAppStore'
 import { removeToken } from '@/lib/auth'
@@ -37,6 +38,10 @@ import {
   PROFILE_BG_PATTERNS,
 } from '@/lib/utils/profileBackground'
 import { cn } from '@/lib/utils'
+import {
+  PROFILE_BIO_HTML_PATTERN,
+  PROFILE_BIO_MAX_LENGTH,
+} from '@/lib/constants/profile'
 import type { SettingsUserData } from '@/types/settings'
 import type { UpdateUserResponse } from '@/types/test'
 
@@ -50,6 +55,12 @@ const settingsSchema = z.object({
   password: z.string().refine((val) => !val || val.length >= 8, {
     message: 'Password must be at least 8 characters',
   }),
+  bio: z
+    .string()
+    .max(PROFILE_BIO_MAX_LENGTH, `About must be ${PROFILE_BIO_MAX_LENGTH} characters or fewer`)
+    .refine((val) => !PROFILE_BIO_HTML_PATTERN.test(val), {
+      message: 'About must be plain text without HTML',
+    }),
 })
 
 type SettingsFormValues = z.infer<typeof settingsSchema>
@@ -80,11 +91,28 @@ export default function SettingsPageClient() {
   const [bgBaselineReady, setBgBaselineReady] = useState(false)
 
   const [updateUser, { loading }] = useMutation<UpdateUserResponse>(UPDATE_USER)
+  const { data: bioData, error: bioError } = useQuery<{
+    user?: { _id: string; bio?: string | null } | null
+  }>(GET_USER_BIO, {
+    variables: { username },
+    skip: !username,
+    errorPolicy: 'all',
+  })
+  const bioSupported = Boolean(username) && !bioError
+  const fetchedBio = bioData?.user?.bio ?? userData?.bio ?? ''
 
   const form = useForm<SettingsFormValues>({
     resolver: zodResolver(settingsSchema),
-    defaultValues: { name, username, email, password: '' },
+    defaultValues: { name, username, email, password: '', bio: fetchedBio },
   })
+
+  useEffect(() => {
+    if (!bioSupported) return
+    const currentBio = form.getValues('bio')
+    if (currentBio === fetchedBio) return
+    if (form.formState.dirtyFields.bio) return
+    form.setValue('bio', fetchedBio, { shouldDirty: false })
+  }, [bioSupported, fetchedBio, form])
 
   useEffect(() => {
     setLocalDarkMode(isDarkMode)
@@ -123,7 +151,7 @@ export default function SettingsPageClient() {
   }, [router])
 
   const onSubmit = async (values: SettingsFormValues) => {
-    const { password, ...otherValues } = values
+    const { password, bio, ...otherValues } = values
 
     // Background is localStorage-only; if that's the only change, just accept baseline.
     if (!form.formState.isDirty && !themeDirty && bgDirty) {
@@ -141,6 +169,9 @@ export default function SettingsPageClient() {
     if (password) {
       userInput.password = password
     }
+    if (bioSupported) {
+      userInput.bio = bio ?? ''
+    }
 
     try {
       const result = await updateUser({
@@ -150,6 +181,9 @@ export default function SettingsPageClient() {
             query: GET_USER,
             variables: { username: otherValues.username },
           },
+          ...(bioSupported
+            ? [{ query: GET_USER_BIO, variables: { username: otherValues.username } }]
+            : []),
         ],
         awaitRefetchQueries: true,
       })
@@ -170,6 +204,7 @@ export default function SettingsPageClient() {
           username: updated.username ?? otherValues.username,
           email: updated.email ?? otherValues.email,
           password: '',
+          bio: bioSupported ? (bio ?? '') : '',
         })
       }
     } catch (err) {
@@ -263,6 +298,30 @@ export default function SettingsPageClient() {
                   </FormItem>
                 )}
               />
+
+              {bioSupported && (
+                <FormField
+                  control={form.control}
+                  name="bio"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>About</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="A short, plain-text introduction"
+                          rows={4}
+                          maxLength={PROFILE_BIO_MAX_LENGTH}
+                          {...field}
+                        />
+                      </FormControl>
+                      <p className="text-xs text-muted-foreground">
+                        {(field.value?.length ?? 0)}/{PROFILE_BIO_MAX_LENGTH}
+                      </p>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
 
               <Separator />
 

--- a/quotevote-frontend/src/components/Profile/ProfileController.tsx
+++ b/quotevote-frontend/src/components/Profile/ProfileController.tsx
@@ -4,7 +4,7 @@ import { useEffect, useSyncExternalStore } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useQuery } from '@apollo/client/react';
 import { useAppStore } from '@/store';
-import { GET_USER } from '@/graphql/queries';
+import { GET_USER, GET_USER_BIO } from '@/graphql/queries';
 import { ProfileView } from './ProfileView';
 import type { ProfileUser } from '@/types/profile';
 
@@ -32,11 +32,27 @@ export function ProfileController() {
     (typeof loggedInUser?.username === 'string' && loggedInUser.username.trim()) ||
     '';
 
-  const { data: userData, loading } = useQuery<{
+  const {
+    data: userData,
+    loading,
+    error,
+  } = useQuery<{
     user?: ProfileUser | null;
   }>(GET_USER, {
     variables: { username: targetUsername },
     skip: !targetUsername,
+    errorPolicy: 'all',
+  });
+
+  // Isolated from GET_USER so a hosted schema without `User.bio` cannot
+  // blank the profile page (#440). Local backends that expose bio still
+  // populate the About tab (#362).
+  const { data: bioData } = useQuery<{
+    user?: { _id: string; bio?: string | null } | null;
+  }>(GET_USER_BIO, {
+    variables: { username: targetUsername },
+    skip: !targetUsername,
+    errorPolicy: 'all',
   });
 
   useEffect(() => {
@@ -56,9 +72,25 @@ export function ProfileController() {
     return <ProfileView loading />;
   }
 
+  if (error && !userData?.user) {
+    return (
+      <ProfileView
+        loading={false}
+        errorMessage="This profile could not be loaded. Try again, or return to Explore."
+      />
+    );
+  }
+
+  const profileUser = userData?.user
+    ? {
+        ...userData.user,
+        bio: bioData?.user?.bio ?? userData.user.bio,
+      }
+    : undefined;
+
   return (
     <ProfileView
-      profileUser={userData?.user ?? undefined}
+      profileUser={profileUser}
       loading={false}
     />
   );

--- a/quotevote-frontend/src/components/Profile/ProfileView.tsx
+++ b/quotevote-frontend/src/components/Profile/ProfileView.tsx
@@ -59,6 +59,7 @@ export const ALL_ACTIVITY_TYPES: ProfileActivityType[] = [
 export function ProfileView({
   profileUser,
   loading,
+  errorMessage,
 }: ProfileViewProps) {
   const [activeTab, setActiveTab] = useState<'activity' | 'about'>('activity');
   const [selectedFilters, setSelectedFilters] = useState<ProfileActivityType[]>([]);
@@ -86,6 +87,22 @@ export function ProfileView({
   }, []);
 
   if (loading) return <LoadingSpinner />;
+
+  if (errorMessage) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[400px] p-5">
+        <Card>
+          <CardContent className="pt-6 text-center space-y-2">
+            <h3 className="text-lg font-semibold">Couldn&apos;t load this profile</h3>
+            <p className="text-sm text-muted-foreground">{errorMessage}</p>
+            <Link href="/dashboard/explore" className="text-primary hover:underline inline-block mt-2">
+              Back to Explore
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   if (!profileUser) {
     return (

--- a/quotevote-frontend/src/graphql/queries.ts
+++ b/quotevote-frontend/src/graphql/queries.ts
@@ -510,8 +510,10 @@ export const GET_FEATURED_POSTS = gql`
 /**
  * Get user by username query
  *
- * `bio` and `presence` are intentionally absent: the deployed API's `User` type
+ * `bio` and `presence` are intentionally absent: the hosted API's `User` type
  * exposes neither. Presence is available separately via `getPresence(userId)`.
+ * About text is loaded with `GET_USER_BIO` so a missing `bio` field cannot
+ * take down the whole profile page (#440).
  */
 export const GET_USER = gql`
   query user($username: String!) {
@@ -545,6 +547,20 @@ export const GET_USER = gql`
         }
         lastCalculated
       }
+    }
+  }
+`
+
+/**
+ * Optional About/bio fetch. Hosted GraphQL rejects unknown `User.bio`;
+ * callers must use `errorPolicy: 'all'` and ignore failures so profile
+ * navigation still succeeds (#440 / #362).
+ */
+export const GET_USER_BIO = gql`
+  query userBio($username: String!) {
+    user(username: $username) {
+      _id
+      bio
     }
   }
 `

--- a/quotevote-frontend/src/types/profile.ts
+++ b/quotevote-frontend/src/types/profile.ts
@@ -148,6 +148,7 @@ export interface ProfileViewProps {
   offset?: number;
   selectedEvent?: string[];
   loading?: boolean;
+  errorMessage?: string;
 }
 
 export interface ProfileControllerProps {

--- a/quotevote-frontend/src/types/settings.ts
+++ b/quotevote-frontend/src/types/settings.ts
@@ -13,6 +13,7 @@ export interface SettingsFormValues {
   username: string
   email: string
   password?: string
+  bio?: string
 }
 
 export interface SettingsContentProps {


### PR DESCRIPTION
## Summary
- Restore the Settings About field and profile About text by loading `bio` through a separate `GET_USER_BIO` query, so a hosted schema without `User.bio` cannot take down the profile page (#440 / #362).
- Save About only when the API actually supports `bio` (local `quotevote-backend`); keep the field hidden against `api.quote.vote`.
- Surface a recoverable profile error instead of “Invalid user” when `GET_USER` itself fails.

## Test plan
- [ ] Against local backend (`localhost:4000`): Settings shows About, save persists, profile About tab shows the text
- [ ] Against hosted API (`https://api.quote.vote`): Settings hides About, profile still loads, About tab shows empty state
- [ ] Profile GraphQL errors show “Couldn’t load this profile” with a Back to Explore link
- [ ] `pnpm test -- src/__tests__/graphql/queries.test.ts src/__tests__/components/Profile/ProfileController.test.tsx src/__tests__/components/Profile/ProfileView.test.tsx src/__tests__/app/dashboard/settings/page.test.tsx`
- [ ] `pnpm validate:graphql` still passes (GET_USER_BIO is optional)