### PR TITLE
feat(nav): replace mobile Settings with Messages (#465)

### DIFF
--- a/quotevote-frontend/e2e/chat.spec.ts
+++ b/quotevote-frontend/e2e/chat.spec.ts
@@ -316,10 +316,10 @@ test.describe('E2E-CHAT-008 Chat Search', () => {
     if (isMobile) {
       console.log('TEST PROGRESS: Mobile navigation to Messages');
       await expect(page.locator('[data-testid="chat-page"]').filter({ visible: true })).toHaveCount(0);
-      // Click Account/profile menu button in mobile bottom nav
-      await page.locator('button[aria-label="Account menu"]').filter({ visible: true }).click({ force: true });
-      // Click "Messages" option in the dropdown menu
-      await page.locator('[role="menuitem"]:has-text("Messages")').click({ force: true });
+      await page
+        .getByRole('navigation', { name: 'Mobile navigation' })
+        .getByRole('button', { name: 'Messages' })
+        .click({ force: true });
     }
 
     // Verify chat page loads

--- a/quotevote-frontend/src/app/dashboard/layout.tsx
+++ b/quotevote-frontend/src/app/dashboard/layout.tsx
@@ -15,7 +15,6 @@ import {
   ShieldCheck,
   LogOut,
   ChevronDown,
-  Settings,
   ArrowLeft,
   Share2,
 } from 'lucide-react';
@@ -119,6 +118,7 @@ export default function DashboardLayout({
   const router = useRouter();
   const { openAuthModal } = useAuthModal();
   const setSelectedPage = useAppStore((s) => s.setSelectedPage);
+  const chatOpen = useAppStore((s) => s.chat.open);
   const setChatOpen = useAppStore((s) => s.setChatOpen);
   const user = useAppStore((s) => s.user.data);
   const logout = useAppStore((s) => s.logout);
@@ -433,18 +433,26 @@ export default function DashboardLayout({
           <span className="text-[10px] font-semibold">Home</span>
         </Link>
 
-        {/* Settings */}
-        <Link
-          href="/dashboard/settings"
+        {/* Messages */}
+        <button
+          type="button"
+          onClick={() => requireAuthForAction(() => setChatOpen(true))}
           className={cn(
-            'flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors duration-150',
-            isActive('/dashboard/settings') ? 'text-[#52b274]' : 'text-muted-foreground'
+            'relative flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors duration-150 border-0 bg-transparent cursor-pointer',
+            chatOpen ? 'text-[#52b274]' : 'text-muted-foreground'
           )}
-          aria-label="Settings"
+          aria-label="Messages"
         >
-          <Settings className="size-[22px]" />
-          <span className="text-[10px] font-semibold">Settings</span>
-        </Link>
+          <div className="relative">
+            <MessageSquare className="size-[22px]" fill={chatOpen ? 'currentColor' : 'none'} />
+            {unreadChat > 0 && (
+              <span className="absolute -top-1 -right-2 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full bg-red-500 text-white text-[8px] font-bold leading-none shadow ring-1 ring-card">
+                {unreadChat > 9 ? '9+' : unreadChat}
+              </span>
+            )}
+          </div>
+          <span className="text-[10px] font-semibold">Messages</span>
+        </button>
 
         {/* Create — floating green circle */}
         <button
@@ -497,22 +505,15 @@ export default function DashboardLayout({
                 aria-label="Account menu"
                 data-testid="user-profile-menu"
               >
-                <div className="relative">
-                  <DisplayAvatar
-                    avatar={user?.avatar as string | Record<string, unknown> | undefined}
-                    username={avatarSeed}
-                    size={24}
-                    className={cn(
-                      'size-6 transition-all',
-                      isActive('/dashboard/profile') ? 'ring-2 ring-[#52b274] ring-offset-1' : 'ring-1 ring-border'
-                    )}
-                  />
-                  {unreadChat > 0 && (
-                    <span className="absolute -top-0.5 -right-1 flex items-center justify-center min-w-[12px] h-[12px] px-0.5 rounded-full bg-[#52b274] text-white text-[7px] font-bold leading-none shadow ring-1 ring-card">
-                      {unreadChat > 9 ? '9+' : unreadChat}
-                    </span>
+                <DisplayAvatar
+                  avatar={user?.avatar as string | Record<string, unknown> | undefined}
+                  username={avatarSeed}
+                  size={24}
+                  className={cn(
+                    'size-6 transition-all',
+                    isActive('/dashboard/profile') ? 'ring-2 ring-[#52b274] ring-offset-1' : 'ring-1 ring-border'
                   )}
-                </div>
+                />
                 <span className="text-[10px] font-semibold">Profile</span>
               </button>
             </DropdownMenuTrigger>


### PR DESCRIPTION
## Summary
- Swap the mobile bottom-nav **Settings** item for **Messages**, keeping it between Home and Create.
- Opening Messages uses the existing chat sheet, shows the active state while chat is open, and moves the unread badge onto that tab.
- Settings stays available from the Profile menu (**Settings & Privacy**).

Closes #465

## Test plan
- [ ] On a mobile viewport, confirm the bar is Home · Messages · Create · Activity · Profile
- [ ] Tapping Messages opens chat and highlights the Messages tab
- [ ] Unread chat count appears on Messages, not the Profile avatar
- [ ] Profile menu still has Settings & Privacy → `/dashboard/settings`
- [ ] Desktop nav is unchanged
- [ ] `pnpm test:e2e chat.spec.ts` from `quotevote-frontend/` (mobile project)


Made with [Cursor](https://cursor.com)