### PR TITLE
fix: Neo Brutalism discussion header ink bar

### DIFF
--- a/quotevote-frontend/src/app/globals.css
+++ b/quotevote-frontend/src/app/globals.css
@@ -694,7 +694,7 @@ body {
   color: var(--nb-ink) !important;
 }
 
-.neo-brutalism [role="separator"] {
+.neo-brutalism [role="separator"]:not([aria-valuenow]) {
   background-color: var(--nb-border-color) !important;
   height: 2px !important;
   margin: 0.25rem 0 !important;

--- a/quotevote-frontend/src/components/Post/MobileDiscussionSplit.tsx
+++ b/quotevote-frontend/src/components/Post/MobileDiscussionSplit.tsx
@@ -154,7 +154,7 @@ export default function MobileDiscussionSplit({
             aria-valuenow={quotePercent}
             aria-label="Resize quote and discussion panes"
             data-testid="discussion-divider"
-            className="flex cursor-row-resize touch-none select-none flex-col items-center pt-2 pb-1"
+            className="flex cursor-row-resize touch-none select-none flex-col items-center"
             onPointerDown={handlePointerDown}
             onPointerMove={handlePointerMove}
             onPointerUp={handlePointerUp}


### PR DESCRIPTION
## Summary
- Stops Neo Brutalism from treating the mobile discussion resize handle as a menu separator, which drew a full-width black line through the yellow Discussion header ([#459](https://github.com/QuoteVote/quotevote-next/issues/459)).
- Tightens grabber padding so the yellow header reads as one block.

## Test plan
- [ ] Enable Neo Brutalism, open a post on portrait mobile, open Discussion
- [ ] Yellow `Discussion · N` header is a single block (no black line cutting through it)
- [ ] Divider still drags to resize Quote / Discussion panes
- [ ] Default (non–Neo Brutalism) theme is unchanged
- [ ] Dropdown/menu separators still render as ink rules under Neo Brutalism


Made with [Cursor](https://cursor.com)