### PR TITLE
fix(directory): pin search and filters for signed-in mobile users

### DIFF
--- a/quotevote-frontend/src/__tests__/app/page.test.tsx
+++ b/quotevote-frontend/src/__tests__/app/page.test.tsx
@@ -5,8 +5,10 @@
  * and no marketing landing sections.
  */
 
+import { type ReactNode } from 'react'
 import { render, screen } from '../utils/test-utils'
 import { PublicDirectoryContent } from '@/app/components/PublicDirectory/PublicDirectoryContent'
+import { AuthAwareHome } from '@/app/components/AuthAwareHome'
 import { useAppStore } from '@/store'
 
 const mockPush = jest.fn()
@@ -35,6 +37,12 @@ jest.mock('@apollo/client/react', () => ({
 
 jest.mock('@/hooks/useDebounce', () => ({
   useDebounce: <T,>(value: T) => value,
+}))
+
+jest.mock('@/components/DashboardShell', () => ({
+  DashboardShell: ({ children }: { children: ReactNode }) => (
+    <div data-testid="dashboard-shell">{children}</div>
+  ),
 }))
 
 function renderDirectory() {
@@ -105,5 +113,33 @@ describe('Public directory (`/`)', () => {
     })
     renderDirectory()
     expect(mockPush).not.toHaveBeenCalled()
+  })
+})
+
+describe('Authenticated directory (`/`)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useAppStore.getState().setUserData({
+      _id: 'user-1',
+      username: 'tester',
+      name: 'Tester',
+    })
+  })
+
+  it('keeps search and filters pinned above the scrolling post list on mobile', () => {
+    render(<AuthAwareHome />)
+    const chrome = screen.getByTestId('directory-sticky-chrome')
+    const scroll = screen.getByTestId('directory-scroll')
+    expect(screen.getByTestId('authenticated-directory')).toBeInTheDocument()
+    expect(chrome).toContainElement(screen.getByTestId('directory-toolbar'))
+    expect(chrome).toHaveClass('shrink-0')
+    expect(screen.getByTestId('authenticated-directory')).toHaveClass(
+      'h-full',
+      'overflow-hidden',
+      'md:h-auto',
+      'md:overflow-visible'
+    )
+    expect(scroll).toHaveClass('overflow-y-auto', 'md:overflow-visible')
+    expect(scroll).not.toContainElement(screen.getByTestId('directory-toolbar'))
   })
 })

--- a/quotevote-frontend/src/app/components/AuthAwareHome.tsx
+++ b/quotevote-frontend/src/app/components/AuthAwareHome.tsx
@@ -19,6 +19,12 @@ export function AuthAwareHome(): ReactElement {
   return <AuthenticatedFeed />
 }
 
+/**
+ * Signed-in home feed. Mobile: search + filters stay pinned while posts scroll
+ * (same contract as the guest directory, #487 / #488). DashboardShell already
+ * owns the fixed nav, so only the toolbar sits in the non-scrolling chrome.
+ * Desktop: page scroll is unchanged; the toolbar is not pinned.
+ */
 function AuthenticatedFeed(): ReactElement {
   const searchParams = useSearchParams()
 
@@ -32,19 +38,31 @@ function AuthenticatedFeed(): ReactElement {
 
   return (
     <DashboardShell>
-      <DirectoryToolbar />
-      <div className="w-full max-w-2xl mx-auto min-w-0">
-        <PaginatedPostsList
-          defaultPageSize={20}
-          maxVisiblePages={5}
-          searchKey={q}
-          startDateRange={from || undefined}
-          endDateRange={to || undefined}
-          sortOrder={sortOrder}
-          interactions={interactions}
-          groupId={groupId}
-          compact
-        />
+      <div
+        data-testid="authenticated-directory"
+        className="flex h-full min-h-0 flex-col overflow-hidden md:h-auto md:overflow-visible"
+      >
+        <div data-testid="directory-sticky-chrome" className="z-40 shrink-0 bg-background">
+          <DirectoryToolbar />
+        </div>
+        <div
+          data-testid="directory-scroll"
+          className="min-h-0 w-full flex-1 overflow-y-auto md:overflow-visible"
+        >
+          <div className="mx-auto w-full min-w-0 max-w-2xl">
+            <PaginatedPostsList
+              defaultPageSize={20}
+              maxVisiblePages={5}
+              searchKey={q}
+              startDateRange={from || undefined}
+              endDateRange={to || undefined}
+              sortOrder={sortOrder}
+              interactions={interactions}
+              groupId={groupId}
+              compact
+            />
+          </div>
+        </div>
       </div>
     </DashboardShell>
   )

--- a/quotevote-frontend/src/app/components/PublicDirectory/DirectoryToolbar.tsx
+++ b/quotevote-frontend/src/app/components/PublicDirectory/DirectoryToolbar.tsx
@@ -91,7 +91,7 @@ export function DirectoryToolbar(): ReactElement {
   return (
     <div
       data-testid="directory-toolbar"
-      className="w-full max-w-2xl mx-auto px-4 pt-3 pb-2 space-y-3 min-w-0 bg-[#eef4f9]"
+      className="w-full max-w-2xl mx-auto px-4 pt-3 pb-2 space-y-3 min-w-0 bg-background"
     >
       <form
         role="search"

--- a/quotevote-frontend/src/app/components/PublicDirectory/PublicDirectoryContent.tsx
+++ b/quotevote-frontend/src/app/components/PublicDirectory/PublicDirectoryContent.tsx
@@ -27,14 +27,9 @@ export function PublicDirectoryContent(): ReactElement {
   return (
     <div
       data-testid="public-directory"
-      className="h-dvh overflow-hidden md:h-auto md:min-h-screen md:overflow-visible w-full max-w-[100vw] min-w-0 flex flex-col"
-      style={{ background: '#eef4f9' }}
+      className="bg-background h-dvh overflow-hidden md:h-auto md:min-h-screen md:overflow-visible w-full max-w-[100vw] min-w-0 flex flex-col"
     >
-      <div
-        data-testid="directory-sticky-chrome"
-        className="shrink-0 z-50"
-        style={{ background: '#eef4f9' }}
-      >
+      <div data-testid="directory-sticky-chrome" className="shrink-0 z-50 bg-background">
         <DirectoryHeader />
         <DirectoryToolbar />
       </div>

--- a/quotevote-frontend/src/components/DashboardShell.tsx
+++ b/quotevote-frontend/src/components/DashboardShell.tsx
@@ -548,8 +548,10 @@ export function DashboardShell({
       <main
         id="main-content"
         className={cn(
-          'h-full overflow-y-auto overscroll-contain pt-[56px] md:pt-[60px] md:pb-0 md:h-auto md:min-h-screen md:overflow-visible',
+          'h-full overscroll-contain pt-[56px] md:pt-[60px] md:pb-0 md:h-auto md:min-h-screen md:overflow-visible',
           mobileDiscussionOpen ? 'pb-0' : 'pb-[60px]',
+          // Home pins search/filters above the post list on mobile (#487 / #488).
+          pathname === '/' ? 'overflow-hidden' : 'overflow-y-auto',
         )}
       >
         {pathname.startsWith('/profile') || pathname.startsWith('/settings') ? (
@@ -566,7 +568,11 @@ export function DashboardShell({
           </div>
         ) : (
           <div
-            className={cn('mx-auto px-0 md:px-4', pathname.startsWith('/post/') && 'md:px-8 lg:px-12 h-full md:h-auto')}
+            className={cn(
+              'mx-auto px-0 md:px-4',
+              pathname === '/' && 'h-full min-h-0 md:h-auto',
+              pathname.startsWith('/post/') && 'md:px-8 lg:px-12 h-full md:h-auto',
+            )}
             style={{
               maxWidth: pathname.startsWith('/control-panel')
                 ? 'none'


### PR DESCRIPTION
## Summary
- Apply the #488 mobile scroll shell to authenticated `/` so search and filters stay pinned while posts scroll ([#488 comment](https://github.com/QuoteVote/quotevote-next/pull/488#issuecomment-followup)).
- Leave desktop page scrolling unchanged; `DashboardShell` still owns the fixed nav.
- Replace hardcoded `#eef4f9` with `bg-background` so the toolbar stays in sync with the page background.

## Test plan
- Open `/` signed in on a mobile viewport (~390px).
- Confirm visual order is: logo bar, search, filters, then posts.
- Scroll the post list and confirm search and filters stay at the top with no overlap or extra gap.
- Open Filters / Tag / Date popovers after scrolling and confirm they still work.
- On desktop, confirm the toolbar still scrolls away with the page.
- As a guest, confirm the existing pinned chrome is unchanged.
- `pnpm lint && pnpm type-check && pnpm test -- src/__tests__/app/page.test.tsx` in `quotevote-frontend/`.


Made with [Cursor](https://cursor.com)