### PR TITLE
fix(directory): keep mobile guest nav and filters pinned while scrolling

### DIFF
--- a/quotevote-frontend/src/__tests__/app/page.test.tsx
+++ b/quotevote-frontend/src/__tests__/app/page.test.tsx
@@ -80,6 +80,23 @@ describe('Public directory (`/`)', () => {
     expect(screen.getByTestId('filter-date')).toBeInTheDocument()
   })
 
+  it('keeps nav, search, and filters pinned above the scrolling post list on mobile', () => {
+    renderDirectory()
+    const chrome = screen.getByTestId('directory-sticky-chrome')
+    const scroll = screen.getByTestId('directory-scroll')
+    expect(chrome).toContainElement(screen.getByRole('navigation', { name: 'Main navigation' }))
+    expect(chrome).toContainElement(screen.getByTestId('directory-toolbar'))
+    expect(chrome).toHaveClass('shrink-0')
+    expect(screen.getByTestId('public-directory')).toHaveClass(
+      'h-dvh',
+      'overflow-hidden',
+      'md:h-auto',
+      'md:overflow-visible'
+    )
+    expect(scroll).toHaveClass('overflow-y-auto', 'md:overflow-visible')
+    expect(scroll).not.toContainElement(screen.getByTestId('directory-toolbar'))
+  })
+
   it('does not redirect signed-in users since root is home', () => {
     useAppStore.getState().setUserData({
       _id: 'user-1',

--- a/quotevote-frontend/src/app/components/PublicDirectory/DirectoryHeader.tsx
+++ b/quotevote-frontend/src/app/components/PublicDirectory/DirectoryHeader.tsx
@@ -22,7 +22,7 @@ export function DirectoryHeader(): ReactElement {
   return (
     <>
       <header
-        className="sticky top-0 z-50 w-full max-w-[100vw] overflow-x-hidden bg-gradient-to-br from-white to-gray-50 border-b-2 border-transparent bg-clip-padding"
+        className="md:sticky md:top-0 md:z-50 w-full max-w-[100vw] min-w-0 bg-gradient-to-br from-white to-gray-50 border-b-2 border-transparent bg-clip-padding"
         role="navigation"
         aria-label="Main navigation"
         style={{ borderImage: 'linear-gradient(90deg, #2AE6B2, #27C4E1, #178BE1) 1' }}

--- a/quotevote-frontend/src/app/components/PublicDirectory/DirectoryToolbar.tsx
+++ b/quotevote-frontend/src/app/components/PublicDirectory/DirectoryToolbar.tsx
@@ -91,7 +91,7 @@ export function DirectoryToolbar(): ReactElement {
   return (
     <div
       data-testid="directory-toolbar"
-      className="w-full max-w-2xl mx-auto px-4 pt-3 pb-2 space-y-3 min-w-0"
+      className="w-full max-w-2xl mx-auto px-4 pt-3 pb-2 space-y-3 min-w-0 bg-[#eef4f9]"
     >
       <form
         role="search"

--- a/quotevote-frontend/src/app/components/PublicDirectory/PublicDirectoryContent.tsx
+++ b/quotevote-frontend/src/app/components/PublicDirectory/PublicDirectoryContent.tsx
@@ -8,6 +8,10 @@ import { DirectoryToolbar } from './DirectoryToolbar'
 
 /**
  * Public post directory shown at `/` (#454).
+ * Mobile: nav + search + filters stay pinned while posts scroll (#487).
+ * `position: sticky` cannot be used here — `html`/`body` set `overflow-x: hidden`
+ * (#454), which creates a scroll container and prevents sticky from activating.
+ * Desktop: page scroll is unchanged; the toolbar is not pinned.
  */
 export function PublicDirectoryContent(): ReactElement {
   const searchParams = useSearchParams()
@@ -23,12 +27,21 @@ export function PublicDirectoryContent(): ReactElement {
   return (
     <div
       data-testid="public-directory"
-      className="min-h-screen w-full max-w-[100vw] overflow-x-hidden flex flex-col"
+      className="h-dvh overflow-hidden md:h-auto md:min-h-screen md:overflow-visible w-full max-w-[100vw] min-w-0 flex flex-col"
       style={{ background: '#eef4f9' }}
     >
-      <DirectoryHeader />
-      <main className="flex-1 w-full min-w-0 overflow-x-hidden">
+      <div
+        data-testid="directory-sticky-chrome"
+        className="shrink-0 z-50"
+        style={{ background: '#eef4f9' }}
+      >
+        <DirectoryHeader />
         <DirectoryToolbar />
+      </div>
+      <main
+        data-testid="directory-scroll"
+        className="flex-1 min-h-0 w-full overflow-y-auto md:overflow-visible"
+      >
         <div className="w-full max-w-2xl mx-auto min-w-0">
           <PaginatedPostsList
             defaultPageSize={20}


### PR DESCRIPTION
## Summary
- Pin the public directory nav, search, and filter row on mobile so they stay visible while posts scroll underneath ([#487](https://github.com/QuoteVote/quotevote-next/issues/487)).
- Use a mobile scroll shell instead of `position: sticky`, which cannot activate because `html`/`body` set `overflow-x: hidden`.
- Leave desktop page scrolling unchanged so the toolbar is not pinned.

## Test plan
- [ ] Open `/` as a guest on a mobile viewport (~390px).
- [ ] Confirm visual order is still: top nav, search, filters, then posts.
- [ ] Scroll the post list and confirm nav, search, and filters stay at the top with no overlap or extra gap.
- [ ] Open Filters / Tag / Date popovers after scrolling and confirm they still work.
- [ ] On desktop, confirm the toolbar still scrolls away with the page.
- [ ] `pnpm lint && pnpm type-check && pnpm test -- src/__tests__/app/page.test.tsx` in `quotevote-frontend/`.


Made with [Cursor](https://cursor.com)