### PR TITLE
Disable magic-link eyebrow and require feature branches (#460)

### DIFF
--- a/.cursor/rules/backend-graphql.mdc
+++ b/.cursor/rules/backend-graphql.mdc
@@ -1,0 +1,38 @@
+---
+description: Backend Express / Apollo / Mongo conventions
+globs: quotevote-backend/**/*.{ts,js}
+alwaysApply: false
+---
+
+# Backend conventions
+
+## Stack
+
+- Express 5 + Apollo Server 5 (GraphQL)
+- MongoDB via Mongoose 9; Prisma 6 under `prisma/schema/`
+- JWT auth (access ~15m, refresh ~7d) + bcryptjs
+- Logging: Winston + Morgan; path alias `~/*` → `app/*`
+
+## Structure
+
+- Resolvers: `app/data/resolvers/`
+- Models: `app/data/models/`
+- Types: `app/types/` (mandatory; no `any`)
+- Tests: `app/__tests__/` (`unit/`, `integration/`, `utils/`)
+
+## GraphQL
+
+- Keep client query/mutation variable types aligned with schema (prefer matching hosted/legacy `String!` where already published)
+- Public queries listed in `requireAuth` allowlist must stay intentional
+- Resolvers must exist for every Query/Mutation field declared in `server.ts`
+- Return lean, serialized ids (`_id.toString()`) consistently
+
+## Formatting
+
+Single quotes, 100 char width, 2-space indent.
+
+## When changing schema
+
+1. Update typeDefs + resolver + types
+2. `pnpm type-check` and `pnpm test` from `quotevote-backend/`
+3. Confirm frontend operations still validate against the same field types

--- a/.cursor/rules/code-quality.mdc
+++ b/.cursor/rules/code-quality.mdc
@@ -1,0 +1,33 @@
+---
+description: DRY, SOLID, YAGNI, and change-hygiene for Quote.Vote
+alwaysApply: true
+---
+
+# Code quality
+
+## Scope of change
+
+- Change only files needed for the task. No drive-by refactors or unrelated formatting.
+- Prefer extending an existing helper over adding a parallel one.
+
+## DRY
+
+- Search for an existing util, hook, resolver, or component before writing a new one.
+- Shared types live in `types/`; shared UI in `components/`; shared GraphQL in `graphql/`.
+- Extract a shared helper only when the same logic exists in 2+ places.
+
+## SOLID (practical)
+
+- One job per module: a resolver mutates; a component renders; a hook owns one piece of client state.
+- Do not add new abstraction layers (services, factories, generic wrappers) unless reuse is already proven.
+- Depend on public `@/` / `~/` modules rather than reaching into unrelated internals.
+
+## YAGNI and performance
+
+- Do not ship unused params, dead feature flags, or "for later" code.
+- Do not add `useMemo` / `useCallback` or a new package for hypothetical cost. Measure first.
+- Avoid over-fetching GraphQL: request `_id` and only fields the UI uses.
+
+## Security
+
+Follow `security.mdc`. Never weaken `requireAuth`, URL sanitization, or secret handling to "make it work".

--- a/.cursor/rules/frontend-next.mdc
+++ b/.cursor/rules/frontend-next.mdc
@@ -1,0 +1,47 @@
+---
+description: Frontend Next.js 16 / React 19 conventions and performance
+globs: quotevote-frontend/**/*.{ts,tsx}
+alwaysApply: false
+---
+
+# Frontend conventions
+
+## Stack
+
+- Next.js App Router (`src/app/`), React 19, TypeScript strict
+- Server Components by default; add `'use client'` only for interactivity
+- shadcn/ui + Tailwind 4 + lucide-react (no Material-UI)
+- Zustand (`src/store/`), Apollo Client 4, RHF + Zod for forms
+
+## Imports & types
+
+- Path alias only: `@/*` → `src/*` (no deep relative imports)
+- Types live in `src/types/`; never `any` — use `unknown`
+- Type all props, params, and return values
+
+## Patterns
+
+```tsx
+// ❌ BAD — post URL without app prefix
+router.push(post.url)
+
+// ✅ GOOD — backend stores /post/...; app routes under /dashboard/post/...
+import { toAppPostUrl } from '@/lib/utils/sanitizeUrl'
+router.push(toAppPostUrl(post.url))
+```
+
+- Prefer `<Link>` for navigable cards/lists (full clickable area + a11y)
+- List keys: stable ids (`_id`); never array index. Ensure GraphQL queries request `_id`
+- Match GraphQL variable types to the API schema (`String!` vs `ID!` — hosted legacy often uses `String!`)
+- Forms: Zod schemas in `src/lib/validation/`; disable submit until valid
+
+## Formatting
+
+Double quotes, 100 char width, 2-space indent.
+
+## Performance
+
+- Avoid unnecessary `'use client'` boundaries and large client bundles
+- Do not add `useMemo`/`useCallback` by default; follow React Compiler guidance already in repo
+- Prefer `cache-first` / targeted refetch over blanket network policies when appropriate
+- Lazy-load heavy UI (emoji pickers, editors) when not on critical path

--- a/.cursor/rules/project-workflow.mdc
+++ b/.cursor/rules/project-workflow.mdc
@@ -1,0 +1,42 @@
+---
+description: Quote.Vote monorepo workflow — pnpm commands, CI gates, env hygiene
+alwaysApply: true
+---
+
+# Quote.Vote project workflow
+
+Two independent packages (no shared workspace root). Run commands **inside** the package directory. Use **pnpm only** (never npm/yarn).
+
+## Before finishing a change
+
+From the touched package(s), run what applies:
+
+| Check | Frontend | Backend |
+| --- | --- | --- |
+| Lint | `pnpm lint` | `pnpm lint` |
+| Types | `pnpm type-check` | `pnpm type-check` |
+| Format | `pnpm format:check` | `pnpm format:check` |
+| Unit | `pnpm test` (or scoped file) | `pnpm test` |
+| E2E | `pnpm test:e2e <spec>` when UI flows change | — |
+
+CI on PRs to `main`/`develop`: `lint` + `type-check` + Jest for both packages. Frontend Playwright runs when `E2E_AUTHOR_PASSWORD` is set.
+
+## Env files
+
+- Never commit `.env.local` or `.env*.local` (gitignored).
+- Use `quotevote-frontend/.env.example` → `cp .env.example .env.local`.
+- Keep hosted/prod API URLs in local overrides only.
+- E2E secrets: `.env.e2e.local` from `.env.e2e.example`.
+
+## Git / PRs
+
+- **Never commit, push, or open a PR from `main` or `develop`.**
+- If HEAD is `main` or `develop`, create and check out a feature branch first
+  (`fix/...`, `feat/...`, `issue#N`) before any commit. Then `git push -u origin HEAD`.
+- Never `git push origin main` or `git push origin develop`. Do not force-push those branches.
+- Before **every commit** (not just before PR), run at minimum:
+  - Frontend: `pnpm lint && pnpm type-check`
+  - Backend: `pnpm lint && pnpm type-check`
+- Commit only files needed for the task; leave unrelated local fixes out unless asked.
+- Do not amend commits you did not create this session.
+- Prefer small, focused PRs with a clear test plan.

--- a/.cursor/rules/security.mdc
+++ b/.cursor/rules/security.mdc
@@ -1,0 +1,37 @@
+---
+description: Security practices for Quote.Vote frontend and backend
+alwaysApply: true
+---
+
+# Security
+
+## Secrets & env
+
+- Never commit tokens, passwords, or `.env.local` / `.env*.local`
+- Do not log JWTs, refresh tokens, or password reset tokens
+- Prefer `NEXT_PUBLIC_*` only for values safe to expose in the browser
+
+## Auth & authorization
+
+- Enforce auth in GraphQL context / `requireAuth`; do not trust client-only checks
+- Guest guards on the client are UX — server must still authorize mutations
+- Validate ownership/admin for delete/update of posts, comments, votes, quotes
+
+## Input & output
+
+- Validate mutations with explicit types / Zod (or schema args); reject unexpected fields
+- Sanitize URLs before navigation or rendering (`sanitizeUrl` / `toAppPostUrl`)
+- Escape or safely render user HTML; prefer text; never `dangerouslySetInnerHTML` with raw user content
+- Avoid open redirects: only push known app paths or sanitized post URLs
+
+## GraphQL / API
+
+- Do not expose internal errors to clients in production; log server-side
+- Keep CORS origins explicit (`CLIENT_URL`); credentials only for trusted origins
+- Rate-limit or guard expensive public queries when adding new unauthenticated endpoints
+
+## Dependencies & XSS
+
+- Prefer existing shadcn/lucide; avoid adding packages without need
+- Treat `postMessage` / third-party scripts as untrusted
+- Clipboard and share links must use same-origin app routes, not arbitrary strings from the API without normalization

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,0 +1,35 @@
+---
+description: Jest and Playwright testing locations and practices
+globs: quotevote-frontend/src/__tests__/**/*,quotevote-frontend/e2e/**/*,quotevote-frontend/**/*.{test,spec}.{ts,tsx},quotevote-backend/app/__tests__/**/*
+alwaysApply: false
+---
+
+# Testing
+
+## Locations
+
+| Kind | Where |
+| --- | --- |
+| Frontend unit | `quotevote-frontend/src/__tests__/` (`.test.ts` / `.test.tsx`) |
+| Frontend E2E | `quotevote-frontend/e2e/` (`.spec.ts`; helpers in `e2e/helpers/`) |
+| Backend unit/integration | `quotevote-backend/app/__tests__/` |
+
+## Commands
+
+```bash
+# Frontend
+pnpm test -- src/__tests__/path/to/file.test.tsx
+pnpm test:e2e featured-posts.spec.ts
+pnpm test:e2e --project=desktop featured-posts.spec.ts
+
+# Backend
+pnpm test
+```
+
+## Practices
+
+- Cover acceptance criteria with unit tests; add E2E for user-visible navigation/auth flows
+- Mock GraphQL narrowly (`featuredPosts` only) — use `route.fallback()` for other ops to avoid breaking the page
+- E2E guest flows: clear storage state (`cookies: []`, `origins: []`) when auth redirects would hide public UI
+- Prefer `getByRole` / `getByTestId` over brittle CSS selectors
+- Keep fixtures free of real secrets; use `.env.e2e.local` locally, never commit it

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ quotevote-backend/dockerfile
 session_state.md
 graphify-out/
 
-# Local Cursor IDE rules / agent config (machine-specific)
-.cursor/
+# Local Cursor IDE state (machine-specific). Shared project rules are tracked.
+.cursor/*
+!.cursor/rules/
+!.cursor/rules/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,11 @@ pnpm prisma:validate  # Validate Prisma schema
 
 CI runs `lint`, `type-check`, and `test` (Jest) for both frontend and backend on PRs to `main`/`develop`. Frontend E2E (Playwright) runs when the `E2E_AUTHOR_PASSWORD` repository secret is set.
 
+## Git
+
+- Never commit or push to `main` or `develop`. If you are on either branch, create a feature branch first (`fix/...`, `feat/...`, `issue#N`), then `git push -u origin HEAD`.
+- Shared Cursor rules live in `.cursor/rules/` (always-apply workflow, security, and code quality; globbed frontend/backend/testing).
+
 ## Architecture
 
 ### Frontend

--- a/quotevote-frontend/e2e/auth.spec.ts
+++ b/quotevote-frontend/e2e/auth.spec.ts
@@ -4,100 +4,25 @@ import { AUTHOR_PASSWORD, AUTHOR_USERNAME } from "./helpers/auth";
 import { registerAuthorUser } from "./helpers/api";
 
 /**
- * E2E-AUTH-006: Eyebrow Email Gateway — Registered User
+ * E2E-AUTH-006: Magic-link eyebrow is disabled (#460)
  *
- * A logged-out visitor enters an email belonging to an existing registered
- * account into the top-of-page "eyebrow" email gateway. The gateway should
- * recognize the account and offer magic link / password login options,
- * without logging the user in.
- *
- * Out of scope (covered by other issues): completing magic link login,
- * completing password login, invite request flow, pending invite state,
- * approved invite onboarding, password reset, email delivery.
+ * The top-of-page email gateway (magic link / invite-request banner) is
+ * unmounted pending a UX redesign. Username/password login is the supported
+ * path. This spec asserts the banner is not shown to logged-out visitors.
  */
 
-/**
- * Mocks the `/auth/check-email` endpoint so this spec doesn't depend on a
- * real seeded database account or a backend implementation that doesn't
- * exist yet (see e2e/fixtures/registeredUser.ts for context). Swap this for
- * a real seeded fixture once the backend route ships.
- */
-async function mockRegisteredEmailCheck(page: Page, email: string) {
-  // Match on path only — embedding '?'/'=' query-string characters directly
-  // in a glob pattern is fragile (Playwright parses the glob through `new
-  // URL()`, which has known quirks with '?'). Instead, match any request to
-  // the endpoint and verify the email query param inside the handler.
-  await page.route("**/auth/check-email**", async (route) => {
-    const url = new URL(route.request().url());
-    if (url.searchParams.get("email") !== email) {
-      await route.fallback();
-      return;
+test.describe("Magic-link eyebrow disabled (E2E-AUTH-006)", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("does not show the eyebrow email banner on logged-out pages", async ({ page }) => {
+    const loggedOutPaths = ["/", "/auths/login", "/dashboard/explore"];
+
+    for (const path of loggedOutPaths) {
+      await page.goto(path);
+      await expect(page.getByTestId("eyebrow-email-form")).toHaveCount(0);
+      await expect(page.getByTestId("eyebrow-email-input")).toHaveCount(0);
+      await expect(page.getByTestId("magic-link-login-option")).toHaveCount(0);
     }
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ status: "registered" }),
-    });
-  });
-}
-
-test.describe("Eyebrow Email Gateway: Registered User (E2E-AUTH-006)", () => {
-  test.beforeEach(async ({ page }) => {
-    await mockRegisteredEmailCheck(page, registeredUser.email);
-  });
-
-  test("recognizes a registered email and offers login options", async ({ page }) => {
-    const errorToastLocator = page.locator('[data-sonner-toast][data-type="error"]');
-
-    await page.goto("/");
-
-    // 1. Eyebrow email field is visible to logged-out visitors
-    const form = page.getByTestId("eyebrow-email-form");
-    const emailInput = page.getByTestId("eyebrow-email-input");
-    const submitButton = page.getByTestId("eyebrow-email-submit");
-
-    await expect(form).toBeVisible();
-    await expect(emailInput).toBeVisible();
-
-    // Submit is disabled before a valid email is entered
-    await expect(submitButton).toBeDisabled();
-
-    // 2. Email input accepts a registered email address
-    await emailInput.click();
-    await page.keyboard.type(registeredUser.email);
-
-    // 3. Submit button becomes available once the email is valid
-    await expect(submitButton).toBeEnabled();
-    await submitButton.click();
-
-    // 4. Registered-user state appears after submission
-    const registeredMessage = page.getByTestId("registered-user-message");
-    await expect(registeredMessage).toBeVisible();
-    await expect(registeredMessage).toContainText(/we recognize this email/i);
-
-    // 5. Magic link login option is visible
-    const magicLinkOption = page.getByTestId("magic-link-login-option");
-    await expect(magicLinkOption).toBeVisible();
-
-    // 6. Password login option is visible
-    const passwordOption = page.getByTestId("password-login-option");
-    await expect(passwordOption).toBeVisible();
-
-    // 7. User remains logged out — no session/auth cookie or token has
-    // been set, and the eyebrow gateway (which only renders for logged-out
-    // visitors) is still present underneath the modal.
-    const cookies = await page.context().cookies();
-    const hasAuthCookie = cookies.some((cookie) =>
-      /token|session|auth/i.test(cookie.name)
-    );
-    expect(hasAuthCookie).toBe(false);
-    await expect(form).toBeVisible();
-
-    // 8. No runtime error or generic error toast appears
-    await expect(errorToastLocator).toHaveCount(0);
-    const pageErrors: string[] = [];
-    page.on("pageerror", (error) => pageErrors.push(error.message));
-    expect(pageErrors).toHaveLength(0);
   });
 });
 

--- a/quotevote-frontend/e2e/fixtures/registeredUser.ts
+++ b/quotevote-frontend/e2e/fixtures/registeredUser.ts
@@ -1,14 +1,9 @@
 /**
  * Shared test fixtures for auth E2E specs.
  *
- * NOTE: The backend does not yet implement a real `/auth/check-email`
- * endpoint (see quotevote-frontend/src/app/components/Eyebrow/Eyebrow.tsx,
- * which calls it but has no corresponding server route). Until that route
- * exists, these specs mock the network response for `/auth/check-email`
- * rather than depending on a real seeded database record. Once the backend
- * implements the endpoint, `registeredUser.email` should be updated to point
- * at an actual seeded account and the mocked route in auth.spec.ts can be
- * removed.
+ * Prefer E2E_AUTHOR_* / E2E_REGISTERED_* env vars when a live backend is
+ * available. Fallbacks are for mocked GraphQL flows that do not need a
+ * real seeded account.
  */
 
 export const registeredUser = {

--- a/quotevote-frontend/src/app/components/Eyebrow/Eyebrow.tsx
+++ b/quotevote-frontend/src/app/components/Eyebrow/Eyebrow.tsx
@@ -1,5 +1,12 @@
 "use client";
 
+/**
+ * Top-of-page email gateway (magic link / invite request).
+ * Not mounted in the root layout — disabled pending UX redesign (issue #460).
+ * Username/password login is the supported path. Keep this module for a
+ * future reimplementation.
+ */
+
 import { useForm } from "react-hook-form";
 import { useAppStore } from "@/store";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/quotevote-frontend/src/app/layout.tsx
+++ b/quotevote-frontend/src/app/layout.tsx
@@ -8,7 +8,6 @@ import { AuthModalProvider } from "@/context/AuthModalContext";
 import { AuthGateDialog } from "@/components/AuthGateDialog";
 import { ThemeContextProvider } from "@/context/ThemeContext";
 import { cn } from "@/lib/utils";
-import { Eyebrow } from "./components/Eyebrow/Eyebrow";
 import "./globals.css";
 
 /**
@@ -69,7 +68,6 @@ export default function RootLayout({
           <ApolloProviderWrapper>
             <ThemeContextProvider>
               <AuthModalProvider>
-                <Eyebrow />
                 {children}
                 <AuthGateDialog />
                 <Toaster position="top-right" richColors closeButton />


### PR DESCRIPTION
## Summary
- Unmount the top-of-page magic-link / invite-request eyebrow so username/password login is the supported path ([#460](https://github.com/QuoteVote/quotevote-next/issues/460)). The component is kept for a future redesign.
- Track shared Cursor rules in `.cursor/rules/` (still ignore machine-specific `.cursor` state) and require agents to create a feature branch instead of committing or pushing to `main`/`develop`.
- Add a concise code-quality rule (DRY, practical SOLID, YAGNI, no premature optimization) alongside existing security, testing, and frontend/backend conventions.

## Test plan
- [ ] Logged-out homepage, login, and explore do not show the email eyebrow banner or an X-to-dismiss.
- [ ] `/auths/login` still presents username/password login.
- [ ] `pnpm lint && pnpm type-check` in `quotevote-frontend/`
- [ ] `pnpm test -- src/__tests__/components/Eyebrow.test.tsx`
- [ ] `pnpm test:e2e --project=desktop e2e/auth.spec.ts --grep E2E-AUTH-006`

Fixes #460

Made with [Cursor](https://cursor.com)