### PR TITLE
fix: enlarge mobile discussion resize hit area

### DIFF
--- a/quotevote-frontend/src/__tests__/components/Post/MobileDiscussionSplit.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Post/MobileDiscussionSplit.test.tsx
@@ -1,6 +1,23 @@
-import { render, screen, fireEvent } from "@/__tests__/utils/test-utils";
+import { createEvent, fireEvent, render, screen } from "@/__tests__/utils/test-utils";
 import MobileDiscussionSplit from "@/components/Post/MobileDiscussionSplit";
 import { DEFAULT_QUOTE_RATIO, SPLIT_RATIO_STORAGE_KEY } from "@/types/discussionSplit";
+
+function firePointer(
+  element: Element,
+  type: "pointerDown" | "pointerMove",
+  clientY: number
+) {
+  const event = createEvent[type](element, { bubbles: true, pointerId: 1 });
+  Object.assign(event, { clientY, pointerId: 1, pointerType: "touch" });
+  fireEvent(element, event);
+}
+
+function stubSplitHeight(split: HTMLElement, height = 1000) {
+  Object.defineProperty(split, "clientHeight", {
+    configurable: true,
+    get: () => height,
+  });
+}
 
 describe("MobileDiscussionSplit", () => {
   it("shows a compact Discussion bar when collapsed", () => {
@@ -116,5 +133,60 @@ describe("MobileDiscussionSplit", () => {
 
     expect(screen.getByText("Quote body")).toBeInTheDocument();
     expect(screen.getByText("Discussion body")).toBeInTheDocument();
+  });
+
+  it("resizes when dragging the discussion header, not only the 4px pill", () => {
+    render(
+      <MobileDiscussionSplit
+        open
+        onOpenChange={jest.fn()}
+        discussionCount={2}
+        quotePane={<div>Quote body</div>}
+      >
+        <div>Discussion body</div>
+      </MobileDiscussionSplit>
+    );
+
+    const split = screen.getByTestId("discussion-split-view");
+    stubSplitHeight(split);
+
+    firePointer(screen.getByText("Discussion · 2"), "pointerDown", 400);
+    firePointer(screen.getByTestId("discussion-resize-handle"), "pointerMove", 500);
+
+    const quotePane = split.querySelector(
+      '[data-post-detail-pane="content"]'
+    ) as HTMLElement;
+    expect(quotePane).toHaveStyle({ height: "55%" });
+  });
+
+  it("does not start a resize from the collapse button", () => {
+    const onOpenChange = jest.fn();
+    render(
+      <MobileDiscussionSplit
+        open
+        onOpenChange={onOpenChange}
+        discussionCount={2}
+        quotePane={<div>Quote body</div>}
+      >
+        <div>Discussion body</div>
+      </MobileDiscussionSplit>
+    );
+
+    const split = screen.getByTestId("discussion-split-view");
+    stubSplitHeight(split);
+    const collapse = screen.getByLabelText("Collapse discussion");
+
+    firePointer(collapse, "pointerDown", 400);
+    firePointer(screen.getByTestId("discussion-resize-handle"), "pointerMove", 500);
+
+    const quotePane = split.querySelector(
+      '[data-post-detail-pane="content"]'
+    ) as HTMLElement;
+    expect(quotePane).toHaveStyle({
+      height: `${Math.round(DEFAULT_QUOTE_RATIO * 100)}%`,
+    });
+
+    fireEvent.click(collapse);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/quotevote-frontend/src/components/Post/MobileDiscussionSplit.tsx
+++ b/quotevote-frontend/src/components/Post/MobileDiscussionSplit.tsx
@@ -144,7 +144,12 @@ export default function MobileDiscussionSplit({
       >
         <div
           data-discussion-header
-          className="flex shrink-0 flex-col bg-card border-b border-border/60"
+          data-testid="discussion-resize-handle"
+          className="flex shrink-0 cursor-row-resize touch-none select-none flex-col bg-card border-b border-border/60"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
         >
           <div
             role="separator"
@@ -154,20 +159,17 @@ export default function MobileDiscussionSplit({
             aria-valuenow={quotePercent}
             aria-label="Resize quote and discussion panes"
             data-testid="discussion-divider"
-            className="flex cursor-row-resize touch-none select-none flex-col items-center"
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerUp}
-            onPointerCancel={handlePointerUp}
+            className="flex flex-col items-center"
           >
-            <div className="w-10 h-1 rounded-full bg-muted-foreground/30" />
+            <div className="mt-1 w-10 h-1 rounded-full bg-muted-foreground/30 [.neo-brutalism_&]:mt-0" />
           </div>
           <div className="flex items-center gap-2 px-4 pb-2">
             <span className="text-sm font-semibold text-foreground">{title}</span>
             <button
               type="button"
-              className="ml-auto inline-flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-muted/60"
+              className="ml-auto inline-flex size-8 cursor-pointer items-center justify-center rounded-full text-muted-foreground hover:bg-muted/60"
               aria-label="Collapse discussion"
+              onPointerDown={(e) => e.stopPropagation()}
               onClick={handleCollapse}
             >
               <ChevronUp className="size-4" />
@@ -190,7 +192,7 @@ export default function MobileDiscussionSplit({
           )}
           style={{ height: DISCUSSION_BAR_HEIGHT_PX }}
         >
-          {/* Keep spacing aligned with the expanded divider area. We hide it in closed mode so it doesn't look draggable. */}
+          {/* Hidden spacer so the collapsed bar stays 56px without looking draggable. */}
           <div className="w-10 h-1 rounded-full bg-muted-foreground/30 mt-1.5 mb-1 opacity-0" />
           <div className="flex w-full items-center gap-2 px-4 pb-2">
             <span className="text-sm font-semibold text-foreground">{title}</span>


### PR DESCRIPTION
## Summary
- Follow-up to #462: the grabber pill was left at 4px tall, which is too small to drag on a phone.
- The whole discussion header is now the resize handle (pill stays a visual cue). The collapse chevron is excluded so it still closes instead of starting a drag.
- Default theme keeps a little top margin on the pill; Neo Brutalism drops it so the yellow header stays one tight block.

## Test plan
- [ ] Open a post on portrait mobile, expand Discussion
- [ ] Drag from the **Discussion · N** title (not just the pill) and confirm the Quote / Discussion split resizes
- [ ] Collapse chevron still closes Discussion and does not start a drag
- [ ] Default theme: small gap above the pill
- [ ] Neo Brutalism: no extra gap above the pill; yellow header is still one block (no ink bar)


Made with [Cursor](https://cursor.com)