### PR TITLE
fix(rc1-028): blue chrome for profile POSTED cards (#380)

### DIFF
--- a/quotevote-frontend/src/__tests__/components/Activity/ActivityCard.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Activity/ActivityCard.test.tsx
@@ -26,22 +26,42 @@ describe('ActivityCard', () => {
     expect(screen.getByText(/Test activity content/i)).toBeInTheDocument()
   })
 
-  it('renders default background color when cardColor is not provided', () => {
-    const { container } = render(
-      <ActivityCard {...defaultProps} />
-    )
+  // RC1-028 / #380: POSTED activity cards share feed PostCard blue chrome.
+  describe('Card Chrome (RC1-028 / #380)', () => {
+    it('applies standard blue border chrome for POSTED cards', () => {
+      const { container } = render(<ActivityCard {...defaultProps} />)
 
-    const card = container.querySelector('[data-slot="card"]')
-    expect(card).toHaveStyle({ backgroundColor: '#FFFFFF' })
-  })
+      const card = container.querySelector('[data-slot="card"]') as HTMLElement
+      expect(card).toHaveAttribute('data-chrome', 'standard-blue')
+      expect(card.style.border).toContain('#56b3ff')
+      expect(card.style.borderBottom).toContain('#56b3ff')
+      // Fill stays theme/card — not a vote-colored background
+      expect(card.style.backgroundColor).toBe('')
+    })
 
-  it('renders with custom cardColor when provided', () => {
-    const { container } = render(
-      <ActivityCard {...defaultProps} cardColor="#52b274" />
-    )
+    it('keeps activity fill colors for non-POSTED cards', () => {
+      const { container } = render(
+        <ActivityCard
+          {...defaultProps}
+          activityType="UPVOTED"
+          cardColor="#52b274"
+        />
+      )
 
-    const card = container.querySelector('[data-slot="card"]')
-    expect(card).toHaveStyle({ backgroundColor: '#52b274' })
+      const card = container.querySelector('[data-slot="card"]') as HTMLElement
+      expect(card).toHaveAttribute('data-chrome', 'activity')
+      expect(card).toHaveStyle({ backgroundColor: '#52b274' })
+      expect(card.style.border).not.toContain('#56b3ff')
+    })
+
+    it('falls back to white fill for non-POSTED cards without cardColor', () => {
+      const { container } = render(
+        <ActivityCard {...defaultProps} activityType="COMMENTED" />
+      )
+
+      const card = container.querySelector('[data-slot="card"]')
+      expect(card).toHaveStyle({ backgroundColor: '#FFFFFF' })
+    })
   })
 
 

--- a/quotevote-frontend/src/__tests__/utils/postCardTheme.test.ts
+++ b/quotevote-frontend/src/__tests__/utils/postCardTheme.test.ts
@@ -1,0 +1,19 @@
+import {
+  STANDARD_POST_CARD_THEME,
+  isPostedActivityType,
+} from "@/lib/constants/postCardTheme";
+
+describe("postCardTheme", () => {
+  it("exposes the shared blue chrome used by feed and profile POSTED cards", () => {
+    expect(STANDARD_POST_CARD_THEME.borderColor).toBe("#56b3ff");
+  });
+
+  it("recognizes POSTED activity aliases", () => {
+    expect(isPostedActivityType("POSTED")).toBe(true);
+    expect(isPostedActivityType("posted")).toBe(true);
+    expect(isPostedActivityType("POST")).toBe(true);
+    expect(isPostedActivityType("UPVOTED")).toBe(false);
+    expect(isPostedActivityType("")).toBe(false);
+    expect(isPostedActivityType(undefined)).toBe(false);
+  });
+});

--- a/quotevote-frontend/src/components/Activity/PaginatedActivityList.tsx
+++ b/quotevote-frontend/src/components/Activity/PaginatedActivityList.tsx
@@ -20,6 +20,8 @@ import { useAppStore } from '@/store'
 import useGuestGuard from '@/hooks/useGuestGuard'
 import { useRouter } from 'next/navigation'
 import { toAppPostUrl } from '@/lib/utils/sanitizeUrl'
+import { isPostedActivityType } from '@/lib/constants/postCardTheme'
+import { cn } from '@/lib/utils'
 import type { PaginatedActivityListProps, ActivityEntity } from '@/types/activity'
 
 function LoadActivityCard({
@@ -128,9 +130,15 @@ function LoadActivityCard({
     router.push(toAppPostUrl(url.replace(/\?/g, '')))
   }
 
+  // POSTED cards own blue PostCard chrome (#380); skip competing wrapper border.
+  const isPosted = isPostedActivityType(type)
+
   return (
     <div
-      className="rounded-lg shadow-lg border mb-2 w-full max-w-full overflow-x-hidden box-border"
+      className={cn(
+        'mb-2 w-full max-w-full overflow-x-hidden box-border',
+        !isPosted && 'rounded-lg shadow-lg border'
+      )}
       style={{ borderRadius: 7 }}
     >
       <ActivityCard

--- a/quotevote-frontend/src/components/Post/PostCard.tsx
+++ b/quotevote-frontend/src/components/Post/PostCard.tsx
@@ -17,15 +17,12 @@ import useGuestGuard from '@/hooks/useGuestGuard'
 import HighlightText from '@/components/HighlightText/HighlightText'
 import { DisplayAvatar } from '@/components/DisplayAvatar'
 import type { PostCardProps } from '@/types/post'
+import { STANDARD_POST_CARD_THEME } from '@/lib/constants/postCardTheme'
 
 // Standard post cards are always blue. Vote state is communicated by the
 // up/down controls, not the card chrome. Green/red belong to profile activity
 // cards (see ActivityCard + getCardBackgroundColor).
-const CARD_THEME = {
-  borderColor: '#56b3ff',
-  shadow: '4px 4px 0px rgba(86,179,255,0.45)',
-  hoverShadow: '7px 7px 0px rgba(86,179,255,0.55)',
-} as const
+const CARD_THEME = STANDARD_POST_CARD_THEME
 
 type VoteStateMutationPost = {
   _id: string

--- a/quotevote-frontend/src/components/ui/ActivityCard.tsx
+++ b/quotevote-frontend/src/components/ui/ActivityCard.tsx
@@ -8,6 +8,10 @@ import { Card, CardContent, CardFooter } from '@/components/ui/card'
 import { DisplayAvatar } from '@/components/DisplayAvatar'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import {
+  STANDARD_POST_CARD_THEME,
+  isPostedActivityType,
+} from '@/lib/constants/postCardTheme'
 import type { ActivityCardProps } from '@/types/activity'
 
 function ActivityHeader({
@@ -181,6 +185,9 @@ export const ActivityCard = memo(function ActivityCard({
   // name prop is kept for API compatibility but username is used for display
   void _name
   const interactions: unknown[] = []
+  // RC1-028 / #380: POSTED cards use the same blue chrome as feed PostCards.
+  // Colored fills stay for voted/commented/quoted activity only.
+  const isPosted = isPostedActivityType(activityType)
 
   if (!isEmpty(comments)) {
     interactions.push(...comments)
@@ -201,14 +208,42 @@ export const ActivityCard = memo(function ActivityCard({
   // ponytail: apply cardColor directly on Card style for profile activity context
   return (
     <Card
+      data-chrome={isPosted ? 'standard-blue' : 'activity'}
       className={cn(
-        'min-w-[350px] min-h-[200px] rounded-md cursor-pointer transition-shadow hover:shadow-md text-neutral-900',
-        'sm:max-w-full sm:min-w-full sm:w-full'
+        'min-w-[350px] min-h-[200px] cursor-pointer text-neutral-900',
+        'sm:max-w-full sm:min-w-full sm:w-full',
+        isPosted
+          ? 'rounded-[7px] overflow-hidden bg-card border-0 shadow-none'
+          : 'rounded-md border transition-shadow hover:shadow-md'
       )}
       style={{
-        backgroundColor: cardColor || '#FFFFFF',
+        backgroundColor: isPosted ? undefined : cardColor || '#FFFFFF',
         width: typeof width === 'number' ? `${width}px` : '100%',
+        ...(isPosted
+          ? {
+              border: `2px solid ${STANDARD_POST_CARD_THEME.borderColor}`,
+              borderBottom: `8px solid ${STANDARD_POST_CARD_THEME.borderColor}`,
+              boxShadow: STANDARD_POST_CARD_THEME.shadow,
+              transition: 'box-shadow 0.15s ease, transform 0.15s ease',
+            }
+          : {}),
       }}
+      onMouseEnter={
+        isPosted
+          ? (e) => {
+              e.currentTarget.style.boxShadow = STANDARD_POST_CARD_THEME.hoverShadow
+              e.currentTarget.style.transform = 'translate(-2px, -2px)'
+            }
+          : undefined
+      }
+      onMouseLeave={
+        isPosted
+          ? (e) => {
+              e.currentTarget.style.boxShadow = STANDARD_POST_CARD_THEME.shadow
+              e.currentTarget.style.transform = ''
+            }
+          : undefined
+      }
       onClick={onCardClick}
     >
       <CardContent className="pt-1">

--- a/quotevote-frontend/src/lib/constants/postCardTheme.ts
+++ b/quotevote-frontend/src/lib/constants/postCardTheme.ts
@@ -1,0 +1,16 @@
+/**
+ * Standard post card chrome (RC1-028 / #380).
+ * Explore/Home feed PostCards and profile POSTED activity cards share this
+ * blue border/shadow. Vote/activity sentiment must not change this chrome —
+ * green/red/etc. belong on profile activity fills and vote controls only.
+ */
+export const STANDARD_POST_CARD_THEME = {
+  borderColor: "#56b3ff",
+  shadow: "4px 4px 0px rgba(86,179,255,0.45)",
+  hoverShadow: "7px 7px 0px rgba(86,179,255,0.55)",
+} as const;
+
+export function isPostedActivityType(activityType?: string | null): boolean {
+  const normalized = activityType?.toUpperCase() ?? "";
+  return normalized === "POSTED" || normalized === "POST";
+}

--- a/quotevote-frontend/src/lib/utils/getCardBackgroundColor.tsx
+++ b/quotevote-frontend/src/lib/utils/getCardBackgroundColor.tsx
@@ -1,16 +1,18 @@
 import { ActivityContentType } from '@/types/store'
 
 /**
- * Activity Color Design System (RC1-008, RC1-009)
+ * Activity Color Design System (RC1-008, RC1-009, RC1-028 / #380)
  *
- * Mappings for profile activity cards and activity controls:
- * - POSTED: #FFFFFF (White)
+ * Fill colors for profile activity cards and activity controls:
+ * - POSTED: #FFFFFF (White fill; blue border chrome comes from ActivityCard)
  * - COMMENTED: #FDD835 (Yellow)
  * - UPVOTED / UP: #52b274 (Green)
  * - DOWNVOTED / DOWN: #FF6060 (Red)
  * - VOTED: #52b274 (Default green for generic vote activity)
  * - LIKED / HEARTED: #F16C99 (Pink)
  * - QUOTED: #E36DFA (Purple)
+ *
+ * Explore/Home feed PostCards never use these fills for chrome — they stay blue.
  */
 export const ACTIVITY_COLOR_MAP = {
   POSTED: '#FFFFFF',


### PR DESCRIPTION
## Summary
- Addresses the outstanding [#380](https://github.com/QuoteVote/quotevote-next/issues/380) follow-up: profile Posts were white without the Explore blue highlight.
- Share `STANDARD_POST_CARD_THEME` (`#56b3ff`) between feed `PostCard` and profile **POSTED** `ActivityCard`.
- Voted / Commented / Quoted keep activity fill colors (green / yellow / purple); only POSTED gets feed-style blue chrome.

## Test plan
- [ ] Open Explore/Home — post cards remain blue regardless of vote state
- [ ] Open a profile → **Posts** (or All with posted items) — cards show blue border/thick bottom edge like Explore
- [ ] Profile **Voted** / **Commented** / **Quoted** — still use activity-specific fill colors (not blue chrome)
- [ ] Unit: `pnpm test -- src/__tests__/components/Activity/ActivityCard.test.tsx src/__tests__/utils/postCardTheme.test.ts src/__tests__/components/Post/PostCard.test.tsx`

Closes #380

Made with [Cursor](https://cursor.com)