### PR TITLE
feat(#493): open Messages as a mobile bottom sheet

### DIFF
--- a/quotevote-frontend/src/__tests__/components/Chat/MessageBox.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/Chat/MessageBox.test.tsx
@@ -3,7 +3,7 @@
  * 
  * Tests for the MessageBox component including:
  * - Room selection and display
- * - Header actions (back, block, remove buddy, delete chat)
+ * - Header actions (back, block, remove buddy, close chat)
  * - Message rendering integration
  * - Loading and error states
  */
@@ -176,6 +176,7 @@ describe('MessageBox', () => {
           presenceMap: {},
         },
         setSelectedChatRoom: jest.fn(),
+        setChatOpen: jest.fn(),
         setSnackbar: jest.fn(),
       }
       return selector(state)
@@ -189,6 +190,7 @@ describe('MessageBox', () => {
         user: { data: mockCurrentUser },
         chat: { selectedRoom: null, buddyList: [], presenceMap: {} },
         setSelectedChatRoom: jest.fn(),
+        setChatOpen: jest.fn(),
         setSnackbar: jest.fn(),
       }
       return selector(state)
@@ -234,6 +236,7 @@ describe('MessageBox', () => {
           presenceMap: {},
         },
         setSelectedChatRoom: jest.fn(),
+        setChatOpen: jest.fn(),
         setSnackbar: jest.fn(),
       }
       return selector(state)
@@ -271,6 +274,7 @@ describe('MessageBox', () => {
         user: { data: mockCurrentUser },
         chat: { selectedRoom: 'room1', buddyList: [], presenceMap: {} },
         setSelectedChatRoom,
+        setChatOpen: jest.fn(),
         setSnackbar: jest.fn(),
       }
       return selector(state)
@@ -299,7 +303,7 @@ describe('MessageBox', () => {
     expect(screen.getByTestId('typing-indicator')).toBeInTheDocument()
   })
 
-  it('renders settings menu with block, remove buddy, and delete options for USER rooms', async () => {
+  it('renders settings menu with block and remove buddy options for USER rooms', async () => {
     render(<MessageBox />)
 
     await waitFor(() => {
@@ -310,12 +314,53 @@ describe('MessageBox', () => {
     fireEvent.click(settingsButton)
 
     await waitFor(() => {
-      // The dropdown content should be rendered
       expect(screen.getByTestId('dropdown-content')).toBeInTheDocument()
       expect(screen.getByText('Block User')).toBeInTheDocument()
       expect(screen.getByText('Remove Buddy')).toBeInTheDocument()
-      expect(screen.getByText('Close Chat')).toBeInTheDocument()
+      expect(screen.queryByText('Close Chat')).not.toBeInTheDocument()
     })
+  })
+
+  it('renders close chat button and calls setChatOpen(false) when clicked', async () => {
+    const setChatOpen = jest.fn()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockUseAppStore.mockImplementation((selector: any) => {
+      const state = {
+        user: { data: mockCurrentUser },
+        chat: { selectedRoom: 'room1', buddyList: [], presenceMap: {} },
+        setSelectedChatRoom: jest.fn(),
+        setChatOpen,
+        setSnackbar: jest.fn(),
+      }
+      return selector(state)
+    })
+
+    render(<MessageBox />)
+
+    const closeButton = await screen.findByRole('button', { name: /close chat/i })
+    fireEvent.click(closeButton)
+
+    expect(setChatOpen).toHaveBeenCalledWith(false)
+  })
+
+  it('hides settings menu for POST rooms and does not render Close Chat', async () => {
+    const groupRoom: ChatRoom = {
+      _id: 'group-room-1',
+      title: 'Group Chat',
+      messageType: 'POST',
+      users: ['user1', 'user2', 'user3'],
+      created: new Date().toISOString(),
+    }
+
+    render(<MessageBox roomOverride={groupRoom} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Group Chat')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByLabelText('Chat settings')).not.toBeInTheDocument()
+    expect(screen.queryByText('Close Chat')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /close chat/i })).toBeInTheDocument()
   })
 
   it('accepts roomOverride prop to override selected room', async () => {

--- a/quotevote-frontend/src/components/Chat/MessageBox.tsx
+++ b/quotevote-frontend/src/components/Chat/MessageBox.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, Settings, Ban, UserX, Trash2 } from 'lucide-react'
+import { ArrowLeft, Settings, Ban, UserX, X } from 'lucide-react'
 import { useQuery } from '@apollo/client/react'
 
 import MessageSend from './MessageSend'
@@ -19,7 +19,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import type { ChatRoom, StagedChatRoom } from '@/types/chat'
@@ -140,13 +139,8 @@ function Header({ room, stagedProfileUsername }: HeaderProps) {
     }
   }
 
-  const handleDeleteChat = () => {
-    setSelectedChatRoom(null)
-    setChatOpen(false)
-    toast('Chat closed')
-  }
-
   const isUserRoom = messageType === 'USER'
+  const showSettingsMenu = isUserRoom && !!otherUserId
 
   return (
     <div className="sticky top-0 z-10 border-b bg-gradient-to-b from-white to-[#fafbfc] px-4 py-3 backdrop-blur-sm shadow-[0_2px_8px_rgba(0,0,0,0.06),0_1px_3px_rgba(0,0,0,0.04)]">
@@ -195,47 +189,47 @@ function Header({ room, stagedProfileUsername }: HeaderProps) {
           </div>
         </div>
 
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="ml-auto h-8 w-8 rounded-full text-muted-foreground hover:bg-muted hover:text-[#52b274] hover:scale-105 transition-all duration-200"
-              aria-label="Chat settings"
-            >
-              <Settings className="h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            {isUserRoom && otherUserId && (
-              <>
-                <DropdownMenuItem
-                  onClick={handleBlockUser}
-                  className="text-red-600 focus:bg-red-50 dark:text-red-400 dark:focus:bg-red-950/40"
-                >
-                  <Ban className="mr-2 h-4 w-4" />
-                  <span>{isBlocked ? 'Unblock User' : 'Block User'}</span>
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={handleRemoveBuddy}
-                  className="text-red-600 focus:bg-red-50 dark:text-red-400 dark:focus:bg-red-950/40"
-                >
-                  <UserX className="mr-2 h-4 w-4" />
-                  <span>Remove Buddy</span>
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-              </>
-            )}
-            <DropdownMenuItem
-              onClick={handleDeleteChat}
-              className="text-red-600 focus:bg-red-50 dark:text-red-400 dark:focus:bg-red-950/40"
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              <span>Close Chat</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        {showSettingsMenu && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 rounded-full text-muted-foreground hover:bg-muted hover:text-[#52b274] hover:scale-105 transition-all duration-200"
+                aria-label="Chat settings"
+              >
+                <Settings className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuItem
+                onClick={handleBlockUser}
+                className="text-red-600 focus:bg-red-50 dark:text-red-400 dark:focus:bg-red-950/40"
+              >
+                <Ban className="mr-2 h-4 w-4" />
+                <span>{isBlocked ? 'Unblock User' : 'Block User'}</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={handleRemoveBuddy}
+                className="text-red-600 focus:bg-red-50 dark:text-red-400 dark:focus:bg-red-950/40"
+              >
+                <UserX className="mr-2 h-4 w-4" />
+                <span>Remove Buddy</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => setChatOpen(false)}
+          className="h-8 w-8 rounded-full text-muted-foreground hover:bg-muted hover:scale-105 transition-all duration-200"
+          aria-label="Close chat"
+        >
+          <X className="h-4 w-4" />
+        </Button>
       </div>
     </div>
   )

--- a/quotevote-frontend/src/components/DashboardShell.tsx
+++ b/quotevote-frontend/src/components/DashboardShell.tsx
@@ -75,19 +75,28 @@ function ChatPanel() {
   const chatOpen = useAppStore((s) => s.chat.open);
   const setChatOpen = useAppStore((s) => s.setChatOpen);
   const isXlUp = useMediaQuery('(min-width: 1280px)');
+  const isMobile = useMediaQuery('(max-width: 767px)');
 
   if (routeHasPersistentChatPanel(pathname) && isXlUp) return null;
 
   return (
     <Sheet open={chatOpen} onOpenChange={setChatOpen} modal={false}>
-        <SheetContent
-        side="right"
-        overlayClassName="bottom-[56px] md:bottom-0"
-        className="w-full sm:w-[400px] p-0 bottom-[56px] h-[calc(100%-56px)] md:inset-y-0 md:h-full"
+      <SheetContent
+        side={isMobile ? 'bottom' : 'right'}
+        overlayClassName={isMobile ? 'bottom-[56px]' : 'bottom-0'}
+        className={cn(
+          'w-full p-0 gap-0 overflow-hidden',
+          isMobile
+            ? 'bottom-[56px] h-[calc(100dvh-6.5rem)] max-h-[85dvh] rounded-t-2xl sm:max-w-none'
+            : 'sm:w-[400px] sm:max-w-[400px] inset-y-0 h-full',
+        )}
+        data-testid="messages-panel"
         onInteractOutside={(e) => e.preventDefault()}
       >
         <SheetTitle className="sr-only">Messages</SheetTitle>
-        <div className="h-full"><ChatContent /></div>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <ChatContent />
+        </div>
       </SheetContent>
     </Sheet>
   );
@@ -192,6 +201,10 @@ export function DashboardShell({
 
   const handleCreateClick = () => {
     requireAuthForAction(() => setSubmitDialogOpen(true));
+  };
+
+  const closeMessages = () => {
+    if (chatOpen) setChatOpen(false);
   };
 
   return (
@@ -402,6 +415,7 @@ export function DashboardShell({
         {/* Home */}
         <Link
           href="/"
+          onClick={closeMessages}
           className={cn(
             'flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors duration-150',
             isActive('/') ? 'text-[#52b274]' : 'text-muted-foreground'
@@ -415,12 +429,13 @@ export function DashboardShell({
         {/* Messages */}
         <button
           type="button"
-          onClick={() => requireAuthForAction(() => setChatOpen(true))}
+          onClick={() => requireAuthForAction(() => setChatOpen(!chatOpen))}
           className={cn(
             'relative flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors duration-150 border-0 bg-transparent cursor-pointer',
             chatOpen ? 'text-[#52b274]' : 'text-muted-foreground'
           )}
           aria-label="Messages"
+          aria-expanded={chatOpen}
         >
           <div className="relative">
             <MessageSquare className="size-[22px]" fill={chatOpen ? 'currentColor' : 'none'} />
@@ -437,7 +452,10 @@ export function DashboardShell({
         <button
           type="button"
           data-testid="create-post-button"
-          onClick={handleCreateClick}
+          onClick={() => {
+            closeMessages();
+            handleCreateClick();
+          }}
           className="flex flex-col items-center justify-center flex-1 h-full cursor-pointer border-0 bg-transparent"
           aria-label="Create"
         >
@@ -452,7 +470,10 @@ export function DashboardShell({
         {/* Notifications */}
         <button
           type="button"
-          onClick={() => requireAuthForAction(() => router.push('/notifications'))}
+          onClick={() => requireAuthForAction(() => {
+            closeMessages();
+            router.push('/notifications');
+          })}
           className={cn(
             'relative flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors duration-150 border-0 bg-transparent cursor-pointer',
             isActive('/notifications') ? 'text-[#52b274]' : 'text-muted-foreground'
@@ -476,6 +497,7 @@ export function DashboardShell({
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
+                onClick={closeMessages}
                 className={cn(
                   'flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors duration-150 border-0 bg-transparent cursor-pointer',
                   isActive('/profile') ? 'text-[#52b274]' : 'text-muted-foreground'


### PR DESCRIPTION
## Summary
- Open Messages as a bottom-sheet overlay on mobile (page stays visible; bottom nav stays put) and keep the right-side drawer on desktop.
- Toggle the panel from the Messages tab; close it with × or by tapping Home, Activity, Profile, or Create.
- Remove the red trash / Close Chat item from conversation settings and add a top-right × on both the inbox and conversation views.

Closes #493

## Note for reviewers
This overlaps **#495** (`DashboardShell` mobile nav / Profile). Please **merge #495 first**.

This branch still has the Profile dropdown that #495 replaces with a `/profile` link, plus a duplicate Messages item in that menu. After #495 lands, rebase this branch onto `main` and re-attach `closeMessages` to the new Profile link before merging.

## Test plan
- [ ] On a mobile viewport, tap Messages and confirm the panel slides up from above the bottom nav (not from the right)
- [ ] Confirm the current page remains visible behind the sheet and the bottom nav stays in place
- [ ] Tap × and confirm the panel collapses
- [ ] Tap Messages again to reopen, then tap Messages to close
- [ ] With Messages open, tap Home, Activity, and Profile and confirm the panel closes each time
- [ ] Confirm existing chat list, search, DMs, and discussions still work
- [ ] On desktop (`md+`), confirm Messages still opens as a right-side drawer


Made with [Cursor](https://cursor.com)