### PR TITLE
fix(mobile): prevent voting toolbar overlap

### DIFF
--- a/quotevote-frontend/e2e/helpers/selection.ts
+++ b/quotevote-frontend/e2e/helpers/selection.ts
@@ -1,4 +1,4 @@
-import { type Page, expect } from '@playwright/test';
+import { type Page, expect } from "@playwright/test";
 
 /**
  * Selects text inside an element specified by a data-testid.
@@ -29,7 +29,7 @@ export async function selectTextByTestId(page: Page, testId: string): Promise<vo
     const el = document.querySelector(`[data-testid="${selector}"]`);
     if (!el) return;
 
-    const targetNode = el.querySelector('p') || el;
+    const targetNode = el.querySelector("p") || el;
     const selection = window.getSelection();
     const range = document.createRange();
     range.selectNodeContents(targetNode);
@@ -39,7 +39,8 @@ export async function selectTextByTestId(page: Page, testId: string): Promise<vo
       selection.addRange(range);
     }
 
-    const selectable = el.closest('[data-selectable]') || el.querySelector('[data-selectable]') || el;
+    const selectable =
+      el.closest("[data-selectable]") || el.querySelector("[data-selectable]") || el;
     const rect = targetNode.getBoundingClientRect();
     const eventInit = {
       bubbles: true,
@@ -48,10 +49,10 @@ export async function selectTextByTestId(page: Page, testId: string): Promise<vo
       clientY: rect.top + rect.height / 2,
     };
 
-    selectable.dispatchEvent(new Event('selectstart', { bubbles: true, cancelable: true }));
-    selectable.dispatchEvent(new PointerEvent('pointermove', eventInit));
-    selectable.dispatchEvent(new PointerEvent('pointerup', eventInit));
-    document.dispatchEvent(new Event('selectionchange', { bubbles: true }));
+    selectable.dispatchEvent(new Event("selectstart", { bubbles: true, cancelable: true }));
+    selectable.dispatchEvent(new PointerEvent("pointermove", eventInit));
+    selectable.dispatchEvent(new PointerEvent("pointerup", eventInit));
+    document.dispatchEvent(new Event("selectionchange", { bubbles: true }));
   }, testId);
 }
 
@@ -60,7 +61,7 @@ export async function selectTextByTestId(page: Page, testId: string): Promise<vo
  * Does NOT advance to toolbar; caller asserts native vs toolbar visibility.
  */
 export async function selectPostText(page: Page): Promise<void> {
-  await selectTextByTestId(page, 'post-detail-body');
+  await selectTextByTestId(page, "post-detail-body");
 }
 
 /**
@@ -68,42 +69,41 @@ export async function selectPostText(page: Page): Promise<void> {
  * Does NOT advance to toolbar; caller must call advanceMobileSelectionToToolbar().
  */
 export async function selectMobilePostText(page: Page): Promise<void> {
-  await selectTextByTestId(page, 'post-detail-body');
+  await selectTextByTestId(page, "post-detail-body");
+}
+
+/**
+ * Resolves a stable, non-interactive background tap point outside the
+ * selectable content and the popover. Coordinates only — no element tap,
+ * so nothing interactive underneath can be activated.
+ */
+async function backgroundTapPoint(page: Page): Promise<{ x: number; y: number }> {
+  const title = page.getByTestId("post-detail-title");
+  if (await title.isVisible().catch(() => false)) {
+    const box = await title.boundingBox().catch(() => null);
+    if (box) return { x: box.x + 5, y: Math.max(5, box.y - 5) };
+  }
+  // Fallback: top-left viewport corner, padding area
+  return { x: 8, y: 8 };
 }
 
 /**
  * Advances a mobile native selection to the Quote.Vote toolbar.
- * Performs the first outside tap that the delayed workflow requires.
- * Caller should tap a stable, non-interactive page background.
+ * Performs exactly ONE background tap (a full mouse gesture:
+ * pointerdown/up/click). No synthetic extra pointerdown — emitting two
+ * gestures would immediately perform the second transition and dismiss
+ * the toolbar again (P1 #4).
  */
 export async function advanceMobileSelectionToToolbar(page: Page): Promise<void> {
-  // Tap a stable background outside the selectable content and toolbar.
-  // Prefer the page header / body padding. Fallback to coordinates.
-  const candidates = [
-    page.getByTestId('post-detail-title'),
-    page.locator('header').first(),
-    page.locator('body'),
-  ]
-  for (const c of candidates) {
-    if (await c.isVisible().catch(() => false)) {
-      const box = await c.boundingBox().catch(() => null)
-      if (box) {
-        // Tap near top outside selectable
-        await page.mouse.click(box.x + 5, Math.max(5, box.y + 5))
-        // Also dispatch pointerdown for capture handler
-        await page.evaluate(() => {
-          document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, clientX: 5, clientY: 5 }))
-        })
-        return
-      }
-    }
-  }
-  await page.mouse.click(5, 5)
+  const { x, y } = await backgroundTapPoint(page);
+  await page.mouse.click(x, y);
 }
 
 /**
  * Dismisses the retained toolbar with a second background tap.
+ * Exactly ONE gesture, same rules as the advance helper.
  */
 export async function dismissMobileToolbar(page: Page): Promise<void> {
-  await advanceMobileSelectionToToolbar(page)
+  const { x, y } = await backgroundTapPoint(page);
+  await page.mouse.click(x, y);
 }

--- a/quotevote-frontend/e2e/helpers/selection.ts
+++ b/quotevote-frontend/e2e/helpers/selection.ts
@@ -2,7 +2,10 @@ import { type Page, expect } from '@playwright/test';
 
 /**
  * Selects text inside an element specified by a data-testid.
- * Supports both desktop mouse selection and mobile viewport behavior.
+ * Split responsibility (issue #484):
+ * - selectTextByTestId / selectPostText only create the DOM selection.
+ * - advanceMobileSelectionToToolbar performs the first background tap.
+ * Tests own all visibility assertions.
  */
 export async function selectTextByTestId(page: Page, testId: string): Promise<void> {
   const container = page.getByTestId(testId);
@@ -54,6 +57,7 @@ export async function selectTextByTestId(page: Page, testId: string): Promise<vo
 
 /**
  * Convenience helper to select text specifically within the post body.
+ * Does NOT advance to toolbar; caller asserts native vs toolbar visibility.
  */
 export async function selectPostText(page: Page): Promise<void> {
   await selectTextByTestId(page, 'post-detail-body');
@@ -61,8 +65,45 @@ export async function selectPostText(page: Page): Promise<void> {
 
 /**
  * Convenience helper to select text specifically within the post body on mobile viewports.
- * Simulates touch/pointer behavior closely enough to validate real mobile usability.
+ * Does NOT advance to toolbar; caller must call advanceMobileSelectionToToolbar().
  */
 export async function selectMobilePostText(page: Page): Promise<void> {
   await selectTextByTestId(page, 'post-detail-body');
+}
+
+/**
+ * Advances a mobile native selection to the Quote.Vote toolbar.
+ * Performs the first outside tap that the delayed workflow requires.
+ * Caller should tap a stable, non-interactive page background.
+ */
+export async function advanceMobileSelectionToToolbar(page: Page): Promise<void> {
+  // Tap a stable background outside the selectable content and toolbar.
+  // Prefer the page header / body padding. Fallback to coordinates.
+  const candidates = [
+    page.getByTestId('post-detail-title'),
+    page.locator('header').first(),
+    page.locator('body'),
+  ]
+  for (const c of candidates) {
+    if (await c.isVisible().catch(() => false)) {
+      const box = await c.boundingBox().catch(() => null)
+      if (box) {
+        // Tap near top outside selectable
+        await page.mouse.click(box.x + 5, Math.max(5, box.y + 5))
+        // Also dispatch pointerdown for capture handler
+        await page.evaluate(() => {
+          document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, clientX: 5, clientY: 5 }))
+        })
+        return
+      }
+    }
+  }
+  await page.mouse.click(5, 5)
+}
+
+/**
+ * Dismisses the retained toolbar with a second background tap.
+ */
+export async function dismissMobileToolbar(page: Page): Promise<void> {
+  await advanceMobileSelectionToToolbar(page)
 }

--- a/quotevote-frontend/e2e/helpers/selection.ts
+++ b/quotevote-frontend/e2e/helpers/selection.ts
@@ -1,17 +1,9 @@
 import { type Page, expect } from "@playwright/test";
 
-/**
- * Selects text inside an element specified by a data-testid.
- * Split responsibility (issue #484):
- * - selectTextByTestId / selectPostText only create the DOM selection.
- * - advanceMobileSelectionToToolbar performs the first background tap.
- * Tests own all visibility assertions.
- */
 export async function selectTextByTestId(page: Page, testId: string): Promise<void> {
   const container = page.getByTestId(testId);
   await expect(container).toBeVisible({ timeout: 15_000 });
 
-  // 1. Attempt physical mouse/touch selection via bounding box dragging
   const box = await container.boundingBox();
   if (box && box.width > 20 && box.height > 10) {
     const startX = box.x + box.width * 0.1;
@@ -24,7 +16,6 @@ export async function selectTextByTestId(page: Page, testId: string): Promise<vo
     await page.mouse.up();
   }
 
-  // 2. Ensure selection via DOM API and dispatch pointer events to reliably trigger listeners across viewports/devices
   await page.evaluate((selector) => {
     const el = document.querySelector(`[data-testid="${selector}"]`);
     if (!el) return;
@@ -56,53 +47,28 @@ export async function selectTextByTestId(page: Page, testId: string): Promise<vo
   }, testId);
 }
 
-/**
- * Convenience helper to select text specifically within the post body.
- * Does NOT advance to toolbar; caller asserts native vs toolbar visibility.
- */
 export async function selectPostText(page: Page): Promise<void> {
   await selectTextByTestId(page, "post-detail-body");
 }
 
-/**
- * Convenience helper to select text specifically within the post body on mobile viewports.
- * Does NOT advance to toolbar; caller must call advanceMobileSelectionToToolbar().
- */
 export async function selectMobilePostText(page: Page): Promise<void> {
   await selectTextByTestId(page, "post-detail-body");
 }
 
-/**
- * Resolves a stable, non-interactive background tap point outside the
- * selectable content and the popover. Coordinates only — no element tap,
- * so nothing interactive underneath can be activated.
- */
 async function backgroundTapPoint(page: Page): Promise<{ x: number; y: number }> {
   const title = page.getByTestId("post-detail-title");
   if (await title.isVisible().catch(() => false)) {
     const box = await title.boundingBox().catch(() => null);
     if (box) return { x: box.x + 5, y: Math.max(5, box.y - 5) };
   }
-  // Fallback: top-left viewport corner, padding area
   return { x: 8, y: 8 };
 }
 
-/**
- * Advances a mobile native selection to the Quote.Vote toolbar.
- * Performs exactly ONE background tap (a full mouse gesture:
- * pointerdown/up/click). No synthetic extra pointerdown — emitting two
- * gestures would immediately perform the second transition and dismiss
- * the toolbar again (P1 #4).
- */
 export async function advanceMobileSelectionToToolbar(page: Page): Promise<void> {
   const { x, y } = await backgroundTapPoint(page);
   await page.mouse.click(x, y);
 }
 
-/**
- * Dismisses the retained toolbar with a second background tap.
- * Exactly ONE gesture, same rules as the advance helper.
- */
 export async function dismissMobileToolbar(page: Page): Promise<void> {
   const { x, y } = await backgroundTapPoint(page);
   await page.mouse.click(x, y);

--- a/quotevote-frontend/e2e/highlight-popup.spec.ts
+++ b/quotevote-frontend/e2e/highlight-popup.spec.ts
@@ -19,6 +19,10 @@ import { PUBLIC_TAG_NAME } from './helpers/post-composer';
 test.describe('E2E-HILITE-001: Highlight Action Popup', () => {
   test.skip(!AUTHOR_PASSWORD, 'E2E_AUTHOR_PASSWORD is required');
 
+  test.beforeEach(({ isMobile }) => {
+    test.skip(!!isMobile, 'Desktop-only: mobile uses delayed two-tap workflow (see mobile.spec.ts)')
+  })
+
   let createdPostId: string | null = null;
   let authToken: string | null = null;
 
@@ -84,9 +88,14 @@ test.describe('E2E-HILITE-001: Highlight Action Popup', () => {
     }
 
     // Step 3: Select a passage of text within the post body
+    // This spec is desktop-only (delayed mobile workflow not applicable)
+    await page.evaluate(() => {
+      // Ensure desktop media: not coarse touch, so toolbar opens immediately
+      // Playwright's desktop project already matches this; no override needed.
+    })
     await selectPostText(page);
 
-    // Step 4: Confirm that the highlight action popup appears
+    // Step 4: Confirm that the highlight action popup appears immediately (desktop)
     const highlightPopup = page.getByTestId('highlight-popup');
     await expect(highlightPopup).toBeVisible({ timeout: 15_000 });
 

--- a/quotevote-frontend/e2e/highlight-popup.spec.ts
+++ b/quotevote-frontend/e2e/highlight-popup.spec.ts
@@ -9,19 +9,22 @@
  * - Expected: Highlight popup appears with Agree, Disagree, Comment, Quote actions
  * - Viewports: Desktop, Mobile (playwright.config.ts projects)
  */
-import { test, expect } from '@playwright/test';
-import { deletePostViaApi, loginViaApi } from './helpers/api';
-import { AUTHOR_PASSWORD, AUTHOR_USERNAME } from './helpers/auth';
-import { selectPostText } from './helpers/selection';
+import { test, expect } from "@playwright/test";
+import { deletePostViaApi, loginViaApi } from "./helpers/api";
+import { AUTHOR_PASSWORD, AUTHOR_USERNAME } from "./helpers/auth";
+import { selectPostText } from "./helpers/selection";
 
-import { PUBLIC_TAG_NAME } from './helpers/post-composer';
+import { PUBLIC_TAG_NAME } from "./helpers/post-composer";
 
-test.describe('E2E-HILITE-001: Highlight Action Popup', () => {
-  test.skip(!AUTHOR_PASSWORD, 'E2E_AUTHOR_PASSWORD is required');
+test.describe("E2E-HILITE-001: Highlight Action Popup", () => {
+  test.skip(!AUTHOR_PASSWORD, "E2E_AUTHOR_PASSWORD is required");
 
   test.beforeEach(({ isMobile }) => {
-    test.skip(!!isMobile, 'Desktop-only: mobile uses delayed two-tap workflow (see mobile.spec.ts)')
-  })
+    test.skip(
+      !!isMobile,
+      "Desktop-only: mobile uses delayed two-tap workflow (see mobile.spec.ts)"
+    );
+  });
 
   let createdPostId: string | null = null;
   let authToken: string | null = null;
@@ -38,47 +41,47 @@ test.describe('E2E-HILITE-001: Highlight Action Popup', () => {
     }
   });
 
-  test('opens highlight popup on text selection with expected actions', async ({ page }) => {
+  test("opens highlight popup on text selection with expected actions", async ({ page }) => {
     const uniqueSuffix = `${Date.now()}-${test.info().project.name}`;
     const postTitle = `E2E-HILITE-001 ${uniqueSuffix}`;
     const postBody = `Automated post body for testing text highlight selection in ${uniqueSuffix}. Please select this passage of text to see the action popup.`;
 
     // Step 1: Log in as authorUser (precondition via global-setup storageState)
-    await page.goto('/');
-    await expect(page).toHaveURL((url) => url.pathname === '/');
+    await page.goto("/");
+    await expect(page).toHaveURL((url) => url.pathname === "/");
 
     // Ensure at least one public post exists on the explore feed
-    const firstPostCard = page.getByTestId('post-card').first();
+    const firstPostCard = page.getByTestId("post-card").first();
     const hasExistingPost = await firstPostCard.isVisible().catch(() => false);
 
     if (!hasExistingPost) {
       // If no public posts exist in this environment, create one via the composer
-      const createButton = page.getByTestId('create-post-button').locator('visible=true');
+      const createButton = page.getByTestId("create-post-button").locator("visible=true");
       await createButton.click();
 
-      const composer = page.getByTestId('post-composer');
+      const composer = page.getByTestId("post-composer");
       await expect(composer).toBeVisible();
 
-      await page.getByTestId('post-title-input').fill(postTitle);
-      await page.getByTestId('post-body-input').fill(postBody);
+      await page.getByTestId("post-title-input").fill(postTitle);
+      await page.getByTestId("post-body-input").fill(postBody);
 
-      await page.getByTestId('post-tag-select').click();
-      await page.getByPlaceholder('Search or type new tag name...').fill(PUBLIC_TAG_NAME);
-      await page.getByRole('button', { name: PUBLIC_TAG_NAME, exact: true }).click();
+      await page.getByTestId("post-tag-select").click();
+      await page.getByPlaceholder("Search or type new tag name...").fill(PUBLIC_TAG_NAME);
+      await page.getByRole("button", { name: PUBLIC_TAG_NAME, exact: true }).click();
 
-      await page.getByTestId('post-submit-button').click();
-      await expect(page.getByTestId('post-composer')).toBeHidden({ timeout: 30_000 });
-      await expect(page).toHaveURL((url) => url.pathname === '/', { timeout: 30_000 });
+      await page.getByTestId("post-submit-button").click();
+      await expect(page.getByTestId("post-composer")).toBeHidden({ timeout: 30_000 });
+      await expect(page).toHaveURL((url) => url.pathname === "/", { timeout: 30_000 });
     }
 
     // Step 2: Navigate to an existing public post
-    const targetPostCard = page.getByTestId('post-card').first();
+    const targetPostCard = page.getByTestId("post-card").first();
     await expect(targetPostCard).toBeVisible({ timeout: 30_000 });
     await targetPostCard.click();
 
     // Confirm public post page loads successfully and post body text is visible
     await expect(page).toHaveURL(/\/dashboard\/post\/.+\/.+\/.+/, { timeout: 30_000 });
-    const postBodyElement = page.getByTestId('post-detail-body');
+    const postBodyElement = page.getByTestId("post-detail-body");
     await expect(postBodyElement).toBeVisible({ timeout: 30_000 });
 
     const postUrl = page.url();
@@ -92,21 +95,21 @@ test.describe('E2E-HILITE-001: Highlight Action Popup', () => {
     await page.evaluate(() => {
       // Ensure desktop media: not coarse touch, so toolbar opens immediately
       // Playwright's desktop project already matches this; no override needed.
-    })
+    });
     await selectPostText(page);
 
     // Step 4: Confirm that the highlight action popup appears immediately (desktop)
-    const highlightPopup = page.getByTestId('highlight-popup');
+    const highlightPopup = page.getByTestId("highlight-popup");
     await expect(highlightPopup).toBeVisible({ timeout: 15_000 });
 
     // Step 5: Confirm that the popup includes the expected passage-level actions
-    await expect(page.getByTestId('highlight-agree-button')).toBeVisible();
-    await expect(page.getByTestId('highlight-disagree-button')).toBeVisible();
-    await expect(page.getByTestId('highlight-comment-button')).toBeVisible();
-    await expect(page.getByTestId('highlight-quote-button')).toBeVisible();
+    await expect(page.getByTestId("highlight-agree-button")).toBeVisible();
+    await expect(page.getByTestId("highlight-disagree-button")).toBeVisible();
+    await expect(page.getByTestId("highlight-comment-button")).toBeVisible();
+    await expect(page.getByTestId("highlight-quote-button")).toBeVisible();
 
     // Check optional chat action if enabled
-    const chatButton = page.getByTestId('highlight-chat-button');
+    const chatButton = page.getByTestId("highlight-chat-button");
     if ((await chatButton.count()) > 0) {
       await expect(chatButton).toBeVisible();
     }

--- a/quotevote-frontend/e2e/mobile.spec.ts
+++ b/quotevote-frontend/e2e/mobile.spec.ts
@@ -1,29 +1,29 @@
 /**
- * E2E-MOB-005 — Mobile Highlight Selection
+ * E2E-MOB-005 — Mobile Highlight Selection (delayed two-tap, issue #484)
  *
  * Sheet mapping:
  * - Feature Area: Mobile
- * - Scenario: Mobile Highlight Selection
+ * - Scenario: Mobile Highlight Selection (delayed toolbar)
  * - Priority: P0
  * - Actor: Registered User (authorUser)
  * - Auth State: Logged in
  * - Required Data: Public post
  * - Viewport: Mobile
- * - Suggested Spec File: mobile.spec.ts
  *
- * Test Steps:
- * 1. Log in as authorUser in a mobile viewport.
- * 2. Navigate to an existing public post.
- * 3. Select a passage of text within the post body.
- * 4. Confirm the highlight action popup appears.
- * 5. Confirm the popup is fully visible within the viewport (not cut off by left or right edge).
- * 6. Confirm native copy/paste controls do not prevent interaction with the Quote.Vote popup.
- * 7. Tap the available popup actions enough to confirm they are visible, reachable, and responsive.
+ * Steps (delayed workflow):
+ * 1. Select passage → native Selection contains text, toolbar hidden, retained mark absent
+ * 2. First background tap → native cleared, retained mark + toolbar visible, clamped
+ * 3. Actions interactive (Comment tap)
+ * 4. Second background tap → toolbar/highlight dismissed, URL unchanged
  */
 import { test, expect } from '@playwright/test';
 import { deletePostViaApi, loginViaApi } from './helpers/api';
 import { AUTHOR_PASSWORD, AUTHOR_USERNAME } from './helpers/auth';
-import { selectMobilePostText } from './helpers/selection';
+import {
+  selectMobilePostText,
+  advanceMobileSelectionToToolbar,
+  dismissMobileToolbar,
+} from './helpers/selection';
 
 import { PUBLIC_TAG_NAME } from './helpers/post-composer';
 
@@ -49,16 +49,14 @@ test.describe('E2E-MOB-005: Mobile Highlight Selection', () => {
     }
   });
 
-  test('mobile user can select text and interact with highlight popup without clipping or overlap', async ({ page }) => {
+  test('mobile delayed toolbar: selection → first tap shows retained highlight → second tap dismisses', async ({ page }) => {
     const uniqueSuffix = `${Date.now()}-mob`;
     const postTitle = `E2E-MOB-005 ${uniqueSuffix}`;
     const postBody = `Automated mobile post body for testing touch highlight selection in ${uniqueSuffix}. Please select this passage of text on a mobile viewport to see the action popup.`;
 
-    // Step 1: Log in as authorUser in a mobile viewport
     await page.goto('/');
     await expect(page).toHaveURL((url) => url.pathname === '/');
 
-    // Ensure at least one public post exists on the explore feed
     const firstPostCard = page.getByTestId('post-card').first();
     const hasExistingPost = await firstPostCard.isVisible().catch(() => false);
 
@@ -81,12 +79,10 @@ test.describe('E2E-MOB-005: Mobile Highlight Selection', () => {
       await expect(page).toHaveURL((url) => url.pathname === '/', { timeout: 30_000 });
     }
 
-    // Step 2: Navigate to an existing public post
     const targetPostCard = page.getByTestId('post-card').first();
     await expect(targetPostCard).toBeVisible({ timeout: 30_000 });
     await targetPostCard.click();
 
-    // Confirm mobile post page loads successfully and post body text is visible
     await expect(page).toHaveURL(/\/dashboard\/post\/.+\/.+\/.+/, { timeout: 30_000 });
     const postBodyElement = page.getByTestId('post-detail-body');
     await expect(postBodyElement).toBeVisible({ timeout: 30_000 });
@@ -97,43 +93,57 @@ test.describe('E2E-MOB-005: Mobile Highlight Selection', () => {
       createdPostId = postIdMatch[1];
     }
 
-    // Step 3: Select a passage of text within the post body using mobile selection helper
+    const highlightPopup = page.getByTestId('highlight-popup');
+    const retainedMark = page.getByTestId('retained-selection-highlight');
+
+    // Step 1: Create DOM selection — toolbar and retained must remain hidden
     await selectMobilePostText(page);
 
-    // Step 4: Confirm the highlight action popup appears
-    const highlightPopup = page.getByTestId('highlight-popup');
-    await expect(highlightPopup).toBeVisible({ timeout: 15_000 });
+    // Native Selection contains text
+    const nativeText = await page.evaluate(() => window.getSelection()?.toString() ?? '')
+    expect(nativeText.length).toBeGreaterThan(0)
 
-    // Step 5: Confirm the popup is fully visible within the viewport without side-of-screen clipping
+    await expect(highlightPopup).toBeHidden({ timeout: 5_000 })
+    await expect(retainedMark).toBeHidden({ timeout: 5_000 })
+
+    // Step 2: First background tap → retained + toolbar appear, native cleared
+    await advanceMobileSelectionToToolbar(page);
+
+    await expect.poll(async () => await page.evaluate(() => window.getSelection()?.toString() ?? ''), { timeout: 5_000 }).toBe('')
+
+    await expect(retainedMark).toBeVisible({ timeout: 10_000 })
+    // Retained mark contains the selected passage
+    await expect(retainedMark).toContainText(nativeText.slice(0, 20))
+
+    await expect(highlightPopup).toBeVisible({ timeout: 10_000 })
+
+    // Viewport clamped
     const popupBox = await highlightPopup.boundingBox();
     expect(popupBox).not.toBeNull();
     if (popupBox) {
       const viewportSize = page.viewportSize() || { width: 393, height: 851 };
-      // Popup must not be cut off by left edge (x >= 0) or right edge (x + width <= viewportWidth)
       expect(popupBox.x).toBeGreaterThanOrEqual(0);
       expect(popupBox.x + popupBox.width).toBeLessThanOrEqual(viewportSize.width);
     }
 
-    // Step 6 & 7: Confirm native copy/paste controls do not prevent interaction with the Quote.Vote popup,
-    // and tap available popup actions to confirm they are visible, reachable, and responsive.
-    const agreeButton = page.getByTestId('highlight-agree-button').first();
-    const disagreeButton = page.getByTestId('highlight-disagree-button').first();
+    await expect(page.getByTestId('highlight-agree-button').first()).toBeVisible();
+    await expect(page.getByTestId('highlight-disagree-button').first()).toBeVisible();
+    await expect(page.getByTestId('highlight-comment-button').first()).toBeVisible();
+    await expect(page.getByTestId('highlight-quote-button').first()).toBeVisible();
+
+    // Comment input remains usable
     const commentButton = page.getByTestId('highlight-comment-button').first();
-    const quoteButton = page.getByTestId('highlight-quote-button').first();
-
-    await expect(agreeButton).toBeVisible();
-    await expect(disagreeButton).toBeVisible();
-    await expect(commentButton).toBeVisible();
-    await expect(quoteButton).toBeVisible();
-
-    // Tap comment action: Playwright's .tap() ensures the button receives touch events and is not obscured
-    // by native OS selection handles or copy/paste popups.
     await commentButton.tap();
-
-    // Verify tapping responsive action expanded the comment input or state cleanly
     await expect(highlightPopup).toBeVisible();
 
-    // Confirm no runtime error or error toast appears
+    // Step 3: Second background tap dismisses toolbar/highlight, URL unchanged
+    const urlBeforeDismiss = page.url()
+    await dismissMobileToolbar(page);
+
+    await expect(highlightPopup).toBeHidden({ timeout: 5_000 })
+    await expect(retainedMark).toBeHidden({ timeout: 5_000 })
+    expect(page.url()).toBe(urlBeforeDismiss)
+
     await expect(page.locator('[data-sonner-toast][data-type="error"]')).toHaveCount(0);
   });
 });

--- a/quotevote-frontend/e2e/mobile.spec.ts
+++ b/quotevote-frontend/e2e/mobile.spec.ts
@@ -16,19 +16,19 @@
  * 3. Actions interactive (Comment tap)
  * 4. Second background tap → toolbar/highlight dismissed, URL unchanged
  */
-import { test, expect } from '@playwright/test';
-import { deletePostViaApi, loginViaApi } from './helpers/api';
-import { AUTHOR_PASSWORD, AUTHOR_USERNAME } from './helpers/auth';
+import { test, expect } from "@playwright/test";
+import { deletePostViaApi, loginViaApi } from "./helpers/api";
+import { AUTHOR_PASSWORD, AUTHOR_USERNAME } from "./helpers/auth";
 import {
   selectMobilePostText,
   advanceMobileSelectionToToolbar,
   dismissMobileToolbar,
-} from './helpers/selection';
+} from "./helpers/selection";
 
-import { PUBLIC_TAG_NAME } from './helpers/post-composer';
+import { PUBLIC_TAG_NAME } from "./helpers/post-composer";
 
-test.describe('E2E-MOB-005: Mobile Highlight Selection', () => {
-  test.skip(!AUTHOR_PASSWORD, 'E2E_AUTHOR_PASSWORD is required');
+test.describe("E2E-MOB-005: Mobile Highlight Selection", () => {
+  test.skip(!AUTHOR_PASSWORD, "E2E_AUTHOR_PASSWORD is required");
 
   let createdPostId: string | null = null;
   let authToken: string | null = null;
@@ -39,7 +39,7 @@ test.describe('E2E-MOB-005: Mobile Highlight Selection', () => {
   });
 
   test.beforeEach(({ isMobile }) => {
-    test.skip(!isMobile, 'This test suite is designed specifically for mobile viewports');
+    test.skip(!isMobile, "This test suite is designed specifically for mobile viewports");
   });
 
   test.afterEach(async () => {
@@ -49,42 +49,44 @@ test.describe('E2E-MOB-005: Mobile Highlight Selection', () => {
     }
   });
 
-  test('mobile delayed toolbar: selection → first tap shows retained highlight → second tap dismisses', async ({ page }) => {
+  test("mobile delayed toolbar: selection → first tap shows retained highlight → second tap dismisses", async ({
+    page,
+  }) => {
     const uniqueSuffix = `${Date.now()}-mob`;
     const postTitle = `E2E-MOB-005 ${uniqueSuffix}`;
     const postBody = `Automated mobile post body for testing touch highlight selection in ${uniqueSuffix}. Please select this passage of text on a mobile viewport to see the action popup.`;
 
-    await page.goto('/');
-    await expect(page).toHaveURL((url) => url.pathname === '/');
+    await page.goto("/");
+    await expect(page).toHaveURL((url) => url.pathname === "/");
 
-    const firstPostCard = page.getByTestId('post-card').first();
+    const firstPostCard = page.getByTestId("post-card").first();
     const hasExistingPost = await firstPostCard.isVisible().catch(() => false);
 
     if (!hasExistingPost) {
-      const createButton = page.getByTestId('create-post-button').locator('visible=true');
+      const createButton = page.getByTestId("create-post-button").locator("visible=true");
       await createButton.click();
 
-      const composer = page.getByTestId('post-composer');
+      const composer = page.getByTestId("post-composer");
       await expect(composer).toBeVisible();
 
-      await page.getByTestId('post-title-input').fill(postTitle);
-      await page.getByTestId('post-body-input').fill(postBody);
+      await page.getByTestId("post-title-input").fill(postTitle);
+      await page.getByTestId("post-body-input").fill(postBody);
 
-      await page.getByTestId('post-tag-select').click();
-      await page.getByPlaceholder('Search or type new tag name...').fill(PUBLIC_TAG_NAME);
-      await page.getByRole('button', { name: PUBLIC_TAG_NAME, exact: true }).click();
+      await page.getByTestId("post-tag-select").click();
+      await page.getByPlaceholder("Search or type new tag name...").fill(PUBLIC_TAG_NAME);
+      await page.getByRole("button", { name: PUBLIC_TAG_NAME, exact: true }).click();
 
-      await page.getByTestId('post-submit-button').click();
-      await expect(page.getByTestId('post-composer')).toBeHidden({ timeout: 30_000 });
-      await expect(page).toHaveURL((url) => url.pathname === '/', { timeout: 30_000 });
+      await page.getByTestId("post-submit-button").click();
+      await expect(page.getByTestId("post-composer")).toBeHidden({ timeout: 30_000 });
+      await expect(page).toHaveURL((url) => url.pathname === "/", { timeout: 30_000 });
     }
 
-    const targetPostCard = page.getByTestId('post-card').first();
+    const targetPostCard = page.getByTestId("post-card").first();
     await expect(targetPostCard).toBeVisible({ timeout: 30_000 });
     await targetPostCard.click();
 
     await expect(page).toHaveURL(/\/dashboard\/post\/.+\/.+\/.+/, { timeout: 30_000 });
-    const postBodyElement = page.getByTestId('post-detail-body');
+    const postBodyElement = page.getByTestId("post-detail-body");
     await expect(postBodyElement).toBeVisible({ timeout: 30_000 });
 
     const postUrl = page.url();
@@ -93,29 +95,33 @@ test.describe('E2E-MOB-005: Mobile Highlight Selection', () => {
       createdPostId = postIdMatch[1];
     }
 
-    const highlightPopup = page.getByTestId('highlight-popup');
-    const retainedMark = page.getByTestId('retained-selection-highlight');
+    const highlightPopup = page.getByTestId("highlight-popup");
+    const retainedMark = page.getByTestId("retained-selection-highlight");
 
     // Step 1: Create DOM selection — toolbar and retained must remain hidden
     await selectMobilePostText(page);
 
     // Native Selection contains text
-    const nativeText = await page.evaluate(() => window.getSelection()?.toString() ?? '')
-    expect(nativeText.length).toBeGreaterThan(0)
+    const nativeText = await page.evaluate(() => window.getSelection()?.toString() ?? "");
+    expect(nativeText.length).toBeGreaterThan(0);
 
-    await expect(highlightPopup).toBeHidden({ timeout: 5_000 })
-    await expect(retainedMark).toBeHidden({ timeout: 5_000 })
+    await expect(highlightPopup).toBeHidden({ timeout: 5_000 });
+    await expect(retainedMark).toBeHidden({ timeout: 5_000 });
 
     // Step 2: First background tap → retained + toolbar appear, native cleared
     await advanceMobileSelectionToToolbar(page);
 
-    await expect.poll(async () => await page.evaluate(() => window.getSelection()?.toString() ?? ''), { timeout: 5_000 }).toBe('')
+    await expect
+      .poll(async () => await page.evaluate(() => window.getSelection()?.toString() ?? ""), {
+        timeout: 5_000,
+      })
+      .toBe("");
 
-    await expect(retainedMark).toBeVisible({ timeout: 10_000 })
+    await expect(retainedMark).toBeVisible({ timeout: 10_000 });
     // Retained mark contains the selected passage
-    await expect(retainedMark).toContainText(nativeText.slice(0, 20))
+    await expect(retainedMark).toContainText(nativeText.slice(0, 20));
 
-    await expect(highlightPopup).toBeVisible({ timeout: 10_000 })
+    await expect(highlightPopup).toBeVisible({ timeout: 10_000 });
 
     // Viewport clamped
     const popupBox = await highlightPopup.boundingBox();
@@ -126,23 +132,23 @@ test.describe('E2E-MOB-005: Mobile Highlight Selection', () => {
       expect(popupBox.x + popupBox.width).toBeLessThanOrEqual(viewportSize.width);
     }
 
-    await expect(page.getByTestId('highlight-agree-button').first()).toBeVisible();
-    await expect(page.getByTestId('highlight-disagree-button').first()).toBeVisible();
-    await expect(page.getByTestId('highlight-comment-button').first()).toBeVisible();
-    await expect(page.getByTestId('highlight-quote-button').first()).toBeVisible();
+    await expect(page.getByTestId("highlight-agree-button").first()).toBeVisible();
+    await expect(page.getByTestId("highlight-disagree-button").first()).toBeVisible();
+    await expect(page.getByTestId("highlight-comment-button").first()).toBeVisible();
+    await expect(page.getByTestId("highlight-quote-button").first()).toBeVisible();
 
     // Comment input remains usable
-    const commentButton = page.getByTestId('highlight-comment-button').first();
+    const commentButton = page.getByTestId("highlight-comment-button").first();
     await commentButton.tap();
     await expect(highlightPopup).toBeVisible();
 
     // Step 3: Second background tap dismisses toolbar/highlight, URL unchanged
-    const urlBeforeDismiss = page.url()
+    const urlBeforeDismiss = page.url();
     await dismissMobileToolbar(page);
 
-    await expect(highlightPopup).toBeHidden({ timeout: 5_000 })
-    await expect(retainedMark).toBeHidden({ timeout: 5_000 })
-    expect(page.url()).toBe(urlBeforeDismiss)
+    await expect(highlightPopup).toBeHidden({ timeout: 5_000 });
+    await expect(retainedMark).toBeHidden({ timeout: 5_000 });
+    expect(page.url()).toBe(urlBeforeDismiss);
 
     await expect(page.locator('[data-sonner-toast][data-type="error"]')).toHaveCount(0);
   });

--- a/quotevote-frontend/src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
@@ -1,361 +1,140 @@
 /**
- * SelectionPopover component tests
+ * SelectionPopover component tests — pure portal/positioning (issue #484)
  */
 
-import { render, screen, fireEvent, act } from '@/__tests__/utils/test-utils'
+import { render, screen, act } from '@/__tests__/utils/test-utils'
 import SelectionPopover from '@/components/VotingComponents/SelectionPopover'
 import type { SelectionPopoverProps } from '@/types/voting'
+import { createRef } from 'react'
 
 describe('SelectionPopover', () => {
-  const defaultProps: SelectionPopoverProps = {
+  const makeProps = (overrides: Partial<SelectionPopoverProps> = {}): SelectionPopoverProps => ({
     showPopover: false,
-    onSelect: jest.fn(),
-    onDeselect: jest.fn(),
+    resolveAnchorRect: jest.fn(() => ({
+      top: 100,
+      left: 50,
+      width: 200,
+      height: 20,
+      bottom: 120,
+      right: 250,
+      x: 50,
+      y: 100,
+      toJSON: () => {},
+    }) as unknown as DOMRect),
+    popoverRef: createRef<HTMLDivElement>() as React.RefObject<HTMLDivElement | null>,
     children: <div>Test content</div>,
-  }
-
-  beforeEach(() => {
-    // Mock window.getSelection
-    global.window.getSelection = jest.fn(() => {
-      const mockRange = {
-        getBoundingClientRect: () => ({
-          top: 100,
-          left: 50,
-          width: 200,
-          height: 20,
-          x: 50,
-        }),
-        collapsed: false,
-        startContainer: document.createTextNode('test'),
-        startOffset: 0,
-        endContainer: document.createTextNode('test'),
-        endOffset: 4,
-        setStart: jest.fn(),
-        setEnd: jest.fn(),
-      }
-      return {
-        rangeCount: 1,
-        getRangeAt: () => mockRange,
-        removeAllRanges: jest.fn(),
-      } as unknown as Selection
-    })
-
-    // Create a mock selectable element
-    const selectableDiv = document.createElement('div')
-    selectableDiv.setAttribute('data-selectable', 'true')
-    document.body.appendChild(selectableDiv)
-  })
-
-  afterEach(() => {
-    // Clean up
-    const selectable = document.querySelector('[data-selectable]')
-    if (selectable) {
-      document.body.removeChild(selectable)
-    }
-    jest.clearAllMocks()
+    ...overrides,
   })
 
   it('renders children when showPopover is true', () => {
-    render(<SelectionPopover {...defaultProps} showPopover={true} />)
+    render(<SelectionPopover {...makeProps({ showPopover: true })} />)
     expect(screen.getByText('Test content')).toBeInTheDocument()
   })
 
   it('does not render children when showPopover is false', () => {
-    render(<SelectionPopover {...defaultProps} showPopover={false} />)
+    render(<SelectionPopover {...makeProps({ showPopover: false })} />)
     expect(screen.queryByText('Test content')).not.toBeInTheDocument()
   })
 
-  it('calls onDeselect when selection is cleared', async () => {
-    const onDeselect = jest.fn()
-
-    // Override getSelection to return null (cleared)
-    global.window.getSelection = jest.fn(() => null)
-
-    render(
-      <SelectionPopover
-        {...defaultProps}
-        showPopover={true}
-        onDeselect={onDeselect}
-      />,
-    )
-
-    // Trigger a pointermove so selectionChange runs with no active selection
-    await act(async () => {
-      const target = document.querySelector('[data-selectable]')
-      if (target) target.dispatchEvent(new Event('pointermove'))
-    })
-
-    expect(onDeselect).toHaveBeenCalled()
-  })
-
   it('applies custom topOffset', () => {
-    render(
-      <SelectionPopover {...defaultProps} showPopover={true} topOffset={50} />,
-    )
+    render(<SelectionPopover {...makeProps({ showPopover: true, topOffset: 50 })} />)
     const popover = document.querySelector('#selectionPopover')
     expect(popover).toBeInTheDocument()
   })
 
   it('renders above the post sticky action bar (z-index > 10) by default', () => {
-    render(
-      <SelectionPopover {...defaultProps} showPopover={true} />,
-    )
+    render(<SelectionPopover {...makeProps({ showPopover: true })} />)
     const popover = document.querySelector('#selectionPopover') as HTMLElement
     expect(Number(popover.style.zIndex)).toBeGreaterThan(10)
   })
 
   it('applies custom styles', () => {
     const customStyle = { zIndex: 999 }
-    render(
-      <SelectionPopover
-        {...defaultProps}
-        showPopover={true}
-        style={customStyle}
-      />,
-    )
+    render(<SelectionPopover {...makeProps({ showPopover: true, style: customStyle })} />)
     const popover = document.querySelector('#selectionPopover') as HTMLElement
     expect(popover).toHaveStyle({ zIndex: '999' })
   })
 
-  it('calls onSelect when a valid selection exists on pointermove', async () => {
-    const onSelect = jest.fn()
-    const onDeselect = jest.fn()
-
-    render(
-      <SelectionPopover
-        {...defaultProps}
-        showPopover={true}
-        onSelect={onSelect}
-        onDeselect={onDeselect}
-      />,
+  it('computes popover position correctly for desktop', async () => {
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1200 })
+    const resolveAnchorRect = jest.fn(
+      () =>
+        ({
+          top: 200,
+          left: 100,
+          width: 300,
+          height: 20,
+          bottom: 220,
+          right: 400,
+          x: 100,
+          y: 200,
+        }) as unknown as DOMRect
     )
-
+    render(<SelectionPopover {...makeProps({ showPopover: true, resolveAnchorRect })} />)
+    // Let rAF compute
     await act(async () => {
-      const target = document.querySelector('[data-selectable]')
-      if (target) target.dispatchEvent(new Event('pointermove'))
+      await new Promise((r) => requestAnimationFrame(() => r(null)))
     })
-
-    // With the mock selection (rangeCount=1, not collapsed, width > 0), onSelect must fire
-    expect(onSelect).toHaveBeenCalledTimes(1)
-    expect(onDeselect).not.toHaveBeenCalled()
-  })
-
-  it('starts interval polling for selection on selectstart (mobile)', async () => {
-    jest.useFakeTimers()
-    const onSelect = jest.fn()
-
-    render(
-      <SelectionPopover
-        {...defaultProps}
-        showPopover={true}
-        onSelect={onSelect}
-      />,
-    )
-
-    // Trigger mobile selectstart to start the 100ms polling interval
-    await act(async () => {
-      const target = document.querySelector('[data-selectable]')
-      if (target) target.dispatchEvent(new Event('selectstart'))
-    })
-
-    // Advance past one polling tick — selection mock is valid so onSelect fires
-    await act(async () => {
-      jest.advanceTimersByTime(150)
-    })
-
-    expect(onSelect).toHaveBeenCalled()
-    jest.useRealTimers()
-  })
-
-  it('clears selection when showPopover becomes false', () => {
-    const { rerender } = render(
-      <SelectionPopover
-        {...defaultProps}
-        showPopover={true}
-      />,
-    )
-
-    expect(screen.getByText('Test content')).toBeInTheDocument()
-
-    // Change showPopover to false
-    act(() => {
-      rerender(
-        <SelectionPopover
-          {...defaultProps}
-          showPopover={false}
-        />,
-      )
-    })
-
-    // Selection clearing is handled internally by the component
-    // We verify the component handles the state change
-    expect(screen.queryByText('Test content')).not.toBeInTheDocument()
-  })
-
-  it('does not alter selection or call onSelect when mouse enters the popover', async () => {
-    const onSelect = jest.fn()
-
-    render(
-      <SelectionPopover
-        {...defaultProps}
-        showPopover={true}
-        onSelect={onSelect}
-      />,
-    )
-
-    const popover = document.querySelector('#selectionPopover')
-    if (popover) {
-      await act(async () => {
-        fireEvent.mouseEnter(popover)
-      })
-    }
-
-    expect(onSelect).not.toHaveBeenCalled()
-  })
-
-  it('computes popover position correctly for desktop', () => {
-    // Mock window.innerWidth for desktop
-    Object.defineProperty(window, 'innerWidth', {
-      writable: true,
-      configurable: true,
-      value: 1200,
-    })
-
-    render(
-      <SelectionPopover
-        {...defaultProps}
-        showPopover={true}
-        topOffset={30}
-      />,
-    )
-
+    expect(resolveAnchorRect).toHaveBeenCalled()
     const popover = document.querySelector('#selectionPopover')
     expect(popover).toBeInTheDocument()
   })
 
   it('computes popover position correctly for tablet', () => {
-    // Mock window.innerWidth for tablet
-    Object.defineProperty(window, 'innerWidth', {
-      writable: true,
-      configurable: true,
-      value: 800,
-    })
-
-    render(
-      <SelectionPopover
-        {...defaultProps}
-        showPopover={true}
-        topOffset={30}
-      />,
-    )
-
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 800 })
+    render(<SelectionPopover {...makeProps({ showPopover: true, topOffset: 30 })} />)
     const popover = document.querySelector('#selectionPopover')
     expect(popover).toBeInTheDocument()
   })
 
   it('computes popover position correctly for mobile', () => {
-    // Mock window.innerWidth for mobile
-    Object.defineProperty(window, 'innerWidth', {
-      writable: true,
-      configurable: true,
-      value: 400,
-    })
-
-    render(
-      <SelectionPopover
-        {...defaultProps}
-        showPopover={true}
-        topOffset={30}
-      />,
-    )
-
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 400 })
+    render(<SelectionPopover {...makeProps({ showPopover: true, topOffset: 30 })} />)
     const popover = document.querySelector('#selectionPopover')
     expect(popover).toBeInTheDocument()
   })
 
-  it('handles missing selectable element gracefully', () => {
-    // Create a new container without selectable element
-    render(
-      <SelectionPopover
-        {...defaultProps}
-        showPopover={true}
-      />,
-    )
-
-    // Component should still render children when showPopover is true
-    // even if selectable element is missing (it will be created by parent)
+  it('handles missing anchor rect gracefully', () => {
+    const resolveAnchorRect = jest.fn(() => null)
+    render(<SelectionPopover {...makeProps({ showPopover: true, resolveAnchorRect })} />)
     expect(screen.getByText('Test content')).toBeInTheDocument()
   })
 
-  it('calls onDeselect when selection is collapsed', async () => {
-    const onDeselect = jest.fn()
-
-    // Override with a collapsed (zero-width) selection
-    global.window.getSelection = jest.fn(() => {
-      const mockRange = {
-        getBoundingClientRect: () => ({
-          top: 100,
-          left: 50,
-          width: 0,
-          height: 0,
-          x: 50,
-        }),
-        collapsed: true,
-        startContainer: document.createTextNode('test'),
-        startOffset: 0,
-        endContainer: document.createTextNode('test'),
-        endOffset: 0,
-        setStart: jest.fn(),
-        setEnd: jest.fn(),
-      }
-      return {
-        rangeCount: 1,
-        getRangeAt: () => mockRange,
-        removeAllRanges: jest.fn(),
-      } as unknown as Selection
-    })
-
-    render(
-      <SelectionPopover
-        {...defaultProps}
-        showPopover={true}
-        onDeselect={onDeselect}
-      />,
-    )
-
-    // Trigger a selectionChange via pointermove with a collapsed selection
-    await act(async () => {
-      const target = document.querySelector('[data-selectable]')
-      if (target) target.dispatchEvent(new Event('pointermove'))
-    })
-
-    expect(onDeselect).toHaveBeenCalled()
+  it('handles popoverRef without current element gracefully', () => {
+    const emptyRef = { current: null } as React.RefObject<HTMLDivElement | null>
+    render(<SelectionPopover {...makeProps({ showPopover: true, popoverRef: emptyRef })} />)
+    expect(screen.getByText('Test content')).toBeInTheDocument()
   })
 
-  it('cleans up interval on unmount', async () => {
-    const { unmount } = render(
-      <SelectionPopover
-        {...defaultProps}
-        showPopover={true}
-      />,
+  it('recomputes on resize/orientationchange while visible', async () => {
+    const resolveAnchorRect = jest.fn(
+      () =>
+        ({
+          top: 100,
+          left: 50,
+          width: 200,
+          height: 20,
+          bottom: 120,
+          right: 250,
+          x: 50,
+          y: 100,
+        }) as unknown as DOMRect
     )
-
-    // Trigger mobile selection to create interval
+    render(<SelectionPopover {...makeProps({ showPopover: true, resolveAnchorRect })} />)
     await act(async () => {
-      const target = document.querySelector('[data-selectable]')
-      if (target) {
-        const event = new Event('selectstart')
-        target.dispatchEvent(event)
-      }
+      window.dispatchEvent(new Event('resize'))
+      window.dispatchEvent(new Event('orientationchange'))
     })
+    // After events, still mounted
+    expect(document.querySelector('#selectionPopover')).toBeInTheDocument()
+  })
 
-    // Unmount should clean up
-    act(() => {
-      unmount()
-    })
-
-    // Interval should be cleared (no way to directly test, but unmount should not error)
+  it('cleans up rAF on unmount/hide', () => {
+    const { rerender, unmount } = render(<SelectionPopover {...makeProps({ showPopover: true })} />)
+    expect(screen.getByText('Test content')).toBeInTheDocument()
+    rerender(<SelectionPopover {...makeProps({ showPopover: false })} />)
+    expect(screen.queryByText('Test content')).not.toBeInTheDocument()
+    unmount()
     expect(true).toBe(true)
   })
 })
-

--- a/quotevote-frontend/src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/SelectionPopover.test.tsx
@@ -2,61 +2,68 @@
  * SelectionPopover component tests — pure portal/positioning (issue #484)
  */
 
-import { render, screen, act } from '@/__tests__/utils/test-utils'
-import SelectionPopover from '@/components/VotingComponents/SelectionPopover'
-import type { SelectionPopoverProps } from '@/types/voting'
-import { createRef } from 'react'
+import { render, screen, act } from "@/__tests__/utils/test-utils";
+import SelectionPopover from "@/components/VotingComponents/SelectionPopover";
+import type { SelectionPopoverProps } from "@/types/voting";
+import { createRef } from "react";
 
-describe('SelectionPopover', () => {
+describe("SelectionPopover", () => {
   const makeProps = (overrides: Partial<SelectionPopoverProps> = {}): SelectionPopoverProps => ({
     showPopover: false,
-    resolveAnchorRect: jest.fn(() => ({
-      top: 100,
-      left: 50,
-      width: 200,
-      height: 20,
-      bottom: 120,
-      right: 250,
-      x: 50,
-      y: 100,
-      toJSON: () => {},
-    }) as unknown as DOMRect),
+    resolveAnchorRect: jest.fn(
+      () =>
+        ({
+          top: 100,
+          left: 50,
+          width: 200,
+          height: 20,
+          bottom: 120,
+          right: 250,
+          x: 50,
+          y: 100,
+          toJSON: () => {},
+        }) as unknown as DOMRect
+    ),
     popoverRef: createRef<HTMLDivElement>() as React.RefObject<HTMLDivElement | null>,
     children: <div>Test content</div>,
     ...overrides,
-  })
+  });
 
-  it('renders children when showPopover is true', () => {
-    render(<SelectionPopover {...makeProps({ showPopover: true })} />)
-    expect(screen.getByText('Test content')).toBeInTheDocument()
-  })
+  it("renders children when showPopover is true", () => {
+    render(<SelectionPopover {...makeProps({ showPopover: true })} />);
+    expect(screen.getByText("Test content")).toBeInTheDocument();
+  });
 
-  it('does not render children when showPopover is false', () => {
-    render(<SelectionPopover {...makeProps({ showPopover: false })} />)
-    expect(screen.queryByText('Test content')).not.toBeInTheDocument()
-  })
+  it("does not render children when showPopover is false", () => {
+    render(<SelectionPopover {...makeProps({ showPopover: false })} />);
+    expect(screen.queryByText("Test content")).not.toBeInTheDocument();
+  });
 
-  it('applies custom topOffset', () => {
-    render(<SelectionPopover {...makeProps({ showPopover: true, topOffset: 50 })} />)
-    const popover = document.querySelector('#selectionPopover')
-    expect(popover).toBeInTheDocument()
-  })
+  it("applies custom topOffset", () => {
+    render(<SelectionPopover {...makeProps({ showPopover: true, topOffset: 50 })} />);
+    const popover = document.querySelector("#selectionPopover");
+    expect(popover).toBeInTheDocument();
+  });
 
-  it('renders above the post sticky action bar (z-index > 10) by default', () => {
-    render(<SelectionPopover {...makeProps({ showPopover: true })} />)
-    const popover = document.querySelector('#selectionPopover') as HTMLElement
-    expect(Number(popover.style.zIndex)).toBeGreaterThan(10)
-  })
+  it("renders above the post sticky action bar (z-index > 10) by default", () => {
+    render(<SelectionPopover {...makeProps({ showPopover: true })} />);
+    const popover = document.querySelector("#selectionPopover") as HTMLElement;
+    expect(Number(popover.style.zIndex)).toBeGreaterThan(10);
+  });
 
-  it('applies custom styles', () => {
-    const customStyle = { zIndex: 999 }
-    render(<SelectionPopover {...makeProps({ showPopover: true, style: customStyle })} />)
-    const popover = document.querySelector('#selectionPopover') as HTMLElement
-    expect(popover).toHaveStyle({ zIndex: '999' })
-  })
+  it("applies custom styles", () => {
+    const customStyle = { zIndex: 999 };
+    render(<SelectionPopover {...makeProps({ showPopover: true, style: customStyle })} />);
+    const popover = document.querySelector("#selectionPopover") as HTMLElement;
+    expect(popover).toHaveStyle({ zIndex: "999" });
+  });
 
-  it('computes popover position correctly for desktop', async () => {
-    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1200 })
+  it("computes popover position correctly for desktop", async () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 1200,
+    });
     const resolveAnchorRect = jest.fn(
       () =>
         ({
@@ -69,44 +76,44 @@ describe('SelectionPopover', () => {
           x: 100,
           y: 200,
         }) as unknown as DOMRect
-    )
-    render(<SelectionPopover {...makeProps({ showPopover: true, resolveAnchorRect })} />)
+    );
+    render(<SelectionPopover {...makeProps({ showPopover: true, resolveAnchorRect })} />);
     // Let rAF compute
     await act(async () => {
-      await new Promise((r) => requestAnimationFrame(() => r(null)))
-    })
-    expect(resolveAnchorRect).toHaveBeenCalled()
-    const popover = document.querySelector('#selectionPopover')
-    expect(popover).toBeInTheDocument()
-  })
+      await new Promise((r) => requestAnimationFrame(() => r(null)));
+    });
+    expect(resolveAnchorRect).toHaveBeenCalled();
+    const popover = document.querySelector("#selectionPopover");
+    expect(popover).toBeInTheDocument();
+  });
 
-  it('computes popover position correctly for tablet', () => {
-    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 800 })
-    render(<SelectionPopover {...makeProps({ showPopover: true, topOffset: 30 })} />)
-    const popover = document.querySelector('#selectionPopover')
-    expect(popover).toBeInTheDocument()
-  })
+  it("computes popover position correctly for tablet", () => {
+    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 800 });
+    render(<SelectionPopover {...makeProps({ showPopover: true, topOffset: 30 })} />);
+    const popover = document.querySelector("#selectionPopover");
+    expect(popover).toBeInTheDocument();
+  });
 
-  it('computes popover position correctly for mobile', () => {
-    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 400 })
-    render(<SelectionPopover {...makeProps({ showPopover: true, topOffset: 30 })} />)
-    const popover = document.querySelector('#selectionPopover')
-    expect(popover).toBeInTheDocument()
-  })
+  it("computes popover position correctly for mobile", () => {
+    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 400 });
+    render(<SelectionPopover {...makeProps({ showPopover: true, topOffset: 30 })} />);
+    const popover = document.querySelector("#selectionPopover");
+    expect(popover).toBeInTheDocument();
+  });
 
-  it('handles missing anchor rect gracefully', () => {
-    const resolveAnchorRect = jest.fn(() => null)
-    render(<SelectionPopover {...makeProps({ showPopover: true, resolveAnchorRect })} />)
-    expect(screen.getByText('Test content')).toBeInTheDocument()
-  })
+  it("handles missing anchor rect gracefully", () => {
+    const resolveAnchorRect = jest.fn(() => null);
+    render(<SelectionPopover {...makeProps({ showPopover: true, resolveAnchorRect })} />);
+    expect(screen.getByText("Test content")).toBeInTheDocument();
+  });
 
-  it('handles popoverRef without current element gracefully', () => {
-    const emptyRef = { current: null } as React.RefObject<HTMLDivElement | null>
-    render(<SelectionPopover {...makeProps({ showPopover: true, popoverRef: emptyRef })} />)
-    expect(screen.getByText('Test content')).toBeInTheDocument()
-  })
+  it("handles popoverRef without current element gracefully", () => {
+    const emptyRef = { current: null } as React.RefObject<HTMLDivElement | null>;
+    render(<SelectionPopover {...makeProps({ showPopover: true, popoverRef: emptyRef })} />);
+    expect(screen.getByText("Test content")).toBeInTheDocument();
+  });
 
-  it('recomputes on resize/orientationchange while visible', async () => {
+  it("recomputes on resize/orientationchange while visible", async () => {
     const resolveAnchorRect = jest.fn(
       () =>
         ({
@@ -119,22 +126,24 @@ describe('SelectionPopover', () => {
           x: 50,
           y: 100,
         }) as unknown as DOMRect
-    )
-    render(<SelectionPopover {...makeProps({ showPopover: true, resolveAnchorRect })} />)
+    );
+    render(<SelectionPopover {...makeProps({ showPopover: true, resolveAnchorRect })} />);
     await act(async () => {
-      window.dispatchEvent(new Event('resize'))
-      window.dispatchEvent(new Event('orientationchange'))
-    })
+      window.dispatchEvent(new Event("resize"));
+      window.dispatchEvent(new Event("orientationchange"));
+    });
     // After events, still mounted
-    expect(document.querySelector('#selectionPopover')).toBeInTheDocument()
-  })
+    expect(document.querySelector("#selectionPopover")).toBeInTheDocument();
+  });
 
-  it('cleans up rAF on unmount/hide', () => {
-    const { rerender, unmount } = render(<SelectionPopover {...makeProps({ showPopover: true })} />)
-    expect(screen.getByText('Test content')).toBeInTheDocument()
-    rerender(<SelectionPopover {...makeProps({ showPopover: false })} />)
-    expect(screen.queryByText('Test content')).not.toBeInTheDocument()
-    unmount()
-    expect(true).toBe(true)
-  })
-})
+  it("cleans up rAF on unmount/hide", () => {
+    const { rerender, unmount } = render(
+      <SelectionPopover {...makeProps({ showPopover: true })} />
+    );
+    expect(screen.getByText("Test content")).toBeInTheDocument();
+    rerender(<SelectionPopover {...makeProps({ showPopover: false })} />);
+    expect(screen.queryByText("Test content")).not.toBeInTheDocument();
+    unmount();
+    expect(true).toBe(true);
+  });
+});

--- a/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.state.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.state.test.tsx
@@ -1,13 +1,6 @@
-/**
- * VotingBoard — state machine tests (issue #484)
- * Covers P1#1 desktop gating, P1#2 tap-vs-drag, P1#3 popover exemption is via
- * suppression logic in the component, and P2#3 coverage gaps.
- */
-
 import { render, screen, fireEvent, waitFor, act } from "@/__tests__/utils/test-utils";
 import VotingBoard from "@/components/VotingComponents/VotingBoard";
 
-// Polyfill PointerEvent for jsdom
 if (typeof window !== "undefined" && typeof window.PointerEvent === "undefined") {
   class PointerEventPolyfill extends MouseEvent {
     pointerId: number;
@@ -22,7 +15,6 @@ if (typeof window !== "undefined" && typeof window.PointerEvent === "undefined")
     PointerEventPolyfill as unknown as typeof PointerEvent;
 }
 
-// Keep Highlighter mock simple but allow findChunks to determine visibility
 jest.mock("react-highlight-words", () => ({
   __esModule: true,
   default: ({
@@ -47,7 +39,6 @@ jest.mock("react-highlight-words", () => ({
   },
 }));
 
-// Pure portal mock that forwards popoverRef so suppression exemption can be tested
 jest.mock("@/components/VotingComponents/SelectionPopover", () => {
   function MockSelectionPopover({
     children,
@@ -150,7 +141,6 @@ function setSelectionForSubstring(container: HTMLElement, substring: string): Ra
   const range = document.createRange();
   range.setStart(startNode, startOffset);
   range.setEnd(endNode, endOffset);
-  // Direct stub — Range instances in jsdom may not have own getBoundingClientRect
   (range as unknown as { getBoundingClientRect: () => DOMRect }).getBoundingClientRect = () =>
     FAKE_RECT;
   const sel = window.getSelection();
@@ -177,7 +167,6 @@ function dispatchPointer(
     pointerId: (init as { pointerId?: number }).pointerId ?? 1,
     ...init,
   } as PointerEventInit);
-  // Ensure pointerId is set even if ctor ignored it
   if ((init as { pointerId?: number }).pointerId !== undefined) {
     Object.defineProperty(event, "pointerId", {
       value: (init as { pointerId?: number }).pointerId,
@@ -204,10 +193,9 @@ function dispatchClick(target: Element, pointerId?: number, init: Partial<MouseE
   return event;
 }
 
-describe("VotingBoard — state machine (issue #484)", () => {
+describe("VotingBoard — state machine", () => {
   beforeEach(() => {
     Element.prototype.scrollIntoView = jest.fn();
-    // Stub Range rect globally for all ranges created in these tests
     if (!Range.prototype.getBoundingClientRect) {
       Range.prototype.getBoundingClientRect = () => FAKE_RECT;
     }
@@ -220,7 +208,6 @@ describe("VotingBoard — state machine (issue #484)", () => {
     jest.restoreAllMocks();
     window.getSelection()?.removeAllRanges();
     document.body.innerHTML = "";
-    // Clear any interval/suppression timers that were using real timers
     jest.clearAllTimers();
     jest.useRealTimers();
   });
@@ -245,12 +232,11 @@ describe("VotingBoard — state machine (issue #484)", () => {
     expect(onSelect.mock.calls[0][0].text).toBe("hello");
     const popover = screen.getByTestId("selection-popover");
     expect(popover.dataset.show).toBe("true");
-    // Desktop never renders the retained mobile mark
     expect(screen.queryByTestId("retained-selection-highlight")).not.toBeInTheDocument();
     expect(onDeselect).not.toHaveBeenCalled();
   });
 
-  it("desktop: selection collapse dismisses the toolbar (no outside-tap handler)", async () => {
+  it("desktop: selection collapse dismisses the toolbar", async () => {
     mockTouch(false);
     const onSelect = jest.fn();
     const onDeselect = jest.fn();
@@ -266,7 +252,6 @@ describe("VotingBoard — state machine (issue #484)", () => {
     });
     await waitFor(() => expect(onSelect).toHaveBeenCalled());
 
-    // Collapse the selection (click elsewhere) — desktop should dismiss via selectionchange
     window.getSelection()?.removeAllRanges();
     await act(async () => {
       document.dispatchEvent(new Event("selectionchange"));
@@ -276,7 +261,7 @@ describe("VotingBoard — state machine (issue #484)", () => {
     expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
   });
 
-  it("touch: valid selection enters native (popover hidden) before first tap", async () => {
+  it("touch: valid selection enters native before first tap", async () => {
     jest.useFakeTimers();
     mockTouch(true);
     const onSelect = jest.fn();
@@ -294,15 +279,13 @@ describe("VotingBoard — state machine (issue #484)", () => {
       jest.advanceTimersByTime(150);
     });
 
-    // Polling should have stored the selection but not opened the toolbar
     expect(onSelect).not.toHaveBeenCalled();
     expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
     expect(screen.queryByTestId("retained-selection-highlight")).not.toBeInTheDocument();
-    // Native selection still intact
     expect(window.getSelection()?.toString()).toBe("hello");
   });
 
-  it("touch: first outside tap transitions to toolbar, retains highlight, clears native", async () => {
+  it("touch: first outside tap transitions to toolbar", async () => {
     jest.useFakeTimers();
     mockTouch(true);
     const onSelect = jest.fn();
@@ -319,10 +302,6 @@ describe("VotingBoard — state machine (issue #484)", () => {
       jest.advanceTimersByTime(150);
     });
 
-    const outside = document.createElement("div");
-    outside.setAttribute("data-testid", "outside");
-    document.body.appendChild(outside);
-
     await act(async () => {
       dispatchPointer(document, "pointerdown", { pointerId: 1, clientX: 5, clientY: 5 });
     });
@@ -331,7 +310,6 @@ describe("VotingBoard — state machine (issue #484)", () => {
     expect(onSelect.mock.calls[0][0].text).toBe("hello");
     expect(window.getSelection()?.toString()).toBe("");
     await waitFor(() => expect(screen.getByTestId("selection-popover").dataset.show).toBe("true"));
-    // Retained mark rendered with exact occurrence (findChunks mock renders Tag)
     expect(screen.getByTestId("retained-selection-highlight")).toBeInTheDocument();
   });
 
@@ -345,7 +323,6 @@ describe("VotingBoard — state machine (issue #484)", () => {
       </VotingBoard>
     );
 
-    // First selection -> native
     setSelectionForSubstring(container as unknown as HTMLElement, "hello");
     fireEvent(
       container.querySelector("[data-selectable]") as HTMLElement,
@@ -358,9 +335,6 @@ describe("VotingBoard — state machine (issue #484)", () => {
 
     const p = container.querySelector(".voting_board-content") as HTMLElement;
 
-    // Stationary tap inside the quote — must dispatch only on the inside
-    // target. Dispatching on document first would already trigger the
-    // outside-transition and give false confidence (P2 #3).
     await act(async () => {
       dispatchPointer(p, "pointerdown", { pointerId: 2, clientX: 60, clientY: 60 });
       dispatchPointer(p, "pointerup", { pointerId: 2, clientX: 60, clientY: 60 });
@@ -369,7 +343,6 @@ describe("VotingBoard — state machine (issue #484)", () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("selection-popover").dataset.show).toBe("true");
 
-    // Reset for drag case
     window.getSelection()?.removeAllRanges();
     jest.useRealTimers();
     jest.useFakeTimers();
@@ -398,7 +371,6 @@ describe("VotingBoard — state machine (issue #484)", () => {
       dispatchPointer(p2, "pointerup", { pointerId: 3, clientX: 120, clientY: 60 });
     });
 
-    // Dragged gesture should NOT transition
     expect(onSelect).not.toHaveBeenCalled();
     expect(screen.getAllByTestId("selection-popover").pop()?.dataset.show).toBe("false");
   });
@@ -428,24 +400,18 @@ describe("VotingBoard — state machine (issue #484)", () => {
     });
     await waitFor(() => expect(screen.getByTestId("selection-popover").dataset.show).toBe("true"));
 
-    // Underlying UI that would be activated if click were not suppressed
     const underlying = document.createElement("button");
     underlying.setAttribute("data-testid", "underlying-button");
     document.body.appendChild(underlying);
     const underlyingClick = jest.fn();
     underlying.addEventListener("click", underlyingClick);
 
-    // Second outside tap — arms suppression and sets pendingDismiss, does NOT
-    // reset immediately (P1 #1). The delayed compatibility click must be
-    // consumed before we go idle.
     await act(async () => {
       dispatchPointer(document, "pointerdown", { pointerId: 6, clientX: 5, clientY: 5 });
     });
-    // Toolbar is still visible until the click is handled
     expect(screen.getByTestId("selection-popover").dataset.show).toBe("true");
     expect(onDeselect).not.toHaveBeenCalled();
 
-    // Delayed click on the underlying button — should be suppressed
     const clickEvent = await act(async () => {
       return dispatchClick(underlying, 6);
     });
@@ -491,15 +457,12 @@ describe("VotingBoard — state machine (issue #484)", () => {
     const actionClick = jest.fn();
     action.addEventListener("click", actionClick);
 
-    // Quick tap on the toolbar action within the 750ms suppression window.
-    // The click target is inside popoverRef, so it must be let through (P1 #3).
     const toolbarClick = await act(async () => {
       return dispatchClick(action, 10);
     });
 
     expect(toolbarClick.defaultPrevented).toBe(false);
     expect(actionClick).toHaveBeenCalledTimes(1);
-    // Toolbar stays open — suppression was cleared without dismissing
     expect(screen.getByTestId("selection-popover").dataset.show).toBe("true");
     expect(popover.contains(action)).toBe(true);
   });
@@ -541,7 +504,6 @@ describe("VotingBoard — state machine (issue #484)", () => {
     });
 
     expect(onDeselect).toHaveBeenCalled();
-    // Dialog events must not be prevented
     expect(defaultPreventedBefore.called).toBe(false);
     expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
   });

--- a/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.state.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.state.test.tsx
@@ -470,6 +470,7 @@ describe("VotingBoard — state machine", () => {
   it("touch: dialog target clears stale toolbar without swallowing the dialog event", async () => {
     jest.useFakeTimers();
     mockTouch(true);
+    const clearIntervalSpy = jest.spyOn(globalThis, "clearInterval");
     const onDeselect = jest.fn();
     const { container } = render(
       <VotingBoard content={CONTENT} onDeselect={onDeselect}>
@@ -504,8 +505,52 @@ describe("VotingBoard — state machine", () => {
     });
 
     expect(onDeselect).toHaveBeenCalled();
+    expect(clearIntervalSpy).toHaveBeenCalled();
     expect(defaultPreventedBefore.called).toBe(false);
     expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
+  });
+
+  it("touch: content reset clears pending click suppression", async () => {
+    jest.useFakeTimers();
+    mockTouch(true);
+    const onDeselect = jest.fn();
+    const { container, rerender } = render(
+      <VotingBoard content={CONTENT} onDeselect={onDeselect}>
+        {(sel) => <span>{sel.text}</span>}
+      </VotingBoard>
+    );
+
+    setSelectionForSubstring(container as unknown as HTMLElement, "hello");
+    fireEvent(
+      container.querySelector("[data-selectable]") as HTMLElement,
+      new Event("selectstart")
+    );
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+
+    await act(async () => {
+      dispatchPointer(document, "pointerdown", { pointerId: 11, clientX: 5, clientY: 5 });
+    });
+    await waitFor(() => expect(screen.getByTestId("selection-popover").dataset.show).toBe("true"));
+
+    rerender(
+      <VotingBoard content="completely new content for reset" onDeselect={onDeselect}>
+        {(sel) => <span>{sel.text}</span>}
+      </VotingBoard>
+    );
+
+    const underlying = document.createElement("button");
+    document.body.appendChild(underlying);
+    const underlyingClick = jest.fn();
+    underlying.addEventListener("click", underlyingClick);
+
+    const clickEvent = await act(async () => dispatchClick(underlying, 11));
+
+    expect(clickEvent.defaultPrevented).toBe(false);
+    expect(underlyingClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
+    expect(onDeselect).toHaveBeenCalled();
   });
 
   it("resets on content change", async () => {

--- a/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.state.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.state.test.tsx
@@ -1,0 +1,498 @@
+/**
+ * VotingBoard — state machine tests (issue #484)
+ * Covers P1#1 desktop gating, P1#2 tap-vs-drag, P1#3 popover exemption is via
+ * suppression logic in the component, and P2#3 coverage gaps.
+ */
+
+import { render, screen, fireEvent, waitFor, act } from "@/__tests__/utils/test-utils";
+import VotingBoard from "@/components/VotingComponents/VotingBoard";
+
+// Polyfill PointerEvent for jsdom
+if (typeof window !== "undefined" && typeof window.PointerEvent === "undefined") {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    constructor(type: string, init: MouseEventInit & { pointerId?: number } = {}) {
+      super(type, init);
+      this.pointerId = init.pointerId ?? 0;
+    }
+  }
+  (window as unknown as { PointerEvent: typeof PointerEventPolyfill }).PointerEvent =
+    PointerEventPolyfill as unknown as typeof PointerEvent;
+  (global as unknown as { PointerEvent: typeof PointerEventPolyfill }).PointerEvent =
+    PointerEventPolyfill as unknown as typeof PointerEvent;
+}
+
+// Keep Highlighter mock simple but allow findChunks to determine visibility
+jest.mock("react-highlight-words", () => ({
+  __esModule: true,
+  default: ({
+    textToHighlight,
+    highlightTag: Tag,
+    findChunks,
+  }: {
+    textToHighlight: string;
+    highlightTag?: React.ElementType;
+    findChunks?: () => Array<{ start: number; end: number }>;
+  }) => {
+    const chunks = findChunks?.() ?? [];
+    const first = chunks[0];
+    if (Tag && first && first.end > first.start) {
+      return (
+        <span data-testid="highlighter">
+          <Tag>{textToHighlight.slice(first.start, first.end)}</Tag>
+        </span>
+      );
+    }
+    return <span data-testid="highlighter">{textToHighlight}</span>;
+  },
+}));
+
+// Pure portal mock that forwards popoverRef so suppression exemption can be tested
+jest.mock("@/components/VotingComponents/SelectionPopover", () => {
+  function MockSelectionPopover({
+    children,
+    showPopover,
+    popoverRef,
+  }: {
+    children: React.ReactNode;
+    showPopover: boolean;
+    popoverRef: React.RefObject<HTMLDivElement | null>;
+  }) {
+    const { useEffect, useRef } = jest.requireActual("react") as typeof import("react");
+    const innerRef = (useRef as unknown as () => React.RefObject<HTMLDivElement | null>)();
+    useEffect(() => {
+      if (popoverRef) {
+        (popoverRef as React.MutableRefObject<HTMLDivElement | null>).current = innerRef.current;
+      }
+    }, [showPopover, innerRef, popoverRef]);
+
+    return (
+      <div
+        ref={innerRef as React.RefObject<HTMLDivElement>}
+        data-testid="selection-popover"
+        data-show={String(showPopover)}
+      >
+        {showPopover ? children : null}
+      </div>
+    );
+  }
+  return {
+    __esModule: true,
+    default: MockSelectionPopover,
+  };
+});
+
+const CONTENT = "hello world hello world unique end";
+
+const FAKE_RECT = {
+  width: 100,
+  height: 20,
+  top: 100,
+  left: 50,
+  right: 150,
+  bottom: 120,
+  x: 50,
+  y: 100,
+  toJSON() {},
+} as unknown as DOMRect;
+
+function mockTouch(isTouch: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: isTouch && query === "(hover: none) and (pointer: coarse)",
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+}
+
+function textNodesUnder(el: Element): Text[] {
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  const nodes: Text[] = [];
+  let n: Node | null;
+  while ((n = walker.nextNode())) nodes.push(n as Text);
+  return nodes;
+}
+
+function setSelectionForSubstring(container: HTMLElement, substring: string): Range {
+  const p = container.querySelector(".voting_board-content") as HTMLElement;
+  if (!p) throw new Error("voting_board-content not found");
+  const nodes = textNodesUnder(p);
+  const full = nodes.map((n) => n.textContent ?? "").join("");
+  const startIdx = full.indexOf(substring);
+  if (startIdx === -1) throw new Error(`substring "${substring}" not found in "${full}"`);
+  const endIdx = startIdx + substring.length;
+  let acc = 0;
+  let startNode: Text | undefined;
+  let startOffset = 0;
+  let endNode: Text | undefined;
+  let endOffset = 0;
+  for (const n of nodes) {
+    const len = n.textContent?.length ?? 0;
+    if (startNode === undefined && acc + len > startIdx) {
+      startNode = n;
+      startOffset = startIdx - acc;
+    }
+    if (startNode !== undefined && acc + len >= endIdx) {
+      endNode = n;
+      endOffset = endIdx - acc;
+      break;
+    }
+    acc += len;
+  }
+  if (!startNode || !endNode) throw new Error("range nodes not resolved");
+  const range = document.createRange();
+  range.setStart(startNode, startOffset);
+  range.setEnd(endNode, endOffset);
+  // Direct stub — Range instances in jsdom may not have own getBoundingClientRect
+  (range as unknown as { getBoundingClientRect: () => DOMRect }).getBoundingClientRect = () =>
+    FAKE_RECT;
+  const sel = window.getSelection();
+  if (!sel) throw new Error("no selection");
+  sel.removeAllRanges();
+  sel.addRange(range);
+  return range;
+}
+
+function dispatchPointer(
+  target: Element | Document,
+  type: string,
+  init: Partial<PointerEventInit & { pointerId: number }> = {}
+) {
+  const EventCtor =
+    (window as unknown as { PointerEvent: typeof PointerEvent }).PointerEvent ??
+    (global as unknown as { PointerEvent: typeof PointerEvent }).PointerEvent ??
+    MouseEvent;
+  const event = new (EventCtor as unknown as new (type: string, init: unknown) => Event)(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 5,
+    clientY: init.clientY ?? 5,
+    pointerId: (init as { pointerId?: number }).pointerId ?? 1,
+    ...init,
+  } as PointerEventInit);
+  // Ensure pointerId is set even if ctor ignored it
+  if ((init as { pointerId?: number }).pointerId !== undefined) {
+    Object.defineProperty(event, "pointerId", {
+      value: (init as { pointerId?: number }).pointerId,
+      writable: true,
+    });
+  }
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe("VotingBoard — state machine (issue #484)", () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+    // Stub Range rect globally for all ranges created in these tests
+    if (!Range.prototype.getBoundingClientRect) {
+      Range.prototype.getBoundingClientRect = () => FAKE_RECT;
+    }
+    jest.spyOn(Range.prototype, "getBoundingClientRect").mockReturnValue(FAKE_RECT);
+    mockTouch(false);
+    window.getSelection()?.removeAllRanges();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    window.getSelection()?.removeAllRanges();
+    document.body.innerHTML = "";
+    // Clear any interval/suppression timers that were using real timers
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("desktop: selection opens popover immediately without retained mark", async () => {
+    mockTouch(false);
+    const onSelect = jest.fn();
+    const onDeselect = jest.fn();
+    const { container } = render(
+      <VotingBoard content={CONTENT} onSelect={onSelect} onDeselect={onDeselect}>
+        {(sel) => <span data-testid="sel-text">{sel.text}</span>}
+      </VotingBoard>
+    );
+
+    setSelectionForSubstring(container as unknown as HTMLElement, "hello");
+
+    await act(async () => {
+      document.dispatchEvent(new Event("selectionchange"));
+    });
+
+    await waitFor(() => expect(onSelect).toHaveBeenCalledTimes(1));
+    expect(onSelect.mock.calls[0][0].text).toBe("hello");
+    const popover = screen.getByTestId("selection-popover");
+    expect(popover.dataset.show).toBe("true");
+    // Desktop never renders the retained mobile mark
+    expect(screen.queryByTestId("retained-selection-highlight")).not.toBeInTheDocument();
+    expect(onDeselect).not.toHaveBeenCalled();
+  });
+
+  it("desktop: selection collapse dismisses the toolbar (no outside-tap handler)", async () => {
+    mockTouch(false);
+    const onSelect = jest.fn();
+    const onDeselect = jest.fn();
+    const { container } = render(
+      <VotingBoard content={CONTENT} onSelect={onSelect} onDeselect={onDeselect}>
+        {(sel) => <span>{sel.text}</span>}
+      </VotingBoard>
+    );
+
+    setSelectionForSubstring(container as unknown as HTMLElement, "hello");
+    await act(async () => {
+      document.dispatchEvent(new Event("selectionchange"));
+    });
+    await waitFor(() => expect(onSelect).toHaveBeenCalled());
+
+    // Collapse the selection (click elsewhere) — desktop should dismiss via selectionchange
+    window.getSelection()?.removeAllRanges();
+    await act(async () => {
+      document.dispatchEvent(new Event("selectionchange"));
+    });
+
+    await waitFor(() => expect(onDeselect).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
+  });
+
+  it("touch: valid selection enters native (popover hidden) before first tap", async () => {
+    jest.useFakeTimers();
+    mockTouch(true);
+    const onSelect = jest.fn();
+    const { container } = render(
+      <VotingBoard content={CONTENT} onSelect={onSelect}>
+        {(sel) => <span>{sel.text}</span>}
+      </VotingBoard>
+    );
+
+    setSelectionForSubstring(container as unknown as HTMLElement, "hello");
+    const selectable = container.querySelector("[data-selectable]") as HTMLElement;
+    fireEvent(selectable, new Event("selectstart"));
+
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+
+    // Polling should have stored the selection but not opened the toolbar
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
+    expect(screen.queryByTestId("retained-selection-highlight")).not.toBeInTheDocument();
+    // Native selection still intact
+    expect(window.getSelection()?.toString()).toBe("hello");
+  });
+
+  it("touch: first outside tap transitions to toolbar, retains highlight, clears native", async () => {
+    jest.useFakeTimers();
+    mockTouch(true);
+    const onSelect = jest.fn();
+    const { container } = render(
+      <VotingBoard content={CONTENT} onSelect={onSelect}>
+        {(sel) => <span data-testid="sel-text">{sel.text}</span>}
+      </VotingBoard>
+    );
+
+    setSelectionForSubstring(container as unknown as HTMLElement, "hello");
+    const selectable = container.querySelector("[data-selectable]") as HTMLElement;
+    fireEvent(selectable, new Event("selectstart"));
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+
+    const outside = document.createElement("div");
+    outside.setAttribute("data-testid", "outside");
+    document.body.appendChild(outside);
+
+    await act(async () => {
+      dispatchPointer(document, "pointerdown", { pointerId: 1, clientX: 5, clientY: 5 });
+    });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].text).toBe("hello");
+    expect(window.getSelection()?.toString()).toBe("");
+    await waitFor(() => expect(screen.getByTestId("selection-popover").dataset.show).toBe("true"));
+    // Retained mark rendered with exact occurrence (findChunks mock renders Tag)
+    expect(screen.getByTestId("retained-selection-highlight")).toBeInTheDocument();
+  });
+
+  it("touch: stationary tap inside the quote performs the first transition; drag does not", async () => {
+    jest.useFakeTimers();
+    mockTouch(true);
+    const onSelect = jest.fn();
+    const { container } = render(
+      <VotingBoard content={CONTENT} onSelect={onSelect}>
+        {(sel) => <span>{sel.text}</span>}
+      </VotingBoard>
+    );
+
+    // First selection -> native
+    setSelectionForSubstring(container as unknown as HTMLElement, "hello");
+    fireEvent(
+      container.querySelector("[data-selectable]") as HTMLElement,
+      new Event("selectstart")
+    );
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+    expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
+
+    const p = container.querySelector(".voting_board-content") as HTMLElement;
+
+    // Stationary tap inside the quote
+    await act(async () => {
+      dispatchPointer(document, "pointerdown", { pointerId: 2, clientX: 60, clientY: 60 });
+      // pointerdown target is document in this dispatch; simulate inside by dispatching on p
+      dispatchPointer(p, "pointerdown", { pointerId: 2, clientX: 60, clientY: 60 });
+      dispatchPointer(document, "pointerup", { pointerId: 2, clientX: 60, clientY: 60 });
+      dispatchPointer(p, "pointerup", { pointerId: 2, clientX: 60, clientY: 60 });
+    });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("selection-popover").dataset.show).toBe("true");
+
+    // Reset for drag case
+    window.getSelection()?.removeAllRanges();
+    jest.useRealTimers();
+    jest.useFakeTimers();
+    mockTouch(true);
+
+    const { container: container2 } = render(
+      <VotingBoard content={CONTENT} onSelect={onSelect}>
+        {(sel) => <span>{sel.text}</span>}
+      </VotingBoard>
+    );
+    setSelectionForSubstring(container2 as unknown as HTMLElement, "world");
+    fireEvent(
+      container2.querySelector("[data-selectable]") as HTMLElement,
+      new Event("selectstart")
+    );
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+    onSelect.mockClear();
+    const p2 = container2.querySelector(".voting_board-content") as HTMLElement;
+
+    await act(async () => {
+      dispatchPointer(p2, "pointerdown", { pointerId: 3, clientX: 60, clientY: 60 });
+      dispatchPointer(document, "pointermove", { pointerId: 3, clientX: 120, clientY: 60 });
+      dispatchPointer(p2, "pointermove", { pointerId: 3, clientX: 120, clientY: 60 });
+      dispatchPointer(p2, "pointerup", { pointerId: 3, clientX: 120, clientY: 60 });
+    });
+
+    // Dragged gesture should NOT transition
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.getAllByTestId("selection-popover").pop()?.dataset.show).toBe("false");
+  });
+
+  it("touch: second outside tap dismisses the toolbar via click suppression window", async () => {
+    jest.useFakeTimers();
+    mockTouch(true);
+    const onDeselect = jest.fn();
+    const onSelect = jest.fn();
+    const { container } = render(
+      <VotingBoard content={CONTENT} onSelect={onSelect} onDeselect={onDeselect}>
+        {(sel) => <span>{sel.text}</span>}
+      </VotingBoard>
+    );
+
+    setSelectionForSubstring(container as unknown as HTMLElement, "hello");
+    fireEvent(
+      container.querySelector("[data-selectable]") as HTMLElement,
+      new Event("selectstart")
+    );
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+
+    await act(async () => {
+      dispatchPointer(document, "pointerdown", { pointerId: 5, clientX: 5, clientY: 5 });
+    });
+    await waitFor(() => expect(screen.getByTestId("selection-popover").dataset.show).toBe("true"));
+
+    // Second outside tap — should arm suppression and schedule idle
+    await act(async () => {
+      dispatchPointer(document, "pointerdown", { pointerId: 6, clientX: 5, clientY: 5 });
+      jest.advanceTimersByTime(10);
+    });
+
+    // The dismissal is scheduled via setTimeout(0) after arming suppression
+    act(() => {
+      jest.advanceTimersByTime(10);
+    });
+
+    await waitFor(() => expect(onDeselect).toHaveBeenCalled());
+    expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
+    expect(screen.queryByTestId("retained-selection-highlight")).not.toBeInTheDocument();
+  });
+
+  it("touch: dialog target clears stale toolbar without swallowing the dialog event", async () => {
+    jest.useFakeTimers();
+    mockTouch(true);
+    const onDeselect = jest.fn();
+    const { container } = render(
+      <VotingBoard content={CONTENT} onDeselect={onDeselect}>
+        {(sel) => <span>{sel.text}</span>}
+      </VotingBoard>
+    );
+
+    setSelectionForSubstring(container as unknown as HTMLElement, "hello");
+    fireEvent(
+      container.querySelector("[data-selectable]") as HTMLElement,
+      new Event("selectstart")
+    );
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+    await act(async () => {
+      dispatchPointer(document, "pointerdown", { pointerId: 7, clientX: 5, clientY: 5 });
+    });
+    await waitFor(() => expect(screen.getByTestId("selection-popover").dataset.show).toBe("true"));
+
+    const dialog = document.createElement("dialog");
+    dialog.setAttribute("open", "");
+    const btn = document.createElement("button");
+    btn.textContent = "dialog action";
+    dialog.appendChild(btn);
+    document.body.appendChild(dialog);
+
+    const defaultPreventedBefore = { called: false };
+    await act(async () => {
+      const ev = dispatchPointer(btn, "pointerdown", { pointerId: 8, clientX: 10, clientY: 10 });
+      defaultPreventedBefore.called = ev.defaultPrevented;
+    });
+
+    expect(onDeselect).toHaveBeenCalled();
+    // Dialog events must not be prevented
+    expect(defaultPreventedBefore.called).toBe(false);
+    expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
+  });
+
+  it("resets on content change", async () => {
+    mockTouch(false);
+    const onDeselect = jest.fn();
+    const { container, rerender } = render(
+      <VotingBoard content={CONTENT} onDeselect={onDeselect}>
+        {(sel) => <span>{sel.text}</span>}
+      </VotingBoard>
+    );
+
+    setSelectionForSubstring(container as unknown as HTMLElement, "hello");
+    await act(async () => {
+      document.dispatchEvent(new Event("selectionchange"));
+    });
+    await waitFor(() => expect(screen.getByTestId("selection-popover").dataset.show).toBe("true"));
+
+    rerender(
+      <VotingBoard content="completely new content for reset" onDeselect={onDeselect}>
+        {(sel) => <span>{sel.text}</span>}
+      </VotingBoard>
+    );
+
+    expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
+    expect(onDeselect).toHaveBeenCalled();
+  });
+});

--- a/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.state.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.state.test.tsx
@@ -103,6 +103,29 @@ function mockTouch(isTouch: boolean) {
   });
 }
 
+function mockTouchWithChangeListener() {
+  let changeListener: (() => void) | null = null;
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: query === "(hover: none) and (pointer: coarse)",
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn((type: string, listener: () => void) => {
+        if (type === "change") changeListener = listener;
+      }),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+  return () => {
+    if (!changeListener) throw new Error("matchMedia change listener not registered");
+    changeListener();
+  };
+}
+
 function textNodesUnder(el: Element): Text[] {
   const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
   const nodes: Text[] = [];
@@ -546,6 +569,48 @@ describe("VotingBoard — state machine", () => {
     underlying.addEventListener("click", underlyingClick);
 
     const clickEvent = await act(async () => dispatchClick(underlying, 11));
+
+    expect(clickEvent.defaultPrevented).toBe(false);
+    expect(underlyingClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
+    expect(onDeselect).toHaveBeenCalled();
+  });
+
+  it("touch: media query change clears pending click suppression", async () => {
+    jest.useFakeTimers();
+    const dispatchMediaChange = mockTouchWithChangeListener();
+    const onDeselect = jest.fn();
+    const { container } = render(
+      <VotingBoard content={CONTENT} onDeselect={onDeselect}>
+        {(sel) => <span>{sel.text}</span>}
+      </VotingBoard>
+    );
+
+    setSelectionForSubstring(container as unknown as HTMLElement, "hello");
+    fireEvent(
+      container.querySelector("[data-selectable]") as HTMLElement,
+      new Event("selectstart")
+    );
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+
+    await act(async () => {
+      dispatchPointer(document, "pointerdown", { pointerId: 12, clientX: 5, clientY: 5 });
+    });
+    await waitFor(() => expect(screen.getByTestId("selection-popover").dataset.show).toBe("true"));
+
+    const underlying = document.createElement("button");
+    document.body.appendChild(underlying);
+    const underlyingClick = jest.fn();
+    underlying.addEventListener("click", underlyingClick);
+
+    await act(async () => {
+      dispatchPointer(underlying, "pointerdown", { pointerId: 13, clientX: 5, clientY: 5 });
+      dispatchMediaChange();
+    });
+
+    const clickEvent = await act(async () => dispatchClick(underlying, 13));
 
     expect(clickEvent.defaultPrevented).toBe(false);
     expect(underlyingClick).toHaveBeenCalledTimes(1);

--- a/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.state.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.state.test.tsx
@@ -188,6 +188,22 @@ function dispatchPointer(
   return event;
 }
 
+function dispatchClick(target: Element, pointerId?: number, init: Partial<MouseEventInit> = {}) {
+  const event = new MouseEvent("click", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  if (pointerId !== undefined) {
+    Object.defineProperty(event, "pointerId", {
+      value: pointerId,
+      writable: true,
+    });
+  }
+  target.dispatchEvent(event);
+  return event;
+}
+
 describe("VotingBoard — state machine (issue #484)", () => {
   beforeEach(() => {
     Element.prototype.scrollIntoView = jest.fn();
@@ -342,12 +358,11 @@ describe("VotingBoard — state machine (issue #484)", () => {
 
     const p = container.querySelector(".voting_board-content") as HTMLElement;
 
-    // Stationary tap inside the quote
+    // Stationary tap inside the quote — must dispatch only on the inside
+    // target. Dispatching on document first would already trigger the
+    // outside-transition and give false confidence (P2 #3).
     await act(async () => {
-      dispatchPointer(document, "pointerdown", { pointerId: 2, clientX: 60, clientY: 60 });
-      // pointerdown target is document in this dispatch; simulate inside by dispatching on p
       dispatchPointer(p, "pointerdown", { pointerId: 2, clientX: 60, clientY: 60 });
-      dispatchPointer(document, "pointerup", { pointerId: 2, clientX: 60, clientY: 60 });
       dispatchPointer(p, "pointerup", { pointerId: 2, clientX: 60, clientY: 60 });
     });
 
@@ -388,7 +403,7 @@ describe("VotingBoard — state machine (issue #484)", () => {
     expect(screen.getAllByTestId("selection-popover").pop()?.dataset.show).toBe("false");
   });
 
-  it("touch: second outside tap dismisses the toolbar via click suppression window", async () => {
+  it("touch: second outside tap dismisses via click and does not activate underlying UI", async () => {
     jest.useFakeTimers();
     mockTouch(true);
     const onDeselect = jest.fn();
@@ -413,20 +428,80 @@ describe("VotingBoard — state machine (issue #484)", () => {
     });
     await waitFor(() => expect(screen.getByTestId("selection-popover").dataset.show).toBe("true"));
 
-    // Second outside tap — should arm suppression and schedule idle
+    // Underlying UI that would be activated if click were not suppressed
+    const underlying = document.createElement("button");
+    underlying.setAttribute("data-testid", "underlying-button");
+    document.body.appendChild(underlying);
+    const underlyingClick = jest.fn();
+    underlying.addEventListener("click", underlyingClick);
+
+    // Second outside tap — arms suppression and sets pendingDismiss, does NOT
+    // reset immediately (P1 #1). The delayed compatibility click must be
+    // consumed before we go idle.
     await act(async () => {
       dispatchPointer(document, "pointerdown", { pointerId: 6, clientX: 5, clientY: 5 });
-      jest.advanceTimersByTime(10);
+    });
+    // Toolbar is still visible until the click is handled
+    expect(screen.getByTestId("selection-popover").dataset.show).toBe("true");
+    expect(onDeselect).not.toHaveBeenCalled();
+
+    // Delayed click on the underlying button — should be suppressed
+    const clickEvent = await act(async () => {
+      return dispatchClick(underlying, 6);
     });
 
-    // The dismissal is scheduled via setTimeout(0) after arming suppression
-    act(() => {
-      jest.advanceTimersByTime(10);
-    });
-
-    await waitFor(() => expect(onDeselect).toHaveBeenCalled());
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(underlyingClick).not.toHaveBeenCalled();
+    expect(onDeselect).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("selection-popover").dataset.show).toBe("false");
     expect(screen.queryByTestId("retained-selection-highlight")).not.toBeInTheDocument();
+  });
+
+  it("touch: first-transition suppression does not swallow toolbar actions", async () => {
+    jest.useFakeTimers();
+    mockTouch(true);
+    const onSelect = jest.fn();
+    const { container } = render(
+      <VotingBoard content={CONTENT} onSelect={onSelect}>
+        {(sel) => (
+          <span>
+            {sel.text}
+            <button data-testid="toolbar-action">Agree</button>
+          </span>
+        )}
+      </VotingBoard>
+    );
+
+    setSelectionForSubstring(container as unknown as HTMLElement, "hello");
+    fireEvent(
+      container.querySelector("[data-selectable]") as HTMLElement,
+      new Event("selectstart")
+    );
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+
+    await act(async () => {
+      dispatchPointer(document, "pointerdown", { pointerId: 10, clientX: 5, clientY: 5 });
+    });
+    await waitFor(() => expect(screen.getByTestId("selection-popover").dataset.show).toBe("true"));
+
+    const popover = screen.getByTestId("selection-popover");
+    const action = screen.getByTestId("toolbar-action");
+    const actionClick = jest.fn();
+    action.addEventListener("click", actionClick);
+
+    // Quick tap on the toolbar action within the 750ms suppression window.
+    // The click target is inside popoverRef, so it must be let through (P1 #3).
+    const toolbarClick = await act(async () => {
+      return dispatchClick(action, 10);
+    });
+
+    expect(toolbarClick.defaultPrevented).toBe(false);
+    expect(actionClick).toHaveBeenCalledTimes(1);
+    // Toolbar stays open — suppression was cleared without dismissing
+    expect(screen.getByTestId("selection-popover").dataset.show).toBe("true");
+    expect(popover.contains(action)).toBe(true);
   });
 
   it("touch: dialog target clears stale toolbar without swallowing the dialog event", async () => {

--- a/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.test.tsx
@@ -2,61 +2,55 @@
  * VotingBoard component tests
  */
 
-import { render, screen, fireEvent } from '@/__tests__/utils/test-utils'
-import VotingBoard from '@/components/VotingComponents/VotingBoard'
-import type { VotingBoardProps } from '@/types/voting'
+import { render, screen, fireEvent } from "@/__tests__/utils/test-utils";
+import VotingBoard from "@/components/VotingComponents/VotingBoard";
+import type { VotingBoardProps } from "@/types/voting";
 
 // Mock react-highlight-words
-jest.mock('react-highlight-words', () => ({
+jest.mock("react-highlight-words", () => ({
   __esModule: true,
   default: ({
     textToHighlight,
     highlightTag: Tag,
     findChunks,
   }: {
-    textToHighlight: string
-    highlightTag?: React.ElementType
-    findChunks?: () => Array<{ start: number; end: number }>
+    textToHighlight: string;
+    highlightTag?: React.ElementType;
+    findChunks?: () => Array<{ start: number; end: number }>;
   }) => {
-    const chunks = findChunks?.() ?? []
-    const first = chunks[0]
+    const chunks = findChunks?.() ?? [];
+    const first = chunks[0];
     if (Tag && first && first.end > first.start) {
       return (
         <span data-testid="highlighter">
           <Tag>{textToHighlight.slice(first.start, first.end)}</Tag>
         </span>
-      )
+      );
     }
-    return <span data-testid="highlighter">{textToHighlight}</span>
+    return <span data-testid="highlighter">{textToHighlight}</span>;
   },
-}))
+}));
 
 // Mock SelectionPopover — new pure portal API
-jest.mock('@/components/VotingComponents/SelectionPopover', () => ({
+jest.mock("@/components/VotingComponents/SelectionPopover", () => ({
   __esModule: true,
-  default: ({
-    children,
-    showPopover,
-  }: {
-    children: React.ReactNode
-    showPopover: boolean
-  }) => (
+  default: ({ children, showPopover }: { children: React.ReactNode; showPopover: boolean }) => (
     <div data-testid="selection-popover" data-show={String(showPopover)}>
       {children}
     </div>
   ),
-}))
+}));
 
-describe('VotingBoard', () => {
+describe("VotingBoard", () => {
   const defaultProps: VotingBoardProps = {
-    content: 'This is test content for voting board',
+    content: "This is test content for voting board",
     highlights: false,
-  }
+  };
 
   beforeEach(() => {
-    Element.prototype.scrollIntoView = jest.fn()
+    Element.prototype.scrollIntoView = jest.fn();
     // Default to desktop media (toolbar immediate)
-    Object.defineProperty(window, 'matchMedia', {
+    Object.defineProperty(window, "matchMedia", {
       writable: true,
       value: jest.fn().mockImplementation((query: string) => ({
         matches: false,
@@ -68,124 +62,126 @@ describe('VotingBoard', () => {
         removeListener: jest.fn(),
         dispatchEvent: jest.fn(),
       })),
-    })
-  })
+    });
+  });
 
-  it('renders content correctly', () => {
-    const { container } = render(<VotingBoard {...defaultProps} />)
-    expect(container.textContent).toContain('This is test content for voting board')
-  })
+  it("renders content correctly", () => {
+    const { container } = render(<VotingBoard {...defaultProps} />);
+    expect(container.textContent).toContain("This is test content for voting board");
+  });
 
-  it('renders with highlights when highlights prop is true', () => {
-    render(<VotingBoard {...defaultProps} highlights={true} />)
-    expect(screen.getByTestId('highlighter')).toBeInTheDocument()
-  })
+  it("renders with highlights when highlights prop is true", () => {
+    render(<VotingBoard {...defaultProps} highlights={true} />);
+    expect(screen.getByTestId("highlighter")).toBeInTheDocument();
+  });
 
-  it('renders SelectionPopover', () => {
-    render(<VotingBoard {...defaultProps} />)
-    expect(screen.getByTestId('selection-popover')).toBeInTheDocument()
-  })
+  it("renders SelectionPopover", () => {
+    render(<VotingBoard {...defaultProps} />);
+    expect(screen.getByTestId("selection-popover")).toBeInTheDocument();
+  });
 
-  it('calls onSelect when text is selected', () => {
-    const onSelect = jest.fn()
-    const { container } = render(<VotingBoard {...defaultProps} onSelect={onSelect} />)
-    const selectableElement = container.querySelector('[data-selectable]')
-    expect(selectableElement).toBeInTheDocument()
-  })
+  it("calls onSelect when text is selected", () => {
+    const onSelect = jest.fn();
+    const { container } = render(<VotingBoard {...defaultProps} onSelect={onSelect} />);
+    const selectableElement = container.querySelector("[data-selectable]");
+    expect(selectableElement).toBeInTheDocument();
+  });
 
-  it('renders children with selection data', () => {
-    const children = jest.fn(() => <div>Child content</div>)
-    render(<VotingBoard {...defaultProps}>{children}</VotingBoard>)
-    expect(children).toHaveBeenCalled()
-  })
+  it("renders children with selection data", () => {
+    const children = jest.fn(() => <div>Child content</div>);
+    render(<VotingBoard {...defaultProps}>{children}</VotingBoard>);
+    expect(children).toHaveBeenCalled();
+  });
 
-  it('applies custom styles', () => {
-    const customStyle = { backgroundColor: 'red' }
-    const { container } = render(<VotingBoard {...defaultProps} style={customStyle} />)
-    const boardElement = container.querySelector('.h-full.flex.flex-col') as HTMLElement
-    expect(boardElement).toBeInTheDocument()
-    expect(boardElement.style.backgroundColor || getComputedStyle(boardElement).backgroundColor).toBeTruthy()
-  })
+  it("applies custom styles", () => {
+    const customStyle = { backgroundColor: "red" };
+    const { container } = render(<VotingBoard {...defaultProps} style={customStyle} />);
+    const boardElement = container.querySelector(".h-full.flex.flex-col") as HTMLElement;
+    expect(boardElement).toBeInTheDocument();
+    expect(
+      boardElement.style.backgroundColor || getComputedStyle(boardElement).backgroundColor
+    ).toBeTruthy();
+  });
 
-  it('handles focused comment highlighting', () => {
-    const focusedComment = { startWordIndex: 0, endWordIndex: 4 }
-    render(<VotingBoard {...defaultProps} highlights={true} focusedComment={focusedComment} />)
-    expect(screen.getByTestId('highlighter')).toBeInTheDocument()
-  })
+  it("handles focused comment highlighting", () => {
+    const focusedComment = { startWordIndex: 0, endWordIndex: 4 };
+    render(<VotingBoard {...defaultProps} highlights={true} focusedComment={focusedComment} />);
+    expect(screen.getByTestId("highlighter")).toBeInTheDocument();
+  });
 
-  it('handles empty content', () => {
-    const { container } = render(<VotingBoard {...defaultProps} content="" />)
-    expect(container.textContent?.trim()).toBe('')
-  })
+  it("handles empty content", () => {
+    const { container } = render(<VotingBoard {...defaultProps} content="" />);
+    expect(container.textContent?.trim()).toBe("");
+  });
 
-  it('handles content with newlines', () => {
-    const contentWithNewlines = 'Line 1\nLine 2\nLine 3'
-    const { container } = render(<VotingBoard {...defaultProps} content={contentWithNewlines} />)
-    expect(container.textContent).toContain('Line 1')
-    expect(container.textContent).toContain('Line 2')
-    expect(container.textContent).toContain('Line 3')
-  })
+  it("handles content with newlines", () => {
+    const contentWithNewlines = "Line 1\nLine 2\nLine 3";
+    const { container } = render(<VotingBoard {...defaultProps} content={contentWithNewlines} />);
+    expect(container.textContent).toContain("Line 1");
+    expect(container.textContent).toContain("Line 2");
+    expect(container.textContent).toContain("Line 3");
+  });
 
-  it('handles focused comment with invalid indices', () => {
-    const focusedComment = { startWordIndex: 100, endWordIndex: 50 }
+  it("handles focused comment with invalid indices", () => {
+    const focusedComment = { startWordIndex: 100, endWordIndex: 50 };
     const { container } = render(
       <VotingBoard {...defaultProps} highlights={true} focusedComment={focusedComment} />
-    )
-    expect(container.textContent).toContain('This is test content')
-  })
+    );
+    expect(container.textContent).toContain("This is test content");
+  });
 
-  it('handles null focused comment', () => {
-    render(<VotingBoard {...defaultProps} highlights={true} focusedComment={null} />)
-    expect(screen.getByTestId('highlighter')).toBeInTheDocument()
-  })
+  it("handles null focused comment", () => {
+    render(<VotingBoard {...defaultProps} highlights={true} focusedComment={null} />);
+    expect(screen.getByTestId("highlighter")).toBeInTheDocument();
+  });
 
-  it('renders a clickable linked passage when a focused comment range is set', () => {
-    const onHighlightClick = jest.fn()
+  it("renders a clickable linked passage when a focused comment range is set", () => {
+    const onHighlightClick = jest.fn();
     render(
       <VotingBoard
         {...defaultProps}
         highlights={true}
-        focusedComment={{ startWordIndex: 0, endWordIndex: 4, actionId: 'c1' }}
+        focusedComment={{ startWordIndex: 0, endWordIndex: 4, actionId: "c1" }}
         onHighlightClick={onHighlightClick}
       />
-    )
-    fireEvent.click(screen.getByTestId('linked-passage'))
-    expect(onHighlightClick).toHaveBeenCalledTimes(1)
-  })
+    );
+    fireEvent.click(screen.getByTestId("linked-passage"));
+    expect(onHighlightClick).toHaveBeenCalledTimes(1);
+  });
 
-  it('calls onSelect with correct selection data', () => {
-    const onSelect = jest.fn()
-    render(<VotingBoard {...defaultProps} onSelect={onSelect} />)
-    expect(onSelect).toBeDefined()
-  })
+  it("calls onSelect with correct selection data", () => {
+    const onSelect = jest.fn();
+    render(<VotingBoard {...defaultProps} onSelect={onSelect} />);
+    expect(onSelect).toBeDefined();
+  });
 
-  it('handles votes prop (for future use)', () => {
-    const votes = [{ _id: 'vote1', type: 'up', userId: 'user1' }]
-    const { container } = render(<VotingBoard {...defaultProps} votes={votes} />)
-    expect(container.textContent).toContain('This is test content')
-  })
+  it("handles votes prop (for future use)", () => {
+    const votes = [{ _id: "vote1", type: "up", userId: "user1" }];
+    const { container } = render(<VotingBoard {...defaultProps} votes={votes} />);
+    expect(container.textContent).toContain("This is test content");
+  });
 
-  it('applies topOffset to SelectionPopover', () => {
-    render(<VotingBoard {...defaultProps} topOffset={50} />)
-    expect(screen.getByTestId('selection-popover')).toBeInTheDocument()
-  })
+  it("applies topOffset to SelectionPopover", () => {
+    render(<VotingBoard {...defaultProps} topOffset={50} />);
+    expect(screen.getByTestId("selection-popover")).toBeInTheDocument();
+  });
 
-  it('handles selection with empty text', () => {
-    const onSelect = jest.fn()
-    render(<VotingBoard {...defaultProps} onSelect={onSelect} />)
-    expect(onSelect).toBeDefined()
-  })
+  it("handles selection with empty text", () => {
+    const onSelect = jest.fn();
+    render(<VotingBoard {...defaultProps} onSelect={onSelect} />);
+    expect(onSelect).toBeDefined();
+  });
 
-  it('resets on content change', () => {
-    const { rerender } = render(<VotingBoard {...defaultProps} content="first content" />)
-    rerender(<VotingBoard {...defaultProps} content="second content" />)
+  it("resets on content change", () => {
+    const { rerender } = render(<VotingBoard {...defaultProps} content="first content" />);
+    rerender(<VotingBoard {...defaultProps} content="second content" />);
     // Should not crash and show new content
-    expect(document.body.textContent).toContain('second content')
-  })
+    expect(document.body.textContent).toContain("second content");
+  });
 
-  it('exposes onDeselect prop', () => {
-    const onDeselect = jest.fn()
-    render(<VotingBoard {...defaultProps} onDeselect={onDeselect} />)
-    expect(onDeselect).toBeDefined()
-  })
-})
+  it("exposes onDeselect prop", () => {
+    const onDeselect = jest.fn();
+    render(<VotingBoard {...defaultProps} onDeselect={onDeselect} />);
+    expect(onDeselect).toBeDefined();
+  });
+});

--- a/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.test.tsx
+++ b/quotevote-frontend/src/__tests__/components/VotingComponents/VotingBoard.test.tsx
@@ -31,7 +31,7 @@ jest.mock('react-highlight-words', () => ({
   },
 }))
 
-// Mock SelectionPopover
+// Mock SelectionPopover — new pure portal API
 jest.mock('@/components/VotingComponents/SelectionPopover', () => ({
   __esModule: true,
   default: ({
@@ -41,7 +41,7 @@ jest.mock('@/components/VotingComponents/SelectionPopover', () => ({
     children: React.ReactNode
     showPopover: boolean
   }) => (
-    <div data-testid="selection-popover" data-show={showPopover}>
+    <div data-testid="selection-popover" data-show={String(showPopover)}>
       {children}
     </div>
   ),
@@ -55,11 +55,24 @@ describe('VotingBoard', () => {
 
   beforeEach(() => {
     Element.prototype.scrollIntoView = jest.fn()
+    // Default to desktop media (toolbar immediate)
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    })
   })
 
   it('renders content correctly', () => {
     const { container } = render(<VotingBoard {...defaultProps} />)
-    // Content is split into spans, so we check for the container
     expect(container.textContent).toContain('This is test content for voting board')
   })
 
@@ -76,92 +89,53 @@ describe('VotingBoard', () => {
   it('calls onSelect when text is selected', () => {
     const onSelect = jest.fn()
     const { container } = render(<VotingBoard {...defaultProps} onSelect={onSelect} />)
-
-    // Verify the selectable element exists
     const selectableElement = container.querySelector('[data-selectable]')
     expect(selectableElement).toBeInTheDocument()
   })
 
   it('renders children with selection data', () => {
     const children = jest.fn(() => <div>Child content</div>)
-    render(
-      <VotingBoard {...defaultProps}>
-        {children}
-      </VotingBoard>,
-    )
-
-    // Children should be called with selection data
+    render(<VotingBoard {...defaultProps}>{children}</VotingBoard>)
     expect(children).toHaveBeenCalled()
   })
 
   it('applies custom styles', () => {
     const customStyle = { backgroundColor: 'red' }
-    const { container } = render(
-      <VotingBoard {...defaultProps} style={customStyle} />,
-    )
+    const { container } = render(<VotingBoard {...defaultProps} style={customStyle} />)
     const boardElement = container.querySelector('.h-full.flex.flex-col') as HTMLElement
     expect(boardElement).toBeInTheDocument()
-    // Check that style prop is passed (inline styles are applied directly)
     expect(boardElement.style.backgroundColor || getComputedStyle(boardElement).backgroundColor).toBeTruthy()
   })
 
   it('handles focused comment highlighting', () => {
-    const focusedComment = {
-      startWordIndex: 0,
-      endWordIndex: 4,
-    }
-    render(
-      <VotingBoard
-        {...defaultProps}
-        highlights={true}
-        focusedComment={focusedComment}
-      />,
-    )
+    const focusedComment = { startWordIndex: 0, endWordIndex: 4 }
+    render(<VotingBoard {...defaultProps} highlights={true} focusedComment={focusedComment} />)
     expect(screen.getByTestId('highlighter')).toBeInTheDocument()
   })
 
   it('handles empty content', () => {
-    const { container } = render(
-      <VotingBoard {...defaultProps} content="" />,
-    )
-    // Empty content may render as whitespace due to line breaks
+    const { container } = render(<VotingBoard {...defaultProps} content="" />)
     expect(container.textContent?.trim()).toBe('')
   })
 
   it('handles content with newlines', () => {
     const contentWithNewlines = 'Line 1\nLine 2\nLine 3'
-    const { container } = render(
-      <VotingBoard {...defaultProps} content={contentWithNewlines} />,
-    )
+    const { container } = render(<VotingBoard {...defaultProps} content={contentWithNewlines} />)
     expect(container.textContent).toContain('Line 1')
     expect(container.textContent).toContain('Line 2')
     expect(container.textContent).toContain('Line 3')
   })
 
   it('handles focused comment with invalid indices', () => {
-    const focusedComment = {
-      startWordIndex: 100,
-      endWordIndex: 50, // end < start
-    }
+    const focusedComment = { startWordIndex: 100, endWordIndex: 50 }
     const { container } = render(
-      <VotingBoard
-        {...defaultProps}
-        highlights={true}
-        focusedComment={focusedComment}
-      />,
+      <VotingBoard {...defaultProps} highlights={true} focusedComment={focusedComment} />
     )
-    // Should still render without crashing
     expect(container.textContent).toContain('This is test content')
   })
 
   it('handles null focused comment', () => {
-    render(
-      <VotingBoard
-        {...defaultProps}
-        highlights={true}
-        focusedComment={null}
-      />,
-    )
+    render(<VotingBoard {...defaultProps} highlights={true} focusedComment={null} />)
     expect(screen.getByTestId('highlighter')).toBeInTheDocument()
   })
 
@@ -173,7 +147,7 @@ describe('VotingBoard', () => {
         highlights={true}
         focusedComment={{ startWordIndex: 0, endWordIndex: 4, actionId: 'c1' }}
         onHighlightClick={onHighlightClick}
-      />,
+      />
     )
     fireEvent.click(screen.getByTestId('linked-passage'))
     expect(onHighlightClick).toHaveBeenCalledTimes(1)
@@ -182,41 +156,36 @@ describe('VotingBoard', () => {
   it('calls onSelect with correct selection data', () => {
     const onSelect = jest.fn()
     render(<VotingBoard {...defaultProps} onSelect={onSelect} />)
-    
-    // onSelect is called internally when selection is made
-    // The actual selection would be handled by SelectionPopover
-    // This test verifies the prop is passed correctly
     expect(onSelect).toBeDefined()
   })
 
   it('handles votes prop (for future use)', () => {
-    const votes = [
-      {
-        _id: 'vote1',
-        type: 'up',
-        userId: 'user1',
-      },
-    ]
-    const { container } = render(
-      <VotingBoard {...defaultProps} votes={votes} />,
-    )
-    // Votes prop is currently unused but should not cause errors
+    const votes = [{ _id: 'vote1', type: 'up', userId: 'user1' }]
+    const { container } = render(<VotingBoard {...defaultProps} votes={votes} />)
     expect(container.textContent).toContain('This is test content')
   })
 
   it('applies topOffset to SelectionPopover', () => {
     render(<VotingBoard {...defaultProps} topOffset={50} />)
-    // SelectionPopover should receive topOffset prop
     expect(screen.getByTestId('selection-popover')).toBeInTheDocument()
   })
 
   it('handles selection with empty text', () => {
     const onSelect = jest.fn()
     render(<VotingBoard {...defaultProps} onSelect={onSelect} />)
-    
-    // Empty selection should not trigger onSelect
-    // This is handled internally by the component
     expect(onSelect).toBeDefined()
   })
-})
 
+  it('resets on content change', () => {
+    const { rerender } = render(<VotingBoard {...defaultProps} content="first content" />)
+    rerender(<VotingBoard {...defaultProps} content="second content" />)
+    // Should not crash and show new content
+    expect(document.body.textContent).toContain('second content')
+  })
+
+  it('exposes onDeselect prop', () => {
+    const onDeselect = jest.fn()
+    render(<VotingBoard {...defaultProps} onDeselect={onDeselect} />)
+    expect(onDeselect).toBeDefined()
+  })
+})

--- a/quotevote-frontend/src/__tests__/utils/parserDom.test.ts
+++ b/quotevote-frontend/src/__tests__/utils/parserDom.test.ts
@@ -221,6 +221,53 @@ describe("parserDom — parseDomSelection", () => {
     const res = parseDomSelection({ content, selectedText: "abc", range, contentRoot: root });
     expect(res!.startIndex).toBe(8);
   });
+
+  it("CRLF: preceding CRLFs do not shift the approximate offset (P2 #2)", () => {
+    // "x" + 5×CRLF + "foo foo" — first foo normalized at 6, original at 11
+    const content = "x\r\n\r\n\r\n\r\n\r\nfoo foo";
+    const root = makeRoot("");
+    const range = selectSubstring(root, content, "foo", 0);
+    const res = parseDomSelection({ content, selectedText: "foo", range, contentRoot: root });
+    expect(res).toBeDefined();
+    expect(res!.startIndex).toBe(11);
+    expect(res!.endIndex).toBe(14);
+    expect(res!.text).toBe("foo");
+  });
+
+  it("returns undefined when approx is null and multiple occurrences exist", () => {
+    const content = "foo foo foo";
+    const root = makeRoot("");
+    const p = document.createElement("p");
+    p.textContent = "foo";
+    root.appendChild(p);
+    const range = document.createRange();
+    range.selectNodeContents(p);
+    stubRangeRect(range);
+    jest.spyOn(document, "createRange").mockImplementation(() => {
+      throw new Error("forced");
+    });
+    const res = parseDomSelection({ content, selectedText: "foo", range, contentRoot: root });
+    expect(res).toBeUndefined();
+    jest.restoreAllMocks();
+  });
+
+  it("returns single occurrence even when approx is null", () => {
+    const content = "unique foo end";
+    const root = makeRoot("");
+    const p = document.createElement("p");
+    p.textContent = "foo";
+    root.appendChild(p);
+    const range = document.createRange();
+    range.selectNodeContents(p);
+    stubRangeRect(range);
+    jest.spyOn(document, "createRange").mockImplementation(() => {
+      throw new Error("forced");
+    });
+    const res = parseDomSelection({ content, selectedText: "foo", range, contentRoot: root });
+    expect(res).toBeDefined();
+    expect(res!.startIndex).toBe(7);
+    jest.restoreAllMocks();
+  });
 });
 
 describe("parserDom — domApproximateStartOffset", () => {

--- a/quotevote-frontend/src/__tests__/utils/parserDom.test.ts
+++ b/quotevote-frontend/src/__tests__/utils/parserDom.test.ts
@@ -4,7 +4,6 @@ import {
   domApproximateStartOffset,
 } from "@/lib/utils/parserDom";
 
-// JSDOM's Range may not have getBoundingClientRect in some versions — polyfill
 if (typeof Range !== "undefined" && !Range.prototype.getBoundingClientRect) {
   Range.prototype.getBoundingClientRect = function () {
     return {
@@ -41,7 +40,6 @@ function stubRangeRect(range: Range, rect: Partial<DOMRect> = {}) {
     toJSON() {},
     ...rect,
   } as DOMRect;
-  // Range instances have own getBoundingClientRect in JSDOM — stub directly
   (range as unknown as { getBoundingClientRect: () => DOMRect }).getBoundingClientRect = () => fake;
   return range;
 }
@@ -89,9 +87,6 @@ describe("parserDom — parseDomSelection", () => {
   });
 
   function selectSubstring(root: HTMLElement, content: string, needle: string, occurrence: number) {
-    // Find the occurrence index in original content, then create a range that
-    // spans that occurrence inside the DOM. For simplicity we populate the root
-    // with a text node equal to content and select within it.
     const p = document.createElement("p");
     p.textContent = content.replace(/\r\n/g, "\n");
     root.appendChild(p);
@@ -125,12 +120,10 @@ describe("parserDom — parseDomSelection", () => {
   it("picks the occurrence nearest the DOM offset for repeated text", () => {
     const content = "foo bar foo bar foo";
     const root = makeRoot("");
-    // Select the second "foo" (index 8 in normalized content: "foo bar [foo] bar foo")
     const needle = "foo";
     const range = selectSubstring(root, content, needle, 1);
     const res = parseDomSelection({ content, selectedText: needle, range, contentRoot: root });
     expect(res).toBeDefined();
-    // Second "foo" starts at 8
     expect(res!.startIndex).toBe(8);
     expect(res!.endIndex).toBe(11);
   });
@@ -140,7 +133,6 @@ describe("parserDom — parseDomSelection", () => {
     const normalizedNeedle = "line2";
     const root = makeRoot("");
     const range = selectSubstring(root, content, normalizedNeedle, 0);
-    // DOM text normalizes CRLF to LF, so selectedText arrives as "line2"
     const res = parseDomSelection({
       content,
       selectedText: "line2",
@@ -148,7 +140,6 @@ describe("parserDom — parseDomSelection", () => {
       contentRoot: root,
     });
     expect(res).toBeDefined();
-    // "line1\r\n" is 7 chars original, line2 starts at 7
     expect(res!.startIndex).toBe(7);
     expect(res!.endIndex).toBe(12);
     expect(res!.text).toBe("line2");
@@ -157,7 +148,6 @@ describe("parserDom — parseDomSelection", () => {
   it("handles selection spanning a CRLF boundary", () => {
     const content = "a\r\nb\r\nc";
     const root = makeRoot("");
-    // Select "b\nc" in normalized space -> original "b\r\nc"
     const range = selectSubstring(root, content, "b\nc", 0);
     const res = parseDomSelection({
       content,
@@ -214,7 +204,6 @@ describe("parserDom — parseDomSelection", () => {
   });
 
   it("derives correct offset when DOM approximate matches the second occurrence", () => {
-    // Content has "abc abc abc", selection is "abc" at DOM position of third occurrence
     const content = "abc abc abc";
     const root = makeRoot("");
     const range = selectSubstring(root, content, "abc", 2);
@@ -222,8 +211,7 @@ describe("parserDom — parseDomSelection", () => {
     expect(res!.startIndex).toBe(8);
   });
 
-  it("CRLF: preceding CRLFs do not shift the approximate offset (P2 #2)", () => {
-    // "x" + 5×CRLF + "foo foo" — first foo normalized at 6, original at 11
+  it("CRLF: preceding CRLFs do not shift the approximate offset", () => {
     const content = "x\r\n\r\n\r\n\r\n\r\nfoo foo";
     const root = makeRoot("");
     const range = selectSubstring(root, content, "foo", 0);
@@ -287,12 +275,10 @@ describe("parserDom — domApproximateStartOffset", () => {
 
   it("returns null when Range API throws", () => {
     const root = makeRoot("<p>hi</p>");
-    // Force prefix creation to throw
     const originalCreateRange = document.createRange.bind(document);
     jest.spyOn(document, "createRange").mockImplementation(() => {
       throw new Error("forced");
     });
-    // domApproximateStartOffset should catch and return null
     const dummyRange = originalCreateRange();
     dummyRange.selectNodeContents(root.querySelector("p")!);
     expect(domApproximateStartOffset(dummyRange, root)).toBeNull();

--- a/quotevote-frontend/src/__tests__/utils/parserDom.test.ts
+++ b/quotevote-frontend/src/__tests__/utils/parserDom.test.ts
@@ -1,0 +1,254 @@
+import {
+  parseDomSelection,
+  isValidRangeForRoot,
+  domApproximateStartOffset,
+} from "@/lib/utils/parserDom";
+
+// JSDOM's Range may not have getBoundingClientRect in some versions — polyfill
+if (typeof Range !== "undefined" && !Range.prototype.getBoundingClientRect) {
+  Range.prototype.getBoundingClientRect = function () {
+    return {
+      width: 100,
+      height: 20,
+      top: 0,
+      left: 0,
+      right: 100,
+      bottom: 20,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    } as DOMRect;
+  };
+}
+
+function makeRoot(html: string): HTMLElement {
+  const root = document.createElement("div");
+  root.innerHTML = html;
+  document.body.appendChild(root);
+  return root;
+}
+
+function stubRangeRect(range: Range, rect: Partial<DOMRect> = {}) {
+  const fake = {
+    width: 100,
+    height: 20,
+    top: 10,
+    left: 10,
+    right: 110,
+    bottom: 30,
+    x: 10,
+    y: 10,
+    toJSON() {},
+    ...rect,
+  } as DOMRect;
+  // Range instances have own getBoundingClientRect in JSDOM — stub directly
+  (range as unknown as { getBoundingClientRect: () => DOMRect }).getBoundingClientRect = () => fake;
+  return range;
+}
+
+describe("parserDom — isValidRangeForRoot", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    jest.restoreAllMocks();
+  });
+
+  it("rejects collapsed ranges", () => {
+    const root = makeRoot("<p>hello world</p>");
+    const p = root.querySelector("p")!;
+    const range = document.createRange();
+    range.selectNodeContents(p);
+    range.collapse(true);
+    expect(isValidRangeForRoot(range, root)).toBe(false);
+  });
+
+  it("rejects ranges outside the root", () => {
+    const root = makeRoot("<p>inside</p>");
+    const outside = document.createElement("p");
+    outside.textContent = "outside";
+    document.body.appendChild(outside);
+    const range = document.createRange();
+    range.selectNodeContents(outside);
+    stubRangeRect(range);
+    expect(isValidRangeForRoot(range, root)).toBe(false);
+  });
+
+  it("rejects zero-geometry ranges", () => {
+    const root = makeRoot("<p>hello</p>");
+    const p = root.querySelector("p")!;
+    const range = document.createRange();
+    range.selectNodeContents(p);
+    stubRangeRect(range, { width: 0, height: 0 });
+    expect(isValidRangeForRoot(range, root)).toBe(false);
+  });
+});
+
+describe("parserDom — parseDomSelection", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    jest.restoreAllMocks();
+  });
+
+  function selectSubstring(root: HTMLElement, content: string, needle: string, occurrence: number) {
+    // Find the occurrence index in original content, then create a range that
+    // spans that occurrence inside the DOM. For simplicity we populate the root
+    // with a text node equal to content and select within it.
+    const p = document.createElement("p");
+    p.textContent = content.replace(/\r\n/g, "\n");
+    root.appendChild(p);
+    const textNode = p.firstChild as Text;
+    let idx = -1;
+    let from = 0;
+    for (let i = 0; i <= occurrence; i++) {
+      idx = content.replace(/\r\n/g, "\n").indexOf(needle.replace(/\r\n/g, "\n"), from);
+      if (idx === -1) throw new Error(`occurrence ${occurrence} not found`);
+      from = idx + 1;
+    }
+    const range = document.createRange();
+    range.setStart(textNode, idx);
+    range.setEnd(textNode, idx + needle.replace(/\r\n/g, "\n").length);
+    stubRangeRect(range);
+    return range;
+  }
+
+  it("returns correct offsets for a unique passage", () => {
+    const content = "hello world";
+    const root = makeRoot("");
+    const needle = "world";
+    const range = selectSubstring(root, content, needle, 0);
+    const res = parseDomSelection({ content, selectedText: needle, range, contentRoot: root });
+    expect(res).toBeDefined();
+    expect(res!.startIndex).toBe(6);
+    expect(res!.endIndex).toBe(11);
+    expect(res!.text).toBe("world");
+  });
+
+  it("picks the occurrence nearest the DOM offset for repeated text", () => {
+    const content = "foo bar foo bar foo";
+    const root = makeRoot("");
+    // Select the second "foo" (index 8 in normalized content: "foo bar [foo] bar foo")
+    const needle = "foo";
+    const range = selectSubstring(root, content, needle, 1);
+    const res = parseDomSelection({ content, selectedText: needle, range, contentRoot: root });
+    expect(res).toBeDefined();
+    // Second "foo" starts at 8
+    expect(res!.startIndex).toBe(8);
+    expect(res!.endIndex).toBe(11);
+  });
+
+  it("handles CRLF content without splitting a CRLF pair", () => {
+    const content = "line1\r\nline2\r\nline3";
+    const normalizedNeedle = "line2";
+    const root = makeRoot("");
+    const range = selectSubstring(root, content, normalizedNeedle, 0);
+    // DOM text normalizes CRLF to LF, so selectedText arrives as "line2"
+    const res = parseDomSelection({
+      content,
+      selectedText: "line2",
+      range,
+      contentRoot: root,
+    });
+    expect(res).toBeDefined();
+    // "line1\r\n" is 7 chars original, line2 starts at 7
+    expect(res!.startIndex).toBe(7);
+    expect(res!.endIndex).toBe(12);
+    expect(res!.text).toBe("line2");
+  });
+
+  it("handles selection spanning a CRLF boundary", () => {
+    const content = "a\r\nb\r\nc";
+    const root = makeRoot("");
+    // Select "b\nc" in normalized space -> original "b\r\nc"
+    const range = selectSubstring(root, content, "b\nc", 0);
+    const res = parseDomSelection({
+      content,
+      selectedText: "b\nc",
+      range,
+      contentRoot: root,
+    });
+    expect(res).toBeDefined();
+    expect(res!.startIndex).toBe(3);
+    expect(res!.endIndex).toBe(7);
+    expect(res!.text).toBe("b\r\nc");
+  });
+
+  it("returns undefined for text not in content", () => {
+    const content = "hello world";
+    const root = makeRoot("");
+    const p = document.createElement("p");
+    p.textContent = "hello world";
+    root.appendChild(p);
+    const range = document.createRange();
+    range.selectNodeContents(p);
+    stubRangeRect(range);
+    const res = parseDomSelection({
+      content,
+      selectedText: "notfound",
+      range,
+      contentRoot: root,
+    });
+    expect(res).toBeUndefined();
+  });
+
+  it("returns undefined for empty selectedText", () => {
+    const content = "hello";
+    const root = makeRoot("<p>hello</p>");
+    const p = root.querySelector("p")!;
+    const range = document.createRange();
+    range.selectNodeContents(p);
+    stubRangeRect(range);
+    expect(
+      parseDomSelection({ content, selectedText: "", range, contentRoot: root })
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for collapsed range", () => {
+    const content = "hello world";
+    const root = makeRoot("<p>hello world</p>");
+    const p = root.querySelector("p")!;
+    const range = document.createRange();
+    range.setStart(p.firstChild!, 2);
+    range.collapse(true);
+    expect(
+      parseDomSelection({ content, selectedText: "hello", range, contentRoot: root })
+    ).toBeUndefined();
+  });
+
+  it("derives correct offset when DOM approximate matches the second occurrence", () => {
+    // Content has "abc abc abc", selection is "abc" at DOM position of third occurrence
+    const content = "abc abc abc";
+    const root = makeRoot("");
+    const range = selectSubstring(root, content, "abc", 2);
+    const res = parseDomSelection({ content, selectedText: "abc", range, contentRoot: root });
+    expect(res!.startIndex).toBe(8);
+  });
+});
+
+describe("parserDom — domApproximateStartOffset", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns prefix text length", () => {
+    const root = makeRoot("<p>hello </p><p>world</p>");
+    const secondP = root.querySelectorAll("p")[1];
+    const textNode = secondP.firstChild as Text;
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, 5);
+    expect(domApproximateStartOffset(range, root)).toBe("hello ".length);
+  });
+
+  it("returns null when Range API throws", () => {
+    const root = makeRoot("<p>hi</p>");
+    // Force prefix creation to throw
+    const originalCreateRange = document.createRange.bind(document);
+    jest.spyOn(document, "createRange").mockImplementation(() => {
+      throw new Error("forced");
+    });
+    // domApproximateStartOffset should catch and return null
+    const dummyRange = originalCreateRange();
+    dummyRange.selectNodeContents(root.querySelector("p")!);
+    expect(domApproximateStartOffset(dummyRange, root)).toBeNull();
+    jest.restoreAllMocks();
+  });
+});

--- a/quotevote-frontend/src/components/Post/Post.tsx
+++ b/quotevote-frontend/src/components/Post/Post.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, lazy, Suspense } from 'react'
+import { useState, lazy, Suspense, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { includes } from 'lodash'
 import moment from 'moment'
@@ -96,6 +96,10 @@ export default function Post({
     endIndex: 0,
     points: 0,
   })
+
+  const handleDeselect = useCallback(() => {
+    setSelectedText({ text: '', startIndex: 0, endIndex: 0, points: 0 })
+  }, [])
 
   const isFollowing = includes(_followingId, userId)
   const admin = user.admin || false
@@ -597,6 +601,7 @@ export default function Post({
           <VotingBoard
             content={post.text || ''}
             onSelect={setSelectedText}
+            onDeselect={handleDeselect}
             highlights={true}
             votes={post.votes || []}
             focusedComment={linkedPassage}

--- a/quotevote-frontend/src/components/Post/Post.tsx
+++ b/quotevote-frontend/src/components/Post/Post.tsx
@@ -1,14 +1,14 @@
-'use client'
+"use client";
 
-import { useState, lazy, Suspense, useCallback } from 'react'
-import { useRouter } from 'next/navigation'
-import { includes } from 'lodash'
-import moment from 'moment'
-import { useMutation, useQuery } from '@apollo/client/react'
-import type { Reference } from '@apollo/client'
-import { Button } from '@/components/ui/button'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { Separator } from '@/components/ui/separator'
+import { useState, lazy, Suspense, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { includes } from "lodash";
+import moment from "moment";
+import { useMutation, useQuery } from "@apollo/client/react";
+import type { Reference } from "@apollo/client";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Separator } from "@/components/ui/separator";
 import {
   Link2,
   Ban,
@@ -19,17 +19,17 @@ import {
   ArrowLeft,
   MessageCircle,
   ExternalLink,
-} from 'lucide-react'
+} from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
-import { toast } from 'sonner'
-import { DisplayAvatar } from '@/components/DisplayAvatar'
-import { FollowButton } from '../CustomButtons/FollowButton'
-import { BookmarkIconButton } from '../CustomButtons/BookmarkIconButton'
+} from "@/components/ui/dropdown-menu";
+import { toast } from "sonner";
+import { DisplayAvatar } from "@/components/DisplayAvatar";
+import { FollowButton } from "../CustomButtons/FollowButton";
+import { BookmarkIconButton } from "../CustomButtons/BookmarkIconButton";
 import {
   ADD_COMMENT,
   ADD_QUOTE,
@@ -39,21 +39,16 @@ import {
   REJECT_POST,
   DELETE_POST,
   DELETE_VOTE,
-} from '@/graphql/mutations'
-import {
-  GET_POST,
-  GET_TOP_POSTS,
-  GET_USER_ACTIVITY,
-  GET_USERS,
-} from '@/graphql/queries'
-import useGuestGuard from '@/hooks/useGuestGuard'
-import { cn } from '@/lib/utils'
-import { scrollActionIntoDiscussion } from '@/lib/utils/discussionSplit'
-import { useAppStore } from '@/store'
-import VotingBoard from '@/components/VotingComponents/VotingBoard'
-const VotingPopup = lazy(() => import('@/components/VotingComponents/VotingPopup'))
-import type { PostVote, PostProps } from '@/types/post'
-import type { SelectedText, VotedByEntry, VoteType, VoteOption } from '@/types/voting'
+} from "@/graphql/mutations";
+import { GET_POST, GET_TOP_POSTS, GET_USER_ACTIVITY, GET_USERS } from "@/graphql/queries";
+import useGuestGuard from "@/hooks/useGuestGuard";
+import { cn } from "@/lib/utils";
+import { scrollActionIntoDiscussion } from "@/lib/utils/discussionSplit";
+import { useAppStore } from "@/store";
+import VotingBoard from "@/components/VotingComponents/VotingBoard";
+const VotingPopup = lazy(() => import("@/components/VotingComponents/VotingPopup"));
+import type { PostVote, PostProps } from "@/types/post";
+import type { SelectedText, VotedByEntry, VoteType, VoteOption } from "@/types/voting";
 
 export default function Post({
   post,
@@ -64,302 +59,353 @@ export default function Post({
   onOpenDiscussion,
   onActivateLinkedComment,
 }: PostProps) {
-  const router = useRouter()
-  const ensureAuth = useGuestGuard()
-  const linkedPassage = useAppStore((state) => state.ui.linkedPassage)
-  const mobileDiscussionOpen = useAppStore((state) => state.ui.mobileDiscussionOpen)
+  const router = useRouter();
+  const ensureAuth = useGuestGuard();
+  const linkedPassage = useAppStore((state) => state.ui.linkedPassage);
+  const mobileDiscussionOpen = useAppStore((state) => state.ui.mobileDiscussionOpen);
 
   const handleHighlightClick = () => {
-    const actionId = linkedPassage?.actionId
+    const actionId = linkedPassage?.actionId;
     if (!actionId) {
-      onOpenDiscussion?.()
-      return
+      onOpenDiscussion?.();
+      return;
     }
-    onActivateLinkedComment?.(actionId)
+    onActivateLinkedComment?.(actionId);
     // Reverse-nav only when opening Discussion; tapping the highlight while
     // split-screen is already open clears the selection instead.
-    if (mobileDiscussionOpen) return
+    if (mobileDiscussionOpen) return;
     window.requestAnimationFrame(() => {
       window.setTimeout(() => {
-        scrollActionIntoDiscussion(actionId, 'center')
-      }, 220)
-    })
-  }
+        scrollActionIntoDiscussion(actionId, "center");
+      }, 220);
+    });
+  };
 
-  const { title, creator, created, _id, userId } = post
-  const { name, avatar, username } = creator || {}
-  const { _followingId = [] } = user
+  const { title, creator, created, _id, userId } = post;
+  const { name, avatar, username } = creator || {};
+  const { _followingId = [] } = user;
 
   const [selectedText, setSelectedText] = useState<SelectedText>({
-    text: '',
+    text: "",
     startIndex: 0,
     endIndex: 0,
     points: 0,
-  })
+  });
 
   const handleDeselect = useCallback(() => {
-    setSelectedText({ text: '', startIndex: 0, endIndex: 0, points: 0 })
-  }, [])
+    setSelectedText({ text: "", startIndex: 0, endIndex: 0, points: 0 });
+  }, []);
 
-  const isFollowing = includes(_followingId, userId)
-  const admin = user.admin || false
-  const isOwner = user._id === userId
+  const isFollowing = includes(_followingId, userId);
+  const admin = user.admin || false;
+  const isOwner = user._id === userId;
 
   // Admin-only: fetch user list for enhanced tooltips
   useQuery<{ users?: Array<{ _id: string; username: string }> }>(GET_USERS, {
     skip: !admin,
-    errorPolicy: 'all',
-  })
+    errorPolicy: "all",
+  });
 
   const [addVote] = useMutation(VOTE, {
-    update() { refetchPost?.() },
+    update() {
+      refetchPost?.();
+    },
     refetchQueries: [
-      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: '' } },
+      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: "" } },
       { query: GET_POST, variables: { postId: _id } },
     ],
-  })
+  });
 
   const [removeVote] = useMutation(DELETE_VOTE, {
-    update() { refetchPost?.() },
+    update() {
+      refetchPost?.();
+    },
     refetchQueries: [
-      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: '' } },
+      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: "" } },
       { query: GET_POST, variables: { postId: _id } },
     ],
-  })
+  });
 
   const [addComment] = useMutation(ADD_COMMENT, {
     refetchQueries: [
-      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: '' } },
+      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: "" } },
       { query: GET_POST, variables: { postId: _id } },
     ],
-  })
+  });
 
   const [addQuote] = useMutation(ADD_QUOTE, {
     refetchQueries: [
-      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: '' } },
+      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: "" } },
       { query: GET_POST, variables: { postId: _id } },
       {
         query: GET_USER_ACTIVITY,
         variables: {
-          limit: 15, offset: 0, searchKey: '',
-          activityEvent: ['POSTED', 'VOTED', 'COMMENTED', 'QUOTED', 'LIKED'],
-          user_id: user._id || '', startDateRange: '', endDateRange: '',
+          limit: 15,
+          offset: 0,
+          searchKey: "",
+          activityEvent: ["POSTED", "VOTED", "COMMENTED", "QUOTED", "LIKED"],
+          user_id: user._id || "",
+          startDateRange: "",
+          endDateRange: "",
         },
       },
     ],
-  })
+  });
 
-  const [reportPost] = useMutation<{ reportPost: { _id: string; reportedBy: string[] } }>(REPORT_POST, {
-    refetchQueries: [
-      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: '' } },
-      { query: GET_POST, variables: { postId: _id } },
-    ],
-  })
+  const [reportPost] = useMutation<{ reportPost: { _id: string; reportedBy: string[] } }>(
+    REPORT_POST,
+    {
+      refetchQueries: [
+        { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: "" } },
+        { query: GET_POST, variables: { postId: _id } },
+      ],
+    }
+  );
 
   const [approvePost] = useMutation(APPROVE_POST, {
     refetchQueries: [
       { query: GET_POST, variables: { postId: _id } },
-      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: '', interactions: false } },
+      {
+        query: GET_TOP_POSTS,
+        variables: { limit: 5, offset: 0, searchKey: "", interactions: false },
+      },
     ],
-  })
+  });
 
   const [rejectPost] = useMutation(REJECT_POST, {
     refetchQueries: [
       { query: GET_POST, variables: { postId: _id } },
-      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: '', interactions: false } },
+      {
+        query: GET_TOP_POSTS,
+        variables: { limit: 5, offset: 0, searchKey: "", interactions: false },
+      },
     ],
-  })
+  });
 
   const [deletePost] = useMutation<{ deletePost: { _id: string } }>(DELETE_POST, {
     update(cache, { data }) {
-      if (!data?.deletePost) return
-      const deletedId = data.deletePost._id
+      if (!data?.deletePost) return;
+      const deletedId = data.deletePost._id;
       cache.modify({
         fields: {
           posts(existing: unknown = {}, { readField }) {
-            const obj = existing as { entities?: Reference[] }
-            if (!obj.entities) return existing
-            return { ...obj, entities: obj.entities.filter((ref) => readField('_id', ref) !== deletedId) }
+            const obj = existing as { entities?: Reference[] };
+            if (!obj.entities) return existing;
+            return {
+              ...obj,
+              entities: obj.entities.filter((ref) => readField("_id", ref) !== deletedId),
+            };
           },
           featuredPosts(existing: unknown = {}, { readField }) {
-            const obj = existing as { entities?: Reference[] }
-            if (!obj.entities) return existing
-            return { ...obj, entities: obj.entities.filter((ref) => readField('_id', ref) !== deletedId) }
+            const obj = existing as { entities?: Reference[] };
+            if (!obj.entities) return existing;
+            return {
+              ...obj,
+              entities: obj.entities.filter((ref) => readField("_id", ref) !== deletedId),
+            };
           },
         },
-      })
-      cache.evict({ id: cache.identify({ __typename: 'Post', _id: deletedId }) })
-      cache.gc()
+      });
+      cache.evict({ id: cache.identify({ __typename: "Post", _id: deletedId }) });
+      cache.gc();
     },
     refetchQueries: [
-      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: '', interactions: false } },
+      {
+        query: GET_TOP_POSTS,
+        variables: { limit: 5, offset: 0, searchKey: "", interactions: false },
+      },
     ],
-  })
+  });
 
-  const userIdStr = user._id?.toString()
-  const hasApproved = Array.isArray(post.approvedBy) && post.approvedBy.some((id) => id?.toString() === userIdStr)
-  const hasRejected = Array.isArray(post.rejectedBy) && post.rejectedBy.some((id) => id?.toString() === userIdStr)
-  const votedBy = (post.votes || []) as PostVote[]
-  const hasVoted = Array.isArray(votedBy) && votedBy.some(
-    (v) => v.user?._id?.toString() === userIdStr && !(v as { deleted?: boolean }).deleted
-  )
+  const userIdStr = user._id?.toString();
+  const hasApproved =
+    Array.isArray(post.approvedBy) && post.approvedBy.some((id) => id?.toString() === userIdStr);
+  const hasRejected =
+    Array.isArray(post.rejectedBy) && post.rejectedBy.some((id) => id?.toString() === userIdStr);
+  const votedBy = (post.votes || []) as PostVote[];
+  const hasVoted =
+    Array.isArray(votedBy) &&
+    votedBy.some(
+      (v) => v.user?._id?.toString() === userIdStr && !(v as { deleted?: boolean }).deleted
+    );
 
   const getUserVote = () => {
-    if (!hasVoted) return null
+    if (!hasVoted) return null;
     return votedBy.find(
       (v) => v.user?._id?.toString() === userIdStr && !(v as { deleted?: boolean }).deleted
-    )
-  }
+    );
+  };
 
   const getUserVoteType = () => {
-    const userVote = getUserVote()
-    return userVote ? userVote.type : null
-  }
+    const userVote = getUserVote();
+    return userVote ? userVote.type : null;
+  };
 
   const handleDeleteVote = async () => {
-    if (!ensureAuth()) return
-    const userVote = getUserVote()
-    if (!userVote) return
+    if (!ensureAuth()) return;
+    const userVote = getUserVote();
+    if (!userVote) return;
     try {
       await removeVote({
         variables: {
           voteId: userVote._id,
         },
-      })
-      toast.success('Vote removed successfully')
+      });
+      toast.success("Vote removed successfully");
     } catch (err) {
-      toast.error(`Error removing vote: ${err instanceof Error ? err.message : 'Unknown'}`)
+      toast.error(`Error removing vote: ${err instanceof Error ? err.message : "Unknown"}`);
     }
-  }
+  };
 
   const handleVoting = async (obj: { type: VoteType; tags: VoteOption }) => {
-    if (!ensureAuth()) return
-    const userVote = getUserVote()
+    if (!ensureAuth()) return;
+    const userVote = getUserVote();
     try {
       if (userVote) {
         if (userVote.type === obj.type) {
-          await handleDeleteVote()
-          return
+          await handleDeleteVote();
+          return;
         }
         // Switch vote: synchronously delete existing vote first
         await removeVote({
           variables: {
             voteId: userVote._id,
           },
-        })
+        });
       }
       await addVote({
         variables: {
           vote: {
-            content: selectedText.text || '',
-            postId: post._id, userId: user._id,
-            type: obj.type, tags: obj.tags,
-            startWordIndex: selectedText.startIndex, endWordIndex: selectedText.endIndex,
+            content: selectedText.text || "",
+            postId: post._id,
+            userId: user._id,
+            type: obj.type,
+            tags: obj.tags,
+            startWordIndex: selectedText.startIndex,
+            endWordIndex: selectedText.endIndex,
           },
         },
-      })
-      toast.success('Voted successfully')
-    } catch (err) { toast.error(`Vote error: ${err instanceof Error ? err.message : 'Unknown'}`) }
-  }
+      });
+      toast.success("Voted successfully");
+    } catch (err) {
+      toast.error(`Vote error: ${err instanceof Error ? err.message : "Unknown"}`);
+    }
+  };
 
   const handleAddComment = async (comment: string, commentWithQuote = false) => {
-    if (!ensureAuth()) return
+    if (!ensureAuth()) return;
     if (!comment.trim()) {
-      toast.error('Please enter a comment')
-      return
+      toast.error("Please enter a comment");
+      return;
     }
     try {
       await addComment({
         variables: {
           comment: {
-            userId: user._id, content: comment.trim(),
-            startWordIndex: selectedText.startIndex, endWordIndex: selectedText.endIndex,
-            postId: _id, url: post.url,
-            quote: commentWithQuote ? selectedText.text : '',
+            userId: user._id,
+            content: comment.trim(),
+            startWordIndex: selectedText.startIndex,
+            endWordIndex: selectedText.endIndex,
+            postId: _id,
+            url: post.url,
+            quote: commentWithQuote ? selectedText.text : "",
           },
         },
-      })
-      toast.success('Comment added')
-    } catch (err) { toast.error(`Error: ${err instanceof Error ? err.message : 'Unknown'}`) }
-  }
+      });
+      toast.success("Comment added");
+    } catch (err) {
+      toast.error(`Error: ${err instanceof Error ? err.message : "Unknown"}`);
+    }
+  };
 
   const handleAddQuote = async () => {
-    if (!ensureAuth()) return
+    if (!ensureAuth()) return;
     try {
       await addQuote({
         variables: {
           quote: {
-            quote: selectedText.text, postId: post._id,
-            quoter: user._id, quoted: userId,
-            startWordIndex: selectedText.startIndex, endWordIndex: selectedText.endIndex,
+            quote: selectedText.text,
+            postId: post._id,
+            quoter: user._id,
+            quoted: userId,
+            startWordIndex: selectedText.startIndex,
+            endWordIndex: selectedText.endIndex,
           },
         },
-      })
-      toast.success('Quoted successfully')
-    } catch (err) { toast.error(`Error: ${err instanceof Error ? err.message : 'Unknown'}`) }
-  }
+      });
+      toast.success("Quoted successfully");
+    } catch (err) {
+      toast.error(`Error: ${err instanceof Error ? err.message : "Unknown"}`);
+    }
+  };
 
   const handleApprove = async () => {
-    if (!ensureAuth()) return
+    if (!ensureAuth()) return;
     try {
       if (hasApproved) {
-        await approvePost({ variables: { postId: _id, userId: user._id, remove: true } })
-        toast.success('Approval removed')
+        await approvePost({ variables: { postId: _id, userId: user._id, remove: true } });
+        toast.success("Approval removed");
       } else {
-        await approvePost({ variables: { postId: _id, userId: user._id } })
-        toast.success('Post approved')
+        await approvePost({ variables: { postId: _id, userId: user._id } });
+        toast.success("Post approved");
       }
-    } catch (err) { toast.error(`Error: ${err instanceof Error ? err.message : 'Unknown'}`) }
-  }
+    } catch (err) {
+      toast.error(`Error: ${err instanceof Error ? err.message : "Unknown"}`);
+    }
+  };
 
   const handleReject = async () => {
-    if (!ensureAuth()) return
+    if (!ensureAuth()) return;
     try {
       if (hasRejected) {
-        await rejectPost({ variables: { postId: _id, userId: user._id, remove: true } })
-        toast.success('Rejection removed')
+        await rejectPost({ variables: { postId: _id, userId: user._id, remove: true } });
+        toast.success("Rejection removed");
       } else {
-        await rejectPost({ variables: { postId: _id, userId: user._id } })
-        toast.success('Post rejected')
+        await rejectPost({ variables: { postId: _id, userId: user._id } });
+        toast.success("Post rejected");
       }
-    } catch (err) { toast.error(`Error: ${err instanceof Error ? err.message : 'Unknown'}`) }
-  }
+    } catch (err) {
+      toast.error(`Error: ${err instanceof Error ? err.message : "Unknown"}`);
+    }
+  };
 
   const handleReport = async () => {
-    if (!ensureAuth()) return
+    if (!ensureAuth()) return;
     try {
-      const res = await reportPost({ variables: { postId: _id, userId: user._id } })
-      toast.success(`Post reported (${res.data?.reportPost?.reportedBy?.length || 1} total)`)
-    } catch (err) { toast.error(err instanceof Error ? err.message : 'Unknown error') }
-  }
+      const res = await reportPost({ variables: { postId: _id, userId: user._id } });
+      toast.success(`Post reported (${res.data?.reportPost?.reportedBy?.length || 1} total)`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Unknown error");
+    }
+  };
 
   const handleDelete = async () => {
     try {
-      await deletePost({ variables: { postId: _id } })
-      toast.success('Post deleted')
-      router.push('/')
-    } catch (err) { toast.error(`Error: ${err instanceof Error ? err.message : 'Unknown'}`) }
-  }
+      await deletePost({ variables: { postId: _id } });
+      toast.success("Post deleted");
+      router.push("/");
+    } catch (err) {
+      toast.error(`Error: ${err instanceof Error ? err.message : "Unknown"}`);
+    }
+  };
 
   const handleCopy = async () => {
-    const url = typeof window !== 'undefined' ? window.location.href : ''
-    await navigator.clipboard.writeText(url)
-    toast.success('Link copied!')
-  }
+    const url = typeof window !== "undefined" ? window.location.href : "";
+    await navigator.clipboard.writeText(url);
+    toast.success("Link copied!");
+  };
 
-  const approveCount = post.approvedBy?.length || 0
-  const rejectCount = post.rejectedBy?.length || 0
-  const commentCount = post.comments?.length || 0
-  const quoteCount = post.quotes?.length || 0
-  const voteCount = post.votes?.length || 0
-  const interactionCount = commentCount + quoteCount + voteCount
+  const approveCount = post.approvedBy?.length || 0;
+  const rejectCount = post.rejectedBy?.length || 0;
+  const commentCount = post.comments?.length || 0;
+  const quoteCount = post.quotes?.length || 0;
+  const voteCount = post.votes?.length || 0;
+  const interactionCount = commentCount + quoteCount + voteCount;
 
   return (
-    <div className="flex flex-col" role="article" aria-label={title || 'Post'}>
-
+    <div className="flex flex-col" role="article" aria-label={title || "Post"}>
       {/* ── Non-sticky header area ──────────────────────────────────────── */}
       <div className="px-4 sm:px-6 pt-5 pb-3">
-
         {/* Back button */}
         <button
           type="button"
@@ -407,7 +453,7 @@ export default function Post({
                 <span className="text-sm text-muted-foreground">@{username}</span>
               </div>
               <time className="text-xs text-muted-foreground" suppressHydrationWarning>
-                {moment(created).format('MMM D, YYYY · h:mm A')}
+                {moment(created).format("MMM D, YYYY · h:mm A")}
               </time>
             </div>
           </div>
@@ -428,7 +474,10 @@ export default function Post({
               <DropdownMenuItem onClick={handleCopy}>
                 <Link2 className="size-4 mr-2" /> Copy link
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={handleReport} className="text-destructive focus:text-destructive">
+              <DropdownMenuItem
+                onClick={handleReport}
+                className="text-destructive focus:text-destructive"
+              >
                 <Ban className="size-4 mr-2" /> Report post
               </DropdownMenuItem>
             </DropdownMenuContent>
@@ -452,7 +501,7 @@ export default function Post({
             className="inline-flex items-center gap-1.5 text-xs text-primary/80 hover:text-primary px-2.5 py-1 bg-primary/5 rounded-md mt-1 transition-colors"
           >
             <ExternalLink className="size-3" />
-            {post.citationUrl.replace(/^https?:\/\//, '').split('/')[0]}
+            {post.citationUrl.replace(/^https?:\/\//, "").split("/")[0]}
           </a>
         )}
       </div>
@@ -460,10 +509,10 @@ export default function Post({
       {/* ── Action bar: sticky while reading; scrolls with the quote in split view ── */}
       <div
         className={cn(
-          'flex items-center gap-2 px-4 sm:px-6 py-2 border-y border-border/60',
+          "flex items-center gap-2 px-4 sm:px-6 py-2 border-y border-border/60",
           mobileDiscussionOpen
-            ? 'relative bg-background'
-            : 'sticky top-0 z-10 bg-background/80 backdrop-blur-sm',
+            ? "relative bg-background"
+            : "sticky top-0 z-10 bg-background/80 backdrop-blur-sm"
         )}
         role="toolbar"
         aria-label="Post actions"
@@ -473,28 +522,28 @@ export default function Post({
           <Button
             size="sm"
             onClick={handleReject}
-            aria-label={hasRejected ? 'Remove downvote' : 'Downvote this post'}
+            aria-label={hasRejected ? "Remove downvote" : "Downvote this post"}
             className={cn(
-              'rounded-xl font-bold text-xs h-8 border',
+              "rounded-xl font-bold text-xs h-8 border",
               hasRejected
-                ? 'bg-disagree border-disagree text-white hover:bg-disagree-hover'
-                : 'bg-transparent border-disagree/40 text-disagree hover:bg-disagree/5 hover:border-disagree'
+                ? "bg-disagree border-disagree text-white hover:bg-disagree-hover"
+                : "bg-transparent border-disagree/40 text-disagree hover:bg-disagree/5 hover:border-disagree"
             )}
           >
-            Disagree{rejectCount > 0 ? ` (${rejectCount})` : ''}
+            Disagree{rejectCount > 0 ? ` (${rejectCount})` : ""}
           </Button>
           <Button
             size="sm"
             onClick={handleApprove}
-            aria-label={hasApproved ? 'Remove upvote' : 'Upvote this post'}
+            aria-label={hasApproved ? "Remove upvote" : "Upvote this post"}
             className={cn(
-              'rounded-xl font-bold text-xs h-8 border',
+              "rounded-xl font-bold text-xs h-8 border",
               hasApproved
-                ? 'bg-agree border-agree text-white hover:bg-agree-hover'
-                : 'bg-transparent border-agree/40 text-agree hover:bg-agree/5 hover:border-agree'
+                ? "bg-agree border-agree text-white hover:bg-agree-hover"
+                : "bg-transparent border-agree/40 text-agree hover:bg-agree/5 hover:border-agree"
             )}
           >
-            Agree{approveCount > 0 ? ` (${approveCount})` : ''}
+            Agree{approveCount > 0 ? ` (${approveCount})` : ""}
           </Button>
 
           <Separator orientation="vertical" className="h-5 mx-0.5" />
@@ -503,14 +552,14 @@ export default function Post({
             <FollowButton
               isFollowing={isFollowing}
               profileUserId={userId}
-              username={username || ''}
+              username={username || ""}
               showIcon
             />
           )}
 
           <BookmarkIconButton
             post={{ _id: post._id, bookmarkedBy: post.bookmarkedBy || undefined }}
-            user={{ _id: user._id || '' }}
+            user={{ _id: user._id || "" }}
           />
 
           <TooltipProvider>
@@ -521,10 +570,17 @@ export default function Post({
                   aria-label={`${approveCount} support, ${rejectCount} disagree`}
                 >
                   <ArrowBigUp className="size-3.5 text-[var(--color-upvote)]" strokeWidth={1.5} />
-                  <strong className="text-foreground font-semibold tabular-nums">{approveCount}</strong>
+                  <strong className="text-foreground font-semibold tabular-nums">
+                    {approveCount}
+                  </strong>
                   <span className="text-muted-foreground/30 mx-0.5">/</span>
-                  <ArrowBigDown className="size-3.5 text-[var(--color-downvote)]" strokeWidth={1.5} />
-                  <strong className="text-foreground font-semibold tabular-nums">{rejectCount}</strong>
+                  <ArrowBigDown
+                    className="size-3.5 text-[var(--color-downvote)]"
+                    strokeWidth={1.5}
+                  />
+                  <strong className="text-foreground font-semibold tabular-nums">
+                    {rejectCount}
+                  </strong>
                 </span>
               </TooltipTrigger>
               <TooltipContent side="bottom">
@@ -541,25 +597,29 @@ export default function Post({
                     type="button"
                     onClick={onOpenDiscussion}
                     className="flex items-center gap-1 px-2 h-8 rounded-md bg-muted/40 text-[12px] text-muted-foreground hover:bg-muted/70 transition-colors"
-                    aria-label={`${interactionCount} interaction${interactionCount !== 1 ? 's' : ''}`}
+                    aria-label={`${interactionCount} interaction${interactionCount !== 1 ? "s" : ""}`}
                     data-testid="post-comment-count"
                   >
                     <MessageCircle className="size-3.5" />
-                    <strong className="text-foreground font-semibold tabular-nums">{interactionCount}</strong>
+                    <strong className="text-foreground font-semibold tabular-nums">
+                      {interactionCount}
+                    </strong>
                   </button>
                 ) : (
                   <span
                     className="flex items-center gap-1 px-2 h-8 rounded-md bg-muted/40 text-[12px] text-muted-foreground"
-                    aria-label={`${interactionCount} interaction${interactionCount !== 1 ? 's' : ''}`}
+                    aria-label={`${interactionCount} interaction${interactionCount !== 1 ? "s" : ""}`}
                     data-testid="post-comment-count"
                   >
                     <MessageCircle className="size-3.5" />
-                    <strong className="text-foreground font-semibold tabular-nums">{interactionCount}</strong>
+                    <strong className="text-foreground font-semibold tabular-nums">
+                      {interactionCount}
+                    </strong>
                   </span>
                 )}
               </TooltipTrigger>
               <TooltipContent side="bottom">
-                {interactionCount} interaction{interactionCount !== 1 ? 's' : ''}
+                {interactionCount} interaction{interactionCount !== 1 ? "s" : ""}
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -595,11 +655,12 @@ export default function Post({
         <div
           data-testid="post-detail-body"
           className={cn(
-          'text-[15px] leading-[1.75] text-foreground/85',
-          postHeight && postHeight >= 742 && 'max-h-[60vh] overflow-y-auto'
-        )}>
+            "text-[15px] leading-[1.75] text-foreground/85",
+            postHeight && postHeight >= 742 && "max-h-[60vh] overflow-y-auto"
+          )}
+        >
           <VotingBoard
-            content={post.text || ''}
+            content={post.text || ""}
             onSelect={setSelectedText}
             onDeselect={handleDeselect}
             highlights={true}
@@ -610,11 +671,13 @@ export default function Post({
             {(selection) => (
               <Suspense fallback={null}>
                 <VotingPopup
-                  votedBy={(post.votes || []).map((v: PostVote): VotedByEntry => ({
-                    userId: v.user?._id || '',
-                    type: (v.type as VoteType) || 'up',
-                    _id: v._id,
-                  }))}
+                  votedBy={(post.votes || []).map(
+                    (v: PostVote): VotedByEntry => ({
+                      userId: v.user?._id || "",
+                      type: (v.type as VoteType) || "up",
+                      _id: v._id,
+                    })
+                  )}
                   onVote={handleVoting}
                   onAddComment={handleAddComment}
                   onAddQuote={handleAddQuote}
@@ -628,7 +691,6 @@ export default function Post({
           </VotingBoard>
         </div>
       </div>
-
     </div>
-  )
+  );
 }

--- a/quotevote-frontend/src/components/VotingComponents/SelectionPopover.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/SelectionPopover.tsx
@@ -1,18 +1,20 @@
 'use client'
 
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import type { SelectionPopoverProps } from '@/types/voting'
 
 /**
- * SelectionPopover component
- * Handles text selection and displays a popover at the selection position
+ * SelectionPopover — pure portal/positioning (issue #484).
+ * No selection polling, no onSelect/onDeselect. Owner (VotingBoard) owns
+ * selection state and provides `resolveAnchorRect` + `popoverRef`.
+ * Preserves above/below placement, clamping, scroll handlers, z-index 50.
  */
 export default function SelectionPopover({
   showPopover,
   topOffset = 30,
-  onSelect,
-  onDeselect,
+  resolveAnchorRect,
+  popoverRef,
   style,
   children,
 }: SelectionPopoverProps) {
@@ -21,42 +23,15 @@ export default function SelectionPopover({
     top: 0,
     left: 0,
   })
-  const popoverRef = useRef<HTMLDivElement>(null)
-  const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true)
   }, [])
 
-  const selectionExists = useCallback(() => {
-    const selection = window.getSelection()
-    return (
-      selection &&
-      selection.rangeCount > 0 &&
-      selection.getRangeAt(0) &&
-      !selection.getRangeAt(0).collapsed &&
-      selection.getRangeAt(0).getBoundingClientRect().width > 0 &&
-      selection.getRangeAt(0).getBoundingClientRect().height > 0
-    )
-  }, [])
-
-  const clearSelection = useCallback(() => {
-    if (window.getSelection) {
-      window.getSelection()?.removeAllRanges()
-    } else if (
-      (document as unknown as { selection?: { empty: () => void } }).selection
-    ) {
-      ;(document as unknown as { selection: { empty: () => void } }).selection?.empty()
-    }
-  }, [])
-
   const computePopoverBox = useCallback(() => {
-    const selection = window.getSelection()
-    if (!selectionExists() || !selection || selection.rangeCount === 0) {
-      return
-    }
-    const selectionBox = selection.getRangeAt(0).getBoundingClientRect()
+    const selectionBox = resolveAnchorRect()
+    if (!selectionBox) return
     const popoverElement = popoverRef.current
     if (!popoverElement) return
 
@@ -88,82 +63,27 @@ export default function SelectionPopover({
       top: pageTop,
       left: pageLeft,
     })
-  }, [topOffset, selectionExists])
-
-  const selectionChange = useCallback(() => {
-    const selection = window.getSelection()
-    if (selectionExists() && selection) {
-      onSelect(selection)
-      computePopoverBox()
-      return
-    }
-    onDeselect()
-  }, [onSelect, onDeselect, selectionExists, computePopoverBox])
-
-  const handleRemoveInterval = useCallback(() => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current)
-      intervalRef.current = null
-    }
-  }, [])
-
-  const handleMobileSelection = useCallback(() => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current)
-    }
-    intervalRef.current = setInterval(() => {
-      selectionChange()
-    }, 100)
-  }, [selectionChange])
-
-  useEffect(() => {
-    if (showPopover === false) {
-      clearSelection()
-    }
-  }, [showPopover, clearSelection])
-
-  useEffect(() => {
-    const target = document.querySelector('[data-selectable]')
-    if (target) {
-      target.addEventListener('selectstart', handleMobileSelection)
-      target.addEventListener('pointerup', handleRemoveInterval)
-      target.addEventListener('pointermove', selectionChange)
-
-      return () => {
-        target.removeEventListener('selectstart', handleMobileSelection)
-        target.removeEventListener('pointerup', handleRemoveInterval)
-        target.removeEventListener('pointermove', selectionChange)
-      }
-    }
-    return undefined
-  }, [handleMobileSelection, handleRemoveInterval, selectionChange])
+  }, [topOffset, resolveAnchorRect, popoverRef])
 
   useEffect(() => {
     if (showPopover) {
-      // Run on next frames to handle potential layout adjustments and avoid cascading renders lint rule
       const rafId1 = requestAnimationFrame(computePopoverBox)
       const rafId2 = requestAnimationFrame(() => requestAnimationFrame(computePopoverBox))
 
       window.addEventListener('resize', computePopoverBox)
+      window.addEventListener('orientationchange', computePopoverBox)
       window.addEventListener('scroll', computePopoverBox, { passive: true })
 
       return () => {
         cancelAnimationFrame(rafId1)
         cancelAnimationFrame(rafId2)
         window.removeEventListener('resize', computePopoverBox)
+        window.removeEventListener('orientationchange', computePopoverBox)
         window.removeEventListener('scroll', computePopoverBox)
       }
     }
     return undefined
   }, [showPopover, computePopoverBox])
-
-  useEffect(() => {
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-      }
-    }
-  }, [])
 
   if (!mounted) return null
 
@@ -181,8 +101,6 @@ export default function SelectionPopover({
         position: 'absolute',
         top: popoverBox.top,
         left: popoverBox.left,
-        // Must sit above the post's sticky action bar (Disagree/Support,
-        // z-10 in Post.tsx) so the selection interaction isn't hidden behind it.
         zIndex: 50,
         ...style,
       }}
@@ -192,4 +110,3 @@ export default function SelectionPopover({
     document.body
   )
 }
-

--- a/quotevote-frontend/src/components/VotingComponents/SelectionPopover.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/SelectionPopover.tsx
@@ -4,15 +4,6 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
 import type { SelectionPopoverProps } from "@/types/voting";
 
-/**
- * SelectionPopover — pure portal/positioning (issue #484).
- * No selection polling, no onSelect/onDeselect. Owner (VotingBoard) owns
- * selection state and provides `resolveAnchorRect` + `popoverRef`.
- * Preserves above/below placement, clamping, scroll handlers, z-index 50.
- *
- * The portal stays visually hidden until the first position has been
- * computed, so the popup is never exposed at (0, 0) (P2 #1).
- */
 export default function SelectionPopover({
   showPopover,
   topOffset = 30,
@@ -44,7 +35,6 @@ export default function SelectionPopover({
     const popoverWidth = popoverBoxRect.width || 285;
     const popoverHeight = popoverBoxRect.height || 48;
 
-    // Clamp horizontally within viewport
     const margin = 10;
     const viewportLeft = selectionBox.left + selectionBox.width / 2 - popoverWidth / 2;
     const clampedViewportLeft = Math.max(
@@ -53,14 +43,11 @@ export default function SelectionPopover({
     );
     const pageLeft = clampedViewportLeft + window.scrollX;
 
-    // Determine vertical position: top or bottom
     const spaceAtTop = selectionBox.top;
     let pageTop: number;
     if (spaceAtTop < popoverHeight + topOffset + 10) {
-      // Position below the selection
       pageTop = selectionBox.bottom + window.scrollY + topOffset;
     } else {
-      // Position above the selection
       pageTop = selectionBox.top + window.scrollY - popoverHeight - topOffset;
     }
 
@@ -79,7 +66,6 @@ export default function SelectionPopover({
       positionedRef.current = false;
       // eslint-disable-next-line react-hooks/set-state-in-effect -- reset positioning state when popover opens
       setPositioned(false);
-      // Run on next frames to handle potential layout adjustments
       const rafId1 = requestAnimationFrame(computePopoverBox);
       const rafId2 = requestAnimationFrame(() => requestAnimationFrame(computePopoverBox));
 
@@ -101,7 +87,6 @@ export default function SelectionPopover({
 
   if (!mounted) return null;
 
-  // Hidden until both shown AND positioned — never visible at (0, 0)
   const visible = showPopover && positioned;
   const visibility = visible ? "visible" : "hidden";
   const display = visible ? "inline-block" : "none";

--- a/quotevote-frontend/src/components/VotingComponents/SelectionPopover.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/SelectionPopover.tsx
@@ -1,14 +1,17 @@
-'use client'
+"use client";
 
-import { useEffect, useState, useCallback } from 'react'
-import { createPortal } from 'react-dom'
-import type { SelectionPopoverProps } from '@/types/voting'
+import { useEffect, useState, useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
+import type { SelectionPopoverProps } from "@/types/voting";
 
 /**
  * SelectionPopover — pure portal/positioning (issue #484).
  * No selection polling, no onSelect/onDeselect. Owner (VotingBoard) owns
  * selection state and provides `resolveAnchorRect` + `popoverRef`.
  * Preserves above/below placement, clamping, scroll handlers, z-index 50.
+ *
+ * The portal stays visually hidden until the first position has been
+ * computed, so the popup is never exposed at (0, 0) (P2 #1).
  */
 export default function SelectionPopover({
   showPopover,
@@ -18,77 +21,90 @@ export default function SelectionPopover({
   style,
   children,
 }: SelectionPopoverProps) {
-  const [mounted, setMounted] = useState(false)
+  const [mounted, setMounted] = useState(false);
+  const [positioned, setPositioned] = useState(false);
   const [popoverBox, setPopoverBox] = useState({
     top: 0,
     left: 0,
-  })
+  });
+  const positionedRef = useRef(false);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setMounted(true)
-  }, [])
+    setMounted(true);
+  }, []);
 
   const computePopoverBox = useCallback(() => {
-    const selectionBox = resolveAnchorRect()
-    if (!selectionBox) return
-    const popoverElement = popoverRef.current
-    if (!popoverElement) return
+    const selectionBox = resolveAnchorRect();
+    if (!selectionBox) return;
+    const popoverElement = popoverRef.current;
+    if (!popoverElement) return;
 
-    const popoverBoxRect = popoverElement.getBoundingClientRect()
-    const popoverWidth = popoverBoxRect.width || 285
-    const popoverHeight = popoverBoxRect.height || 48
+    const popoverBoxRect = popoverElement.getBoundingClientRect();
+    const popoverWidth = popoverBoxRect.width || 285;
+    const popoverHeight = popoverBoxRect.height || 48;
 
     // Clamp horizontally within viewport
-    const margin = 10
-    const viewportLeft = selectionBox.left + selectionBox.width / 2 - popoverWidth / 2
+    const margin = 10;
+    const viewportLeft = selectionBox.left + selectionBox.width / 2 - popoverWidth / 2;
     const clampedViewportLeft = Math.max(
       margin,
       Math.min(window.innerWidth - popoverWidth - margin, viewportLeft)
-    )
-    const pageLeft = clampedViewportLeft + window.scrollX
+    );
+    const pageLeft = clampedViewportLeft + window.scrollX;
 
     // Determine vertical position: top or bottom
-    const spaceAtTop = selectionBox.top
-    let pageTop: number
+    const spaceAtTop = selectionBox.top;
+    let pageTop: number;
     if (spaceAtTop < popoverHeight + topOffset + 10) {
       // Position below the selection
-      pageTop = selectionBox.bottom + window.scrollY + topOffset
+      pageTop = selectionBox.bottom + window.scrollY + topOffset;
     } else {
       // Position above the selection
-      pageTop = selectionBox.top + window.scrollY - popoverHeight - topOffset
+      pageTop = selectionBox.top + window.scrollY - popoverHeight - topOffset;
     }
 
     setPopoverBox({
       top: pageTop,
       left: pageLeft,
-    })
-  }, [topOffset, resolveAnchorRect, popoverRef])
+    });
+    if (!positionedRef.current) {
+      positionedRef.current = true;
+      setPositioned(true);
+    }
+  }, [topOffset, resolveAnchorRect, popoverRef]);
 
   useEffect(() => {
     if (showPopover) {
-      const rafId1 = requestAnimationFrame(computePopoverBox)
-      const rafId2 = requestAnimationFrame(() => requestAnimationFrame(computePopoverBox))
+      positionedRef.current = false;
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset positioning state when popover opens
+      setPositioned(false);
+      // Run on next frames to handle potential layout adjustments
+      const rafId1 = requestAnimationFrame(computePopoverBox);
+      const rafId2 = requestAnimationFrame(() => requestAnimationFrame(computePopoverBox));
 
-      window.addEventListener('resize', computePopoverBox)
-      window.addEventListener('orientationchange', computePopoverBox)
-      window.addEventListener('scroll', computePopoverBox, { passive: true })
+      window.addEventListener("resize", computePopoverBox);
+      window.addEventListener("orientationchange", computePopoverBox);
+      window.addEventListener("scroll", computePopoverBox, { passive: true });
 
       return () => {
-        cancelAnimationFrame(rafId1)
-        cancelAnimationFrame(rafId2)
-        window.removeEventListener('resize', computePopoverBox)
-        window.removeEventListener('orientationchange', computePopoverBox)
-        window.removeEventListener('scroll', computePopoverBox)
-      }
+        cancelAnimationFrame(rafId1);
+        cancelAnimationFrame(rafId2);
+        window.removeEventListener("resize", computePopoverBox);
+        window.removeEventListener("orientationchange", computePopoverBox);
+        window.removeEventListener("scroll", computePopoverBox);
+      };
     }
-    return undefined
-  }, [showPopover, computePopoverBox])
+    positionedRef.current = false;
+    return undefined;
+  }, [showPopover, computePopoverBox]);
 
-  if (!mounted) return null
+  if (!mounted) return null;
 
-  const visibility = showPopover ? 'visible' : 'hidden'
-  const display = showPopover ? 'inline-block' : 'none'
+  // Hidden until both shown AND positioned — never visible at (0, 0)
+  const visible = showPopover && positioned;
+  const visibility = visible ? "visible" : "hidden";
+  const display = visible ? "inline-block" : "none";
 
   return createPortal(
     <div
@@ -98,7 +114,7 @@ export default function SelectionPopover({
       style={{
         visibility,
         display,
-        position: 'absolute',
+        position: "absolute",
         top: popoverBox.top,
         left: popoverBox.left,
         zIndex: 50,
@@ -108,5 +124,5 @@ export default function SelectionPopover({
       {showPopover && children}
     </div>,
     document.body
-  )
+  );
 }

--- a/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
@@ -138,6 +138,11 @@ export default function VotingBoard({
   }, []);
 
   const resetToIdle = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    clearSuppress();
     cachedRectRef.current = null;
     cachedSelectionRef.current = null;
     touchModeRef.current = false;
@@ -147,7 +152,7 @@ export default function VotingBoard({
     setSelection({ startIndex: 0, endIndex: 0, text: "", points: 0 });
     setPhaseSynced("idle");
     onDeselect?.();
-  }, [onDeselect, setPhaseSynced]);
+  }, [clearSuppress, onDeselect, setPhaseSynced]);
 
   const armSuppress = useCallback(
     (pointerId: number | null) => {

--- a/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
@@ -207,25 +207,13 @@ export default function VotingBoard({
     if (prevContentRef.current === content) return;
     prevContentRef.current = content;
     resetToIdle();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [content]);
+  }, [content, resetToIdle]);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
     const mql = window.matchMedia(TOUCH_MEDIA_QUERY);
     const handler = () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-      clearSuppress();
-      cachedRectRef.current = null;
-      cachedSelectionRef.current = null;
-      touchModeRef.current = false;
-      setTouchMode(false);
-      setSelection({ startIndex: 0, endIndex: 0, text: "", points: 0 });
-      setPhaseSynced("idle");
-      onDeselect?.();
+      resetToIdle();
     };
     if (typeof mql.addEventListener === "function") {
       mql.addEventListener("change", handler);
@@ -240,7 +228,7 @@ export default function VotingBoard({
       return () => legacy.removeListener(handler);
     }
     return undefined;
-  }, [clearSuppress, onDeselect, setPhaseSynced]);
+  }, [resetToIdle]);
 
   useEffect(() => {
     return () => {
@@ -519,12 +507,7 @@ export default function VotingBoard({
       }
       e.preventDefault();
       e.stopPropagation();
-      if (
-        typeof (e as unknown as { stopImmediatePropagation?: () => void })
-          .stopImmediatePropagation === "function"
-      ) {
-        (e as unknown as { stopImmediatePropagation: () => void }).stopImmediatePropagation!();
-      }
+      e.stopImmediatePropagation();
       clearSuppress();
       if (hasPendingDismiss) {
         pendingDismissRef.current = false;

--- a/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
@@ -135,6 +135,10 @@ export default function VotingBoard({
   const pendingTapRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
   const tapDraggedRef = useRef(false);
 
+  // Pending dismiss for second tap (P1 #1): keep click listener alive until
+  // the delayed compatibility click is consumed
+  const pendingDismissRef = useRef(false);
+
   const setPhaseSynced = useCallback((next: SelectionPhase) => {
     phaseRef.current = next;
     setPhase(next);
@@ -150,17 +154,6 @@ export default function VotingBoard({
     }
   }, []);
 
-  const armSuppress = useCallback(
-    (pointerId: number | null) => {
-      suppressNextClickRef.current = true;
-      suppressPointerIdRef.current = pointerId;
-      suppressDeadlineRef.current = Date.now() + 750;
-      if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current);
-      suppressTimerRef.current = setTimeout(clearSuppress, 800);
-    },
-    [clearSuppress]
-  );
-
   const clearNativeSelection = useCallback(() => {
     try {
       window.getSelection()?.removeAllRanges();
@@ -175,10 +168,30 @@ export default function VotingBoard({
     touchModeRef.current = false;
     setTouchMode(false);
     pendingTapRef.current = null;
+    pendingDismissRef.current = false;
     setSelection({ startIndex: 0, endIndex: 0, text: "", points: 0 });
     setPhaseSynced("idle");
     onDeselect?.();
   }, [onDeselect, setPhaseSynced]);
+
+  const armSuppress = useCallback(
+    (pointerId: number | null) => {
+      suppressNextClickRef.current = true;
+      suppressPointerIdRef.current = pointerId;
+      suppressDeadlineRef.current = Date.now() + 750;
+      if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current);
+      suppressTimerRef.current = setTimeout(() => {
+        clearSuppress();
+        // Fallback: if the delayed click never arrived (e.g. compat click
+        // was swallowed), still dismiss the pending toolbar
+        if (pendingDismissRef.current) {
+          pendingDismissRef.current = false;
+          resetToIdle();
+        }
+      }, 800);
+    },
+    [clearSuppress, resetToIdle]
+  );
 
   const commentData = focusedComment || null;
   const startWordIndex = commentData?.startWordIndex ?? 0;
@@ -490,12 +503,13 @@ export default function VotingBoard({
       }
 
       if (phaseRef.current === "toolbar") {
-        // Second outside tap: toolbar → idle
+        // Second outside tap: toolbar → idle. Keep the click-capture
+        // listener alive until the delayed compatibility click is consumed
+        // (P1 #1), so the click does not activate UI underneath.
+        pendingDismissRef.current = true;
         armSuppress(e.pointerId ?? null);
         e.preventDefault();
         e.stopPropagation();
-        // Clear after suppress armed so click suppression can fire
-        window.setTimeout(() => resetToIdle(), 0);
       }
     };
 
@@ -525,35 +539,67 @@ export default function VotingBoard({
       }
     };
 
+    document.addEventListener("pointerdown", onPointerDownCapture, true);
+    document.addEventListener("pointermove", onPointerMoveCapture, true);
+    document.addEventListener("pointerup", onPointerUpCapture, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDownCapture, true);
+      document.removeEventListener("pointermove", onPointerMoveCapture, true);
+      document.removeEventListener("pointerup", onPointerUpCapture, true);
+    };
+  }, [phase, touchMode, performNativeToToolbarTransition, resetToIdle, armSuppress]);
+
+  // Click-suppression listener — lives independently of toolbar phase so the
+  // delayed compatibility click is still consumed after we enter idle via
+  // pendingDismiss (P1 #1). Also guards popover interactions (P1 #3).
+  useEffect(() => {
     const onClickCapture = (e: MouseEvent) => {
-      if (!suppressNextClickRef.current) return;
-      if (Date.now() > suppressDeadlineRef.current) {
+      const hasSuppress = suppressNextClickRef.current;
+      const hasPendingDismiss = pendingDismissRef.current;
+      if (!hasSuppress && !hasPendingDismiss) return;
+      if (hasSuppress && Date.now() > suppressDeadlineRef.current) {
         clearSuppress();
+        if (hasPendingDismiss) {
+          pendingDismissRef.current = false;
+          resetToIdle();
+        }
         return;
       }
       const target = e.target;
       // Dialogs are higher-priority UI (guest auth): let the click through
       if (isDialogTarget(target)) {
         clearSuppress();
+        pendingDismissRef.current = false;
         return;
       }
       // Popover interactions are never suppressed (P1 #3): a quick
       // Agree/Comment/Quote tap after the transition must work.
       if (popoverRef.current && target instanceof Node && popoverRef.current.contains(target)) {
         clearSuppress();
+        pendingDismissRef.current = false;
+        return;
+      }
+      // If suppression is not armed but a dismiss is pending, the click is
+      // the second-tap's compatibility click without a matching pointerId
+      // (e.g. mouse compat click) — still need to dismiss without swallowing
+      // if it matches the pending gesture. We only swallow when suppression
+      // is armed; otherwise just handle the pending dismiss.
+      if (!hasSuppress) {
+        if (hasPendingDismiss) {
+          pendingDismissRef.current = false;
+          resetToIdle();
+        }
         return;
       }
       // Suppress only the click matching the consumed pointer (P1 #3).
-      // MouseEvent has no pointerId; for touch, PointerEvent-driven clicks
-      // carry a matching pointerId when available.
       const clickPointerId = (e as unknown as { pointerId?: number }).pointerId;
       if (
         suppressPointerIdRef.current !== null &&
         clickPointerId !== undefined &&
         clickPointerId !== suppressPointerIdRef.current
       ) {
-        // Different pointer than the consumed gesture — let it through
         clearSuppress();
+        pendingDismissRef.current = false;
         return;
       }
       e.preventDefault();
@@ -565,28 +611,15 @@ export default function VotingBoard({
         (e as unknown as { stopImmediatePropagation: () => void }).stopImmediatePropagation!();
       }
       clearSuppress();
+      if (hasPendingDismiss) {
+        pendingDismissRef.current = false;
+        resetToIdle();
+      }
     };
 
-    document.addEventListener("pointerdown", onPointerDownCapture, true);
-    document.addEventListener("pointermove", onPointerMoveCapture, true);
-    document.addEventListener("pointerup", onPointerUpCapture, true);
     document.addEventListener("click", onClickCapture, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDownCapture, true);
-      document.removeEventListener("pointermove", onPointerMoveCapture, true);
-      document.removeEventListener("pointerup", onPointerUpCapture, true);
-      document.removeEventListener("click", onClickCapture, true);
-    };
-  }, [
-    phase,
-    touchMode,
-    performNativeToToolbarTransition,
-    resetToIdle,
-    onSelect,
-    onDeselect,
-    armSuppress,
-    clearSuppress,
-  ]);
+    return () => document.removeEventListener("click", onClickCapture, true);
+  }, [clearSuppress, resetToIdle]);
 
   const findChunksAtBeginningOfWords = useCallback(
     () => [{ start: startWordIndex > 0 ? startWordIndex : 0, end: endWordIndex }],

--- a/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
@@ -1,15 +1,20 @@
 'use client'
 
-import { Fragment, useState, useCallback, useLayoutEffect } from 'react'
+import { Fragment, useState, useCallback, useLayoutEffect, useEffect, useRef } from 'react'
+import { flushSync } from 'react-dom'
 import Highlighter from 'react-highlight-words'
 import { parser } from '@/lib/utils/parser'
+import { parseDomSelection } from '@/lib/utils/parserDom'
 import { cn } from '@/lib/utils'
 import { scrollLinkedPassageIntoView } from '@/lib/utils/discussionSplit'
 import SelectionPopover from './SelectionPopover'
-import type { VotingBoardProps, SelectedText } from '@/types/voting'
+import type { VotingBoardProps, SelectedText, SelectionPhase } from '@/types/voting'
 
 const LINKED_PASSAGE_CLASS =
   'bg-[#52b274]/20 text-foreground rounded-sm box-decoration-clone cursor-pointer px-0.5'
+
+const RETAINED_PASSAGE_CLASS =
+  'bg-[#52b274]/20 text-foreground rounded-sm box-decoration-clone px-0.5'
 
 /**
  * Stable highlight tag so Highlighter does not remount on parent re-renders.
@@ -42,13 +47,42 @@ function LinkedPassageMark({
   )
 }
 
+function RetainedPassageMark({
+  children,
+  className,
+}: {
+  children?: React.ReactNode
+  className?: string
+  highlightIndex?: number
+}) {
+  return (
+    <mark
+      data-testid="retained-selection-highlight"
+      className={cn(className, RETAINED_PASSAGE_CLASS)}
+    >
+      {children}
+    </mark>
+  )
+}
+
+function isCoarseTouchEnvironment(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia('(hover: none) and (pointer: coarse)').matches
+}
+
+function isDialogTarget(target: HTMLElement | null): boolean {
+  if (!target) return false
+  return !!target.closest('dialog[open], [role="dialog"], [role="alertdialog"]')
+}
+
 /**
- * VotingBoard component
- * Displays selectable text content with highlighting support for votes and comments
+ * VotingBoard — explicit selection state machine for issue #484.
+ * Touch-first devices use delayed workflow; desktop opens immediately.
  */
 export default function VotingBoard({
   topOffset,
   onSelect,
+  onDeselect,
   highlights = false,
   content,
   children,
@@ -57,10 +91,9 @@ export default function VotingBoard({
   focusedComment,
   onHighlightClick,
 }: VotingBoardProps) {
-  // votes prop is available for future use (e.g., highlighting vote ranges)
-  // Currently unused but kept for API compatibility
   void votes
-  const [open, setOpen] = useState(false)
+  const [phase, setPhase] = useState<SelectionPhase>('idle')
+  const phaseRef = useRef<SelectionPhase>('idle')
   const [selection, setSelection] = useState<SelectedText>({
     startIndex: 0,
     endIndex: 0,
@@ -68,73 +101,382 @@ export default function VotingBoard({
     points: 0,
   })
 
-  // Use prop if provided, otherwise default to no highlight
-  // Note: store has commentId as string, but we need startWordIndex/endWordIndex
-  // The parent component should provide focusedComment with the proper structure
-  const commentData = focusedComment || null
+  // Retained toolbar anchor: cached native rect for immediate positioning after flushSync
+  const cachedRectRef = useRef<DOMRect | null>(null)
+  const cachedSelectionRef = useRef<SelectedText | null>(null)
+  const contentRef = useRef<HTMLParagraphElement>(null)
+  const selectableRef = useRef<HTMLDivElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
+  // Click suppression — mounted listener with pointerId + 750ms deadline (refinement 5)
+  const suppressNextClickRef = useRef(false)
+  const suppressPointerIdRef = useRef<number | null>(null)
+  const suppressDeadlineRef = useRef<number>(0)
+  const suppressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const setPhaseSynced = useCallback((next: SelectionPhase) => {
+    phaseRef.current = next
+    setPhase(next)
+  }, [])
+
+  const clearSuppress = useCallback(() => {
+    suppressNextClickRef.current = false
+    suppressPointerIdRef.current = null
+    suppressDeadlineRef.current = 0
+    if (suppressTimerRef.current) {
+      clearTimeout(suppressTimerRef.current)
+      suppressTimerRef.current = null
+    }
+  }, [])
+
+  const armSuppress = useCallback(
+    (pointerId: number | null) => {
+      suppressNextClickRef.current = true
+      suppressPointerIdRef.current = pointerId
+      suppressDeadlineRef.current = Date.now() + 750
+      if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current)
+      suppressTimerRef.current = setTimeout(clearSuppress, 800)
+    },
+    [clearSuppress]
+  )
+
+  const clearNativeSelection = useCallback(() => {
+    try {
+      window.getSelection()?.removeAllRanges()
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  const resetToIdle = useCallback(() => {
+    cachedRectRef.current = null
+    cachedSelectionRef.current = null
+    setSelection({ startIndex: 0, endIndex: 0, text: '', points: 0 })
+    setPhaseSynced('idle')
+    onDeselect?.()
+  }, [onDeselect, setPhaseSynced])
+
+  const commentData = focusedComment || null
   const startWordIndex = commentData?.startWordIndex ?? 0
   const endWordIndex = commentData?.endWordIndex ?? 0
   const highlightedText = content.substring(startWordIndex, endWordIndex).replace(/(\r\n|\n|\r)/gm, '')
   const hasLinkedRange = endWordIndex > startWordIndex
+  const hasValidRetainedSelection =
+    phase === 'toolbar' &&
+    cachedSelectionRef.current != null &&
+    cachedSelectionRef.current.endIndex > cachedSelectionRef.current.startIndex &&
+    cachedSelectionRef.current.text.length > 0
 
   useLayoutEffect(() => {
     if (!hasLinkedRange) return
+    // Retained highlight takes precedence while toolbar open; don't auto-scroll linked
+    if (phase === 'toolbar' && hasValidRetainedSelection) return
     const frame = window.requestAnimationFrame(() => {
       scrollLinkedPassageIntoView()
     })
     return () => window.cancelAnimationFrame(frame)
-  }, [hasLinkedRange, commentData?.actionId, startWordIndex, endWordIndex])
+  }, [hasLinkedRange, commentData?.actionId, startWordIndex, endWordIndex, phase, hasValidRetainedSelection])
 
-  const handleSelect = useCallback(
-    (select: Selection) => {
-      const text = select.toString()
+  // Content change / input-mode change / unmount resets
+  useEffect(() => {
+    resetToIdle()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [content])
 
-      if (!text) {
-        setSelection({
-          startIndex: 0,
-          endIndex: 0,
-          text: '',
-          points: 0,
-        })
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const mql = window.matchMedia('(hover: none) and (pointer: coarse)')
+    const handler = () => {
+      // Input-mode change resets state and removes stale listeners/timers
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+      clearSuppress()
+      cachedRectRef.current = null
+      cachedSelectionRef.current = null
+      setSelection({ startIndex: 0, endIndex: 0, text: '', points: 0 })
+      setPhaseSynced('idle')
+      onDeselect?.()
+    }
+    // Modern browsers
+    if (typeof mql.addEventListener === 'function') {
+      mql.addEventListener('change', handler)
+      return () => mql.removeEventListener('change', handler)
+    }
+    // Safari fallback
+    const legacy = mql as unknown as { addListener: (cb: () => void) => void; removeListener: (cb: () => void) => void }
+    if (legacy.addListener) {
+      legacy.addListener(handler)
+      return () => legacy.removeListener(handler)
+    }
+    return undefined
+  }, [clearSuppress, onDeselect, setPhaseSynced])
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+      if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current)
+    }
+  }, [])
+
+  const tryParseSelection = useCallback(
+    (sel: Selection): { parsed: SelectedText; rect: DOMRect } | null => {
+      const text = sel.toString()
+      if (!text) return null
+      if (sel.rangeCount === 0) return null
+      const range = sel.getRangeAt(0)
+      if (range.collapsed) return null
+      const root = contentRef.current
+      if (!root) return null
+      if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) return null
+      let rect: DOMRect
+      try {
+        rect = range.getBoundingClientRect()
+      } catch {
+        return null
+      }
+      if (rect.width <= 0 || rect.height <= 0) return null
+
+      // DOM-aware parser for correct repeated-text handling; fallback to legacy parser for collapsed newline edge
+      const domParsed = parseDomSelection({
+        content,
+        selectedText: text,
+        range,
+        contentRoot: root,
+      })
+      let parsed: SelectedText | null = null
+      if (domParsed && typeof domParsed.startIndex === 'number' && typeof domParsed.endIndex === 'number') {
+        // Validate slice matches normalized selection
+        const slice = content.slice(domParsed.startIndex as number, domParsed.endIndex as number)
+        const normSlice = slice.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+        const normText = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+        if (normSlice === normText || slice === text) {
+          parsed = {
+            startIndex: domParsed.startIndex as number,
+            endIndex: domParsed.endIndex as number,
+            text: slice,
+            points: (domParsed.endIndex as number) - (domParsed.startIndex as number),
+          }
+        }
+      }
+      if (!parsed) {
+        // Don't use legacy indexOf as authoritative — reject if DOM parser couldn't defensibly match
+        // But keep legacy as desktop fallback when DOM enumeration failed due to ephemeral rect
+        const legacy = parser(content, text)
+        if (!legacy || typeof legacy.startIndex !== 'number' || legacy.startIndex === -1) return null
+        // Only accept legacy if it passes slice verification
+        const legacySlice = content.slice(legacy.startIndex as number, legacy.endIndex as number)
+        if (legacySlice !== text) return null
+        parsed = {
+          startIndex: legacy.startIndex as number,
+          endIndex: legacy.endIndex as number,
+          text,
+          points: legacy.endIndex as number - (legacy.startIndex as number),
+        }
+      }
+      if (parsed.startIndex < 0 || parsed.endIndex > content.length || parsed.endIndex <= parsed.startIndex) {
+        return null
+      }
+      return { parsed, rect }
+    },
+    [content]
+  )
+
+  const handleSelectionChange = useCallback(() => {
+    const sel = window.getSelection()
+    if (!sel || sel.rangeCount === 0) {
+      // Refinement 2: collapsed with no cached passage → idle; with cached passage → ignore
+      if (phaseRef.current === 'native' && cachedSelectionRef.current) return
+      if (phaseRef.current === 'native' && !cachedSelectionRef.current) {
+        resetToIdle()
+      }
+      return
+    }
+    const range = sel.getRangeAt(0)
+    if (range.collapsed) {
+      if (phaseRef.current === 'native' && cachedSelectionRef.current) return
+      if (phaseRef.current === 'native' && !cachedSelectionRef.current) resetToIdle()
+      return
+    }
+    const result = tryParseSelection(sel)
+    if (!result) {
+      if (phaseRef.current === 'native' && cachedSelectionRef.current) return
+      return
+    }
+    const { parsed, rect } = result
+    cachedSelectionRef.current = parsed
+    cachedRectRef.current = rect
+    setSelection(parsed)
+
+    const delayed = isCoarseTouchEnvironment()
+    if (delayed) {
+      // Touch-first: store but keep toolbar hidden (native menu active)
+      setPhaseSynced('native')
+      // Don't call onSelect yet; toolbar not shown
+    } else {
+      // Desktop: open immediately
+      setPhaseSynced('toolbar')
+      onSelect?.(parsed)
+    }
+  }, [tryParseSelection, resetToIdle, setPhaseSynced, onSelect])
+
+  // Selection ownership scoped to local selectable-content ref + polling fallback
+  useEffect(() => {
+    const target = selectableRef.current
+    if (!target) return
+
+    const onSelectStart = () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+      intervalRef.current = setInterval(() => {
+        // Polling fallback for mobile handle drag; also observe selectionchange in native
+        handleSelectionChange()
+      }, 100)
+    }
+    const onPointerUp = () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+      // Let selection settle then refresh
+      window.setTimeout(handleSelectionChange, 0)
+    }
+
+    target.addEventListener('selectstart', onSelectStart)
+    target.addEventListener('pointerup', onPointerUp)
+    // While in native, selectionchange from handle drag should refresh
+    const onDocSelectionChange = () => {
+      if (phaseRef.current === 'native') handleSelectionChange()
+      else if (phaseRef.current === 'idle' && !isCoarseTouchEnvironment()) handleSelectionChange()
+    }
+    document.addEventListener('selectionchange', onDocSelectionChange)
+
+    return () => {
+      target.removeEventListener('selectstart', onSelectStart)
+      target.removeEventListener('pointerup', onPointerUp)
+      document.removeEventListener('selectionchange', onDocSelectionChange)
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+    }
+  }, [handleSelectionChange])
+
+  // Outside-tap handlers: only while native or toolbar active
+  useEffect(() => {
+    if (phase !== 'native' && phase !== 'toolbar') return
+
+    const onPointerDownCapture = (e: PointerEvent) => {
+      const target = e.target as HTMLElement | null
+      // Protect guest auth dialog
+      if (isDialogTarget(target)) {
+        // Clear stale toolbar but don't swallow dialog interaction
+        if (phaseRef.current === 'toolbar' || phaseRef.current === 'native') {
+          cachedRectRef.current = null
+          cachedSelectionRef.current = null
+          setSelection({ startIndex: 0, endIndex: 0, text: '', points: 0 })
+          setPhaseSynced('idle')
+          onDeselect?.()
+        }
+        return
+      }
+      // Inside popover — preserve
+      if (popoverRef.current?.contains(target as Node)) return
+
+      // Inside selectable content while native — refresh, don't transition
+      if (phaseRef.current === 'native' && selectableRef.current?.contains(target as Node)) {
+        // Allow native handles to move; will be handled by selectionchange
         return
       }
 
-      const selectionVal = parser(content, text, select)
-
-      if (text.length > 0 && onSelect && selectionVal) {
-        setOpen(true)
-        const parsedSelection: SelectedText = {
-          startIndex:
-            typeof selectionVal.startIndex === 'number'
-              ? selectionVal.startIndex
-              : 0,
-          endIndex:
-            typeof selectionVal.endIndex === 'number'
-              ? selectionVal.endIndex
-              : 0,
-          text: typeof selectionVal.text === 'string' ? selectionVal.text : '',
-          points:
-            typeof selectionVal.points === 'number' ? selectionVal.points : 0,
+      if (phaseRef.current === 'native') {
+        // First outside tap: native → toolbar
+        // Refresh cached selection if still valid
+        const sel = window.getSelection()
+        if (sel && sel.rangeCount > 0) {
+          const refreshed = tryParseSelection(sel)
+          if (refreshed) {
+            cachedSelectionRef.current = refreshed.parsed
+            cachedRectRef.current = refreshed.rect
+            setSelection(refreshed.parsed)
+          }
         }
-        setSelection(parsedSelection)
-        onSelect(parsedSelection)
-      } else {
-        setSelection({
-          startIndex: 0,
-          endIndex: 0,
-          text: '',
-          points: 0,
+        if (!cachedSelectionRef.current || !cachedRectRef.current) {
+          resetToIdle()
+          return
+        }
+        const rectToCache = cachedRectRef.current
+        const parsedToCommit = cachedSelectionRef.current
+        // Refinement 1 ordering: cache rect → phaseRef → flushSync render → clear native → position
+        // Must run flushSync only from this pointerdown handler, not an effect
+        flushSync(() => {
+          phaseRef.current = 'toolbar'
+          setPhase('toolbar')
+          setSelection(parsedToCommit)
         })
+        // Now retained <mark> exists; clear native
+        clearNativeSelection()
+        // Prime popover positioning from cached rect; recompute from retained mark on next frames handled by popover
+        cachedRectRef.current = rectToCache
+        onSelect?.(parsedToCommit)
+        armSuppress(e.pointerId ?? null)
+        e.preventDefault()
+        e.stopPropagation()
+        // Also suppress the compatibility click
+        return
       }
-    },
-    [content, onSelect],
-  )
+
+      if (phaseRef.current === 'toolbar') {
+        // Second outside tap: toolbar → idle
+        // If tap inside content but not toolbar, dismiss
+        armSuppress(e.pointerId ?? null)
+        e.preventDefault()
+        e.stopPropagation()
+        // Clear after suppress armed so click suppression can fire
+        window.setTimeout(() => resetToIdle(), 0)
+      }
+    }
+
+    const onClickCapture = (e: MouseEvent) => {
+      if (!suppressNextClickRef.current) return
+      if (Date.now() > suppressDeadlineRef.current) {
+        clearSuppress()
+        return
+      }
+      const target = e.target as HTMLElement | null
+      if (isDialogTarget(target)) {
+        clearSuppress()
+        return
+      }
+      // Only suppress if this click corresponds to the suppressed pointer
+      // For mouse compatibility clicks pointerId is not available; suppress any outside click within deadline
+      e.preventDefault()
+      e.stopPropagation()
+      if (typeof (e as unknown as { stopImmediatePropagation?: () => void }).stopImmediatePropagation === 'function') {
+        ;(e as unknown as { stopImmediatePropagation: () => void }).stopImmediatePropagation!()
+      }
+      clearSuppress()
+    }
+
+    document.addEventListener('pointerdown', onPointerDownCapture, true)
+    document.addEventListener('click', onClickCapture, true)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDownCapture, true)
+      document.removeEventListener('click', onClickCapture, true)
+    }
+  }, [phase, tryParseSelection, clearNativeSelection, resetToIdle, setPhaseSynced, onSelect, onDeselect, armSuppress, clearSuppress])
 
   const findChunksAtBeginningOfWords = useCallback(
     () => [{ start: startWordIndex > 0 ? startWordIndex : 0, end: endWordIndex }],
-    [startWordIndex, endWordIndex],
+    [startWordIndex, endWordIndex]
   )
+
+  const findRetainedChunks = useCallback(() => {
+    const s = cachedSelectionRef.current
+    if (!s) return []
+    return [{ start: s.startIndex, end: s.endIndex }]
+  }, [])
 
   const disableContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
@@ -154,15 +496,63 @@ export default function VotingBoard({
     [onHighlightClick],
   )
 
+  const resolveAnchorRect = useCallback((): DOMRect | null => {
+    // Mobile toolbar: prefer retained mark rect, fall back to cached native rect during transition frame
+    if (phaseRef.current === 'toolbar') {
+      const mark = document.querySelector('[data-testid="retained-selection-highlight"]') as HTMLElement | null
+      if (mark) {
+        const r = mark.getBoundingClientRect()
+        if (r.width > 0 && r.height > 0) return r
+      }
+      if (cachedRectRef.current) return cachedRectRef.current
+      return null
+    }
+    // Desktop toolbar (immediate) or native measurement: live range
+    const sel = window.getSelection()
+    if (sel && sel.rangeCount > 0) {
+      try {
+        const r = sel.getRangeAt(0).getBoundingClientRect()
+        if (r.width > 0 && r.height > 0) return r
+      } catch {
+        // ignore
+      }
+    }
+    if (cachedRectRef.current) return cachedRectRef.current
+    return null
+  }, [])
+
+  const showPopover = phase === 'toolbar' && hasValidRetainedSelection
+
+  // Desktop immediate mode also uses toolbar phase; hasValidRetainedSelection may be false for desktop
+  // because isCoarseTouchEnvironment() returns false → we set phase toolbar but hasValidRetainedSelection needs cache.
+  // Unify: desktop should show popover whenever phase toolbar and selection has text.
+  const isDesktopToolbar = phase === 'toolbar' && !isCoarseTouchEnvironment() && selection.text.length > 0
+  const effectiveShowPopover = showPopover || isDesktopToolbar
+
   const renderHighlights = () => {
-    if (highlights) {
-      // If there's a focused comment, highlight it
-      if (hasLinkedRange) {
+    if (effectiveShowPopover || (phase === 'toolbar' && hasValidRetainedSelection)) {
+      // Refinement 4: explicit priority branch — retained takes precedence, no mutation of hasLinkedRange
+      if (phase === 'toolbar' && hasValidRetainedSelection) {
         return (
           <Highlighter
-            style={{
-              whiteSpace: 'pre-line',
-            }}
+            style={{ whiteSpace: 'pre-line' }}
+            highlightClassName={RETAINED_PASSAGE_CLASS}
+            highlightTag={RetainedPassageMark}
+            textToHighlight={content}
+            searchWords={[]}
+            findChunks={findRetainedChunks}
+            autoEscape
+            onContextMenu={disableContextMenu}
+          />
+        )
+      }
+    }
+
+    if (highlights) {
+      if (hasLinkedRange && !(phase === 'toolbar' && hasValidRetainedSelection)) {
+        return (
+          <Highlighter
+            style={{ whiteSpace: 'pre-line' }}
             highlightClassName={LINKED_PASSAGE_CLASS}
             highlightTag={LinkedPassageMark}
             textToHighlight={content}
@@ -174,16 +564,46 @@ export default function VotingBoard({
         )
       }
 
+      // When not linked but highlights on, we still want retained to show if in toolbar; handled above
+      if (phase === 'toolbar' && hasValidRetainedSelection) {
+        return (
+          <Highlighter
+            style={{ whiteSpace: 'pre-line' }}
+            highlightClassName={RETAINED_PASSAGE_CLASS}
+            highlightTag={RetainedPassageMark}
+            textToHighlight={content}
+            searchWords={[]}
+            findChunks={findRetainedChunks}
+            autoEscape
+            onContextMenu={disableContextMenu}
+          />
+        )
+      }
+
       return (
         <Highlighter
-          style={{
-            whiteSpace: 'pre-line',
-          }}
+          style={{ whiteSpace: 'pre-line' }}
           highlightClassName={LINKED_PASSAGE_CLASS}
           searchWords={[highlightedText]}
           textToHighlight={content}
           autoEscape
           caseSensitive
+          onContextMenu={disableContextMenu}
+        />
+      )
+    }
+
+    // Non-highlight mode but toolbar active: still show retained mark
+    if (phase === 'toolbar' && hasValidRetainedSelection) {
+      return (
+        <Highlighter
+          style={{ whiteSpace: 'pre-line' }}
+          highlightClassName={RETAINED_PASSAGE_CLASS}
+          highlightTag={RetainedPassageMark}
+          textToHighlight={content}
+          searchWords={[]}
+          findChunks={findRetainedChunks}
+          autoEscape
           onContextMenu={disableContextMenu}
         />
       )
@@ -201,8 +621,9 @@ export default function VotingBoard({
 
   return (
     <div className="relative h-full flex flex-col" style={style}>
-      <div data-selectable className="flex-1">
+      <div ref={selectableRef} data-selectable className="flex-1">
         <p
+          ref={contentRef}
           className="voting_board-content m-0 p-0 h-full"
           onContextMenu={disableContextMenu}
           onClick={handlePassageClick}
@@ -211,14 +632,13 @@ export default function VotingBoard({
         </p>
       </div>
       <SelectionPopover
-        showPopover={open}
+        showPopover={effectiveShowPopover}
         topOffset={topOffset}
-        onSelect={handleSelect}
-        onDeselect={() => setOpen(false)}
+        resolveAnchorRect={resolveAnchorRect}
+        popoverRef={popoverRef}
       >
         {children && children(selection)}
       </SelectionPopover>
     </div>
   )
 }
-

--- a/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
@@ -17,10 +17,6 @@ const RETAINED_PASSAGE_CLASS =
 
 const TOUCH_MEDIA_QUERY = "(hover: none) and (pointer: coarse)";
 
-/**
- * Stable highlight tag so Highlighter does not remount on parent re-renders.
- * Clicks bubble to the passage container, which owns the reverse-nav handler.
- */
 function LinkedPassageMark({
   children,
   className,
@@ -48,10 +44,6 @@ function LinkedPassageMark({
   );
 }
 
-/**
- * Retained passage mark (issue #484): plain semantic <mark>, no button
- * semantics — the text stays in the accessibility tree.
- */
 function RetainedPassageMark({
   children,
   className,
@@ -80,12 +72,6 @@ function isDialogTarget(target: EventTarget | null): boolean {
   return !!target.closest('dialog[open], [role="dialog"], [role="alertdialog"]');
 }
 
-/**
- * VotingBoard — explicit selection state machine for issue #484.
- * Touch-first devices use the delayed (two-tap) workflow; desktop opens
- * the toolbar immediately from the live selection and never renders the
- * retained mark nor installs outside-tap suppression.
- */
 export default function VotingBoard({
   topOffset,
   onSelect,
@@ -108,16 +94,9 @@ export default function VotingBoard({
     points: 0,
   });
 
-  /**
-   * Touch mode captured at the moment a selection becomes valid.
-   * Gates ALL retained-mobile behavior so desktop never renders the retained
-   * mark, never installs outside-tap suppression, and keeps its legacy
-   * selection-driven dismissal (P1 #1).
-   */
   const [touchMode, setTouchMode] = useState(false);
   const touchModeRef = useRef(false);
 
-  // Retained toolbar anchor: cached native rect for immediate positioning after flushSync
   const cachedRectRef = useRef<DOMRect | null>(null);
   const cachedSelectionRef = useRef<SelectedText | null>(null);
   const contentRef = useRef<HTMLParagraphElement>(null);
@@ -125,18 +104,14 @@ export default function VotingBoard({
   const popoverRef = useRef<HTMLDivElement>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Click suppression — mounted listener with pointerId + deadline (refinement 5)
   const suppressNextClickRef = useRef(false);
   const suppressPointerIdRef = useRef<number | null>(null);
   const suppressDeadlineRef = useRef<number>(0);
   const suppressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Tap-vs-drag discrimination for taps inside selectable content (P1 #2)
   const pendingTapRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
   const tapDraggedRef = useRef(false);
 
-  // Pending dismiss for second tap (P1 #1): keep click listener alive until
-  // the delayed compatibility click is consumed
   const pendingDismissRef = useRef(false);
 
   const setPhaseSynced = useCallback((next: SelectionPhase) => {
@@ -182,8 +157,6 @@ export default function VotingBoard({
       if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current);
       suppressTimerRef.current = setTimeout(() => {
         clearSuppress();
-        // Fallback: if the delayed click never arrived (e.g. compat click
-        // was swallowed), still dismiss the pending toolbar
         if (pendingDismissRef.current) {
           pendingDismissRef.current = false;
           resetToIdle();
@@ -201,10 +174,6 @@ export default function VotingBoard({
     .replace(/(\r\n|\n|\r)/gm, "");
   const hasLinkedRange = endWordIndex > startWordIndex;
 
-  /**
-   * Retained rendering is gated on the captured touch-mode flag (P1 #1):
-   * desktop reaches 'toolbar' phase too, but never renders the mark.
-   */
   const hasValidRetainedSelection =
     phase === "toolbar" &&
     touchMode &&
@@ -214,7 +183,6 @@ export default function VotingBoard({
 
   useLayoutEffect(() => {
     if (!hasLinkedRange) return;
-    // Retained highlight takes precedence while toolbar open; don't auto-scroll linked
     if (phase === "toolbar" && hasValidRetainedSelection) return;
     const frame = window.requestAnimationFrame(() => {
       scrollLinkedPassageIntoView();
@@ -229,7 +197,6 @@ export default function VotingBoard({
     hasValidRetainedSelection,
   ]);
 
-  // Content change resets state (skip initial mount)
   const prevContentRef = useRef(content);
   useEffect(() => {
     if (prevContentRef.current === content) return;
@@ -242,7 +209,6 @@ export default function VotingBoard({
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
     const mql = window.matchMedia(TOUCH_MEDIA_QUERY);
     const handler = () => {
-      // Input-mode change resets state and removes stale listeners/timers
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;
@@ -256,12 +222,10 @@ export default function VotingBoard({
       setPhaseSynced("idle");
       onDeselect?.();
     };
-    // Modern browsers
     if (typeof mql.addEventListener === "function") {
       mql.addEventListener("change", handler);
       return () => mql.removeEventListener("change", handler);
     }
-    // Safari fallback
     const legacy = mql as unknown as {
       addListener: (cb: () => void) => void;
       removeListener: (cb: () => void) => void;
@@ -298,8 +262,6 @@ export default function VotingBoard({
       }
       if (rect.width <= 0 || rect.height <= 0) return null;
 
-      // DOM-aware parser only (P2 #2): no legacy indexOf fallback —
-      // rejecting the selection is safer than binding the wrong passage.
       const domParsed = parseDomSelection({
         content,
         selectedText: text,
@@ -318,7 +280,6 @@ export default function VotingBoard({
       if (startIndex < 0 || endIndex > content.length || endIndex <= startIndex) {
         return null;
       }
-      // Final verification: normalized slice must match normalized selection
       const slice = content.slice(startIndex, endIndex);
       const normSlice = slice.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
       const normText = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
@@ -340,14 +301,10 @@ export default function VotingBoard({
     const sel = window.getSelection();
     const collapsedOrEmpty = !sel || sel.rangeCount === 0 || sel.getRangeAt(0).collapsed;
     if (collapsedOrEmpty) {
-      // Refinement 2: collapsed with no cached passage → idle; with cached passage → ignore
       if (phaseRef.current === "native") {
         if (!cachedSelectionRef.current) resetToIdle();
         return;
       }
-      // Desktop toolbar: selection cleared (click elsewhere) → dismiss.
-      // Retained (touch) toolbar clears the native selection deliberately
-      // during the transition, so it must NOT reset here.
       if (phaseRef.current === "toolbar" && !touchModeRef.current) {
         resetToIdle();
       }
@@ -363,22 +320,17 @@ export default function VotingBoard({
     cachedRectRef.current = rect;
     setSelection(parsed);
 
-    // Capture input mode at the moment the selection becomes valid (P1 #1)
     const delayed = isCoarseTouchEnvironment();
     touchModeRef.current = delayed;
     setTouchMode(delayed);
     if (delayed) {
-      // Touch-first: store but keep toolbar hidden (native menu active)
       setPhaseSynced("native");
-      // Don't call onSelect yet; toolbar not shown
     } else {
-      // Desktop: open immediately, live selection drives rendering/positioning
       setPhaseSynced("toolbar");
       onSelect?.(parsed);
     }
   }, [tryParseSelection, resetToIdle, setPhaseSynced, onSelect]);
 
-  // Selection ownership scoped to local selectable-content ref + polling fallback
   useEffect(() => {
     const target = selectableRef.current;
     if (!target) return;
@@ -386,7 +338,6 @@ export default function VotingBoard({
     const onSelectStart = () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
       intervalRef.current = setInterval(() => {
-        // Polling fallback for mobile handle drag; also observe selectionchange in native
         handleSelectionChange();
       }, 100);
     };
@@ -395,16 +346,11 @@ export default function VotingBoard({
         clearInterval(intervalRef.current);
         intervalRef.current = null;
       }
-      // Let selection settle then refresh
       window.setTimeout(handleSelectionChange, 0);
     };
 
     target.addEventListener("selectstart", onSelectStart);
     target.addEventListener("pointerup", onPointerUp);
-    // While in native, selectionchange from handle drag should refresh;
-    // desktop selectionchange drives both open (idle→toolbar) and dismissal
-    // (toolbar→idle when the selection collapses). Retained toolbar ignores
-    // it because the native selection was deliberately cleared.
     const onDocSelectionChange = () => {
       if (phaseRef.current === "native") handleSelectionChange();
       else if (phaseRef.current === "idle" && !isCoarseTouchEnvironment()) handleSelectionChange();
@@ -423,14 +369,8 @@ export default function VotingBoard({
     };
   }, [handleSelectionChange]);
 
-  /**
-   * Perform the native → toolbar transition (first tap).
-   * Ordering (refinement 1): cache rect → phase → flushSync mark → clear
-   * native → position. flushSync runs only from this pointer-event path.
-   */
   const performNativeToToolbarTransition = useCallback(
     (pointerId: number | null) => {
-      // Refresh cached selection if still valid
       const sel = window.getSelection();
       if (sel && sel.rangeCount > 0) {
         const refreshed = tryParseSelection(sel);
@@ -451,9 +391,7 @@ export default function VotingBoard({
         setPhase("toolbar");
         setSelection(parsedToCommit);
       });
-      // Now retained <mark> exists; clear native
       clearNativeSelection();
-      // Prime popover positioning from cached rect; popover recomputes from mark
       cachedRectRef.current = rectToCache;
       onSelect?.(parsedToCommit);
       armSuppress(pointerId);
@@ -461,25 +399,18 @@ export default function VotingBoard({
     [tryParseSelection, resetToIdle, clearNativeSelection, onSelect, armSuppress]
   );
 
-  // Outside-tap handlers: only for the touch workflow (native phase, or the
-  // retained toolbar). Desktop toolbar installs NO document-level capture
-  // handlers — dismissal is selection-driven, so normal desktop clicks are
-  // never consumed (P1 #1).
   useEffect(() => {
     const active = phase === "native" || (phase === "toolbar" && touchMode);
     if (!active) return;
 
     const onPointerDownCapture = (e: PointerEvent) => {
       const target = e.target;
-      // Protect guest auth dialog
       if (isDialogTarget(target)) {
-        // Clear stale toolbar but don't swallow dialog interaction
         if (phaseRef.current === "toolbar" || phaseRef.current === "native") {
           resetToIdle();
         }
         return;
       }
-      // Inside popover — preserve
       if (popoverRef.current && target instanceof Node && popoverRef.current.contains(target)) {
         return;
       }
@@ -488,14 +419,10 @@ export default function VotingBoard({
 
       if (phaseRef.current === "native") {
         if (insideSelectable) {
-          // Tap-vs-drag (P1 #2): a stationary tap inside the quote should
-          // transition; dragging the selection handles should not. Track the
-          // gesture and decide on pointerup.
           pendingTapRef.current = { pointerId: e.pointerId, x: e.clientX, y: e.clientY };
           tapDraggedRef.current = false;
           return;
         }
-        // First outside tap: native → toolbar
         performNativeToToolbarTransition(e.pointerId ?? null);
         e.preventDefault();
         e.stopPropagation();
@@ -503,9 +430,6 @@ export default function VotingBoard({
       }
 
       if (phaseRef.current === "toolbar") {
-        // Second outside tap: toolbar → idle. Keep the click-capture
-        // listener alive until the delayed compatibility click is consumed
-        // (P1 #1), so the click does not activate UI underneath.
         pendingDismissRef.current = true;
         armSuppress(e.pointerId ?? null);
         e.preventDefault();
@@ -516,7 +440,6 @@ export default function VotingBoard({
     const onPointerMoveCapture = (e: PointerEvent) => {
       if (!pendingTapRef.current) return;
       const tap = pendingTapRef.current;
-      // Mark as drag once the pointer moves beyond a small slop threshold
       if (
         e.pointerId === tap.pointerId &&
         (Math.abs(e.clientX - tap.x) > 8 || Math.abs(e.clientY - tap.y) > 8)
@@ -531,7 +454,6 @@ export default function VotingBoard({
       pendingTapRef.current = null;
       if (e.pointerId !== tap.pointerId) return;
       if (tapDraggedRef.current) return;
-      // Stationary tap inside the quote: perform the first transition
       if (phaseRef.current === "native" && cachedSelectionRef.current) {
         performNativeToToolbarTransition(e.pointerId ?? null);
         e.preventDefault();
@@ -549,9 +471,6 @@ export default function VotingBoard({
     };
   }, [phase, touchMode, performNativeToToolbarTransition, resetToIdle, armSuppress]);
 
-  // Click-suppression listener — lives independently of toolbar phase so the
-  // delayed compatibility click is still consumed after we enter idle via
-  // pendingDismiss (P1 #1). Also guards popover interactions (P1 #3).
   useEffect(() => {
     const onClickCapture = (e: MouseEvent) => {
       const hasSuppress = suppressNextClickRef.current;
@@ -566,24 +485,16 @@ export default function VotingBoard({
         return;
       }
       const target = e.target;
-      // Dialogs are higher-priority UI (guest auth): let the click through
       if (isDialogTarget(target)) {
         clearSuppress();
         pendingDismissRef.current = false;
         return;
       }
-      // Popover interactions are never suppressed (P1 #3): a quick
-      // Agree/Comment/Quote tap after the transition must work.
       if (popoverRef.current && target instanceof Node && popoverRef.current.contains(target)) {
         clearSuppress();
         pendingDismissRef.current = false;
         return;
       }
-      // If suppression is not armed but a dismiss is pending, the click is
-      // the second-tap's compatibility click without a matching pointerId
-      // (e.g. mouse compat click) — still need to dismiss without swallowing
-      // if it matches the pending gesture. We only swallow when suppression
-      // is armed; otherwise just handle the pending dismiss.
       if (!hasSuppress) {
         if (hasPendingDismiss) {
           pendingDismissRef.current = false;
@@ -591,7 +502,6 @@ export default function VotingBoard({
         }
         return;
       }
-      // Suppress only the click matching the consumed pointer (P1 #3).
       const clickPointerId = (e as unknown as { pointerId?: number }).pointerId;
       if (
         suppressPointerIdRef.current !== null &&
@@ -651,8 +561,6 @@ export default function VotingBoard({
   );
 
   const resolveAnchorRect = useCallback((): DOMRect | null => {
-    // Retained (touch) toolbar: prefer retained mark rect, fall back to cached
-    // native rect during the transition frame.
     if (phaseRef.current === "toolbar" && touchModeRef.current) {
       const mark = document.querySelector(
         '[data-testid="retained-selection-highlight"]'
@@ -664,7 +572,6 @@ export default function VotingBoard({
       if (cachedRectRef.current) return cachedRectRef.current;
       return null;
     }
-    // Desktop toolbar (immediate) or native measurement: live range
     const sel = window.getSelection();
     if (sel && sel.rangeCount > 0) {
       try {
@@ -678,7 +585,6 @@ export default function VotingBoard({
     return null;
   }, []);
 
-  // Popover visibility: retained (touch) or desktop-immediate toolbar
   const showRetainedPopover = phase === "toolbar" && hasValidRetainedSelection;
   const showDesktopPopover = phase === "toolbar" && !touchMode && selection.text.length > 0;
   const effectiveShowPopover = showRetainedPopover || showDesktopPopover;
@@ -697,9 +603,6 @@ export default function VotingBoard({
   );
 
   const renderHighlights = () => {
-    // Explicit priority branch (refinement 4): retained takes precedence,
-    // hasLinkedRange is not mutated so the linked highlight returns after
-    // dismissal.
     if (phase === "toolbar" && hasValidRetainedSelection) {
       return renderRetained();
     }

--- a/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
@@ -182,9 +182,8 @@ export default function VotingBoard({
   const hasValidRetainedSelection =
     phase === "toolbar" &&
     touchMode &&
-    cachedSelectionRef.current != null &&
-    cachedSelectionRef.current.endIndex > cachedSelectionRef.current.startIndex &&
-    cachedSelectionRef.current.text.length > 0;
+    selection.endIndex > selection.startIndex &&
+    selection.text.length > 0;
 
   useLayoutEffect(() => {
     if (!hasLinkedRange) return;
@@ -206,6 +205,7 @@ export default function VotingBoard({
   useEffect(() => {
     if (prevContentRef.current === content) return;
     prevContentRef.current = content;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- replacing content invalidates the active selection state
     resetToIdle();
   }, [content, resetToIdle]);
 

--- a/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
+++ b/quotevote-frontend/src/components/VotingComponents/VotingBoard.tsx
@@ -1,20 +1,21 @@
-'use client'
+"use client";
 
-import { Fragment, useState, useCallback, useLayoutEffect, useEffect, useRef } from 'react'
-import { flushSync } from 'react-dom'
-import Highlighter from 'react-highlight-words'
-import { parser } from '@/lib/utils/parser'
-import { parseDomSelection } from '@/lib/utils/parserDom'
-import { cn } from '@/lib/utils'
-import { scrollLinkedPassageIntoView } from '@/lib/utils/discussionSplit'
-import SelectionPopover from './SelectionPopover'
-import type { VotingBoardProps, SelectedText, SelectionPhase } from '@/types/voting'
+import { Fragment, useState, useCallback, useLayoutEffect, useEffect, useRef } from "react";
+import { flushSync } from "react-dom";
+import Highlighter from "react-highlight-words";
+import { parseDomSelection } from "@/lib/utils/parserDom";
+import { cn } from "@/lib/utils";
+import { scrollLinkedPassageIntoView } from "@/lib/utils/discussionSplit";
+import SelectionPopover from "./SelectionPopover";
+import type { VotingBoardProps, SelectedText, SelectionPhase } from "@/types/voting";
 
 const LINKED_PASSAGE_CLASS =
-  'bg-[#52b274]/20 text-foreground rounded-sm box-decoration-clone cursor-pointer px-0.5'
+  "bg-[#52b274]/20 text-foreground rounded-sm box-decoration-clone cursor-pointer px-0.5";
 
 const RETAINED_PASSAGE_CLASS =
-  'bg-[#52b274]/20 text-foreground rounded-sm box-decoration-clone px-0.5'
+  "bg-[#52b274]/20 text-foreground rounded-sm box-decoration-clone px-0.5";
+
+const TOUCH_MEDIA_QUERY = "(hover: none) and (pointer: coarse)";
 
 /**
  * Stable highlight tag so Highlighter does not remount on parent re-renders.
@@ -24,9 +25,9 @@ function LinkedPassageMark({
   children,
   className,
 }: {
-  children?: React.ReactNode
-  className?: string
-  highlightIndex?: number
+  children?: React.ReactNode;
+  className?: string;
+  highlightIndex?: number;
 }) {
   return (
     <mark
@@ -36,24 +37,28 @@ function LinkedPassageMark({
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          e.currentTarget.click()
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          e.currentTarget.click();
         }
       }}
     >
       {children}
     </mark>
-  )
+  );
 }
 
+/**
+ * Retained passage mark (issue #484): plain semantic <mark>, no button
+ * semantics — the text stays in the accessibility tree.
+ */
 function RetainedPassageMark({
   children,
   className,
 }: {
-  children?: React.ReactNode
-  className?: string
-  highlightIndex?: number
+  children?: React.ReactNode;
+  className?: string;
+  highlightIndex?: number;
 }) {
   return (
     <mark
@@ -62,22 +67,24 @@ function RetainedPassageMark({
     >
       {children}
     </mark>
-  )
+  );
 }
 
 function isCoarseTouchEnvironment(): boolean {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
-  return window.matchMedia('(hover: none) and (pointer: coarse)').matches
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia(TOUCH_MEDIA_QUERY).matches;
 }
 
-function isDialogTarget(target: HTMLElement | null): boolean {
-  if (!target) return false
-  return !!target.closest('dialog[open], [role="dialog"], [role="alertdialog"]')
+function isDialogTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return !!target.closest('dialog[open], [role="dialog"], [role="alertdialog"]');
 }
 
 /**
  * VotingBoard — explicit selection state machine for issue #484.
- * Touch-first devices use delayed workflow; desktop opens immediately.
+ * Touch-first devices use the delayed (two-tap) workflow; desktop opens
+ * the toolbar immediately from the live selection and never renders the
+ * retained mark nor installs outside-tap suppression.
  */
 export default function VotingBoard({
   topOffset,
@@ -91,468 +98,584 @@ export default function VotingBoard({
   focusedComment,
   onHighlightClick,
 }: VotingBoardProps) {
-  void votes
-  const [phase, setPhase] = useState<SelectionPhase>('idle')
-  const phaseRef = useRef<SelectionPhase>('idle')
+  void votes;
+  const [phase, setPhase] = useState<SelectionPhase>("idle");
+  const phaseRef = useRef<SelectionPhase>("idle");
   const [selection, setSelection] = useState<SelectedText>({
     startIndex: 0,
     endIndex: 0,
-    text: '',
+    text: "",
     points: 0,
-  })
+  });
+
+  /**
+   * Touch mode captured at the moment a selection becomes valid.
+   * Gates ALL retained-mobile behavior so desktop never renders the retained
+   * mark, never installs outside-tap suppression, and keeps its legacy
+   * selection-driven dismissal (P1 #1).
+   */
+  const [touchMode, setTouchMode] = useState(false);
+  const touchModeRef = useRef(false);
 
   // Retained toolbar anchor: cached native rect for immediate positioning after flushSync
-  const cachedRectRef = useRef<DOMRect | null>(null)
-  const cachedSelectionRef = useRef<SelectedText | null>(null)
-  const contentRef = useRef<HTMLParagraphElement>(null)
-  const selectableRef = useRef<HTMLDivElement>(null)
-  const popoverRef = useRef<HTMLDivElement>(null)
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const cachedRectRef = useRef<DOMRect | null>(null);
+  const cachedSelectionRef = useRef<SelectedText | null>(null);
+  const contentRef = useRef<HTMLParagraphElement>(null);
+  const selectableRef = useRef<HTMLDivElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Click suppression — mounted listener with pointerId + 750ms deadline (refinement 5)
-  const suppressNextClickRef = useRef(false)
-  const suppressPointerIdRef = useRef<number | null>(null)
-  const suppressDeadlineRef = useRef<number>(0)
-  const suppressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Click suppression — mounted listener with pointerId + deadline (refinement 5)
+  const suppressNextClickRef = useRef(false);
+  const suppressPointerIdRef = useRef<number | null>(null);
+  const suppressDeadlineRef = useRef<number>(0);
+  const suppressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Tap-vs-drag discrimination for taps inside selectable content (P1 #2)
+  const pendingTapRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
+  const tapDraggedRef = useRef(false);
 
   const setPhaseSynced = useCallback((next: SelectionPhase) => {
-    phaseRef.current = next
-    setPhase(next)
-  }, [])
+    phaseRef.current = next;
+    setPhase(next);
+  }, []);
 
   const clearSuppress = useCallback(() => {
-    suppressNextClickRef.current = false
-    suppressPointerIdRef.current = null
-    suppressDeadlineRef.current = 0
+    suppressNextClickRef.current = false;
+    suppressPointerIdRef.current = null;
+    suppressDeadlineRef.current = 0;
     if (suppressTimerRef.current) {
-      clearTimeout(suppressTimerRef.current)
-      suppressTimerRef.current = null
+      clearTimeout(suppressTimerRef.current);
+      suppressTimerRef.current = null;
     }
-  }, [])
+  }, []);
 
   const armSuppress = useCallback(
     (pointerId: number | null) => {
-      suppressNextClickRef.current = true
-      suppressPointerIdRef.current = pointerId
-      suppressDeadlineRef.current = Date.now() + 750
-      if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current)
-      suppressTimerRef.current = setTimeout(clearSuppress, 800)
+      suppressNextClickRef.current = true;
+      suppressPointerIdRef.current = pointerId;
+      suppressDeadlineRef.current = Date.now() + 750;
+      if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current);
+      suppressTimerRef.current = setTimeout(clearSuppress, 800);
     },
     [clearSuppress]
-  )
+  );
 
   const clearNativeSelection = useCallback(() => {
     try {
-      window.getSelection()?.removeAllRanges()
+      window.getSelection()?.removeAllRanges();
     } catch {
       // ignore
     }
-  }, [])
+  }, []);
 
   const resetToIdle = useCallback(() => {
-    cachedRectRef.current = null
-    cachedSelectionRef.current = null
-    setSelection({ startIndex: 0, endIndex: 0, text: '', points: 0 })
-    setPhaseSynced('idle')
-    onDeselect?.()
-  }, [onDeselect, setPhaseSynced])
+    cachedRectRef.current = null;
+    cachedSelectionRef.current = null;
+    touchModeRef.current = false;
+    setTouchMode(false);
+    pendingTapRef.current = null;
+    setSelection({ startIndex: 0, endIndex: 0, text: "", points: 0 });
+    setPhaseSynced("idle");
+    onDeselect?.();
+  }, [onDeselect, setPhaseSynced]);
 
-  const commentData = focusedComment || null
-  const startWordIndex = commentData?.startWordIndex ?? 0
-  const endWordIndex = commentData?.endWordIndex ?? 0
-  const highlightedText = content.substring(startWordIndex, endWordIndex).replace(/(\r\n|\n|\r)/gm, '')
-  const hasLinkedRange = endWordIndex > startWordIndex
+  const commentData = focusedComment || null;
+  const startWordIndex = commentData?.startWordIndex ?? 0;
+  const endWordIndex = commentData?.endWordIndex ?? 0;
+  const highlightedText = content
+    .substring(startWordIndex, endWordIndex)
+    .replace(/(\r\n|\n|\r)/gm, "");
+  const hasLinkedRange = endWordIndex > startWordIndex;
+
+  /**
+   * Retained rendering is gated on the captured touch-mode flag (P1 #1):
+   * desktop reaches 'toolbar' phase too, but never renders the mark.
+   */
   const hasValidRetainedSelection =
-    phase === 'toolbar' &&
+    phase === "toolbar" &&
+    touchMode &&
     cachedSelectionRef.current != null &&
     cachedSelectionRef.current.endIndex > cachedSelectionRef.current.startIndex &&
-    cachedSelectionRef.current.text.length > 0
+    cachedSelectionRef.current.text.length > 0;
 
   useLayoutEffect(() => {
-    if (!hasLinkedRange) return
+    if (!hasLinkedRange) return;
     // Retained highlight takes precedence while toolbar open; don't auto-scroll linked
-    if (phase === 'toolbar' && hasValidRetainedSelection) return
+    if (phase === "toolbar" && hasValidRetainedSelection) return;
     const frame = window.requestAnimationFrame(() => {
-      scrollLinkedPassageIntoView()
-    })
-    return () => window.cancelAnimationFrame(frame)
-  }, [hasLinkedRange, commentData?.actionId, startWordIndex, endWordIndex, phase, hasValidRetainedSelection])
+      scrollLinkedPassageIntoView();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [
+    hasLinkedRange,
+    commentData?.actionId,
+    startWordIndex,
+    endWordIndex,
+    phase,
+    hasValidRetainedSelection,
+  ]);
 
-  // Content change / input-mode change / unmount resets
+  // Content change resets state (skip initial mount)
+  const prevContentRef = useRef(content);
   useEffect(() => {
-    resetToIdle()
+    if (prevContentRef.current === content) return;
+    prevContentRef.current = content;
+    resetToIdle();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [content])
+  }, [content]);
 
   useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
-    const mql = window.matchMedia('(hover: none) and (pointer: coarse)')
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mql = window.matchMedia(TOUCH_MEDIA_QUERY);
     const handler = () => {
       // Input-mode change resets state and removes stale listeners/timers
       if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-        intervalRef.current = null
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
-      clearSuppress()
-      cachedRectRef.current = null
-      cachedSelectionRef.current = null
-      setSelection({ startIndex: 0, endIndex: 0, text: '', points: 0 })
-      setPhaseSynced('idle')
-      onDeselect?.()
-    }
+      clearSuppress();
+      cachedRectRef.current = null;
+      cachedSelectionRef.current = null;
+      touchModeRef.current = false;
+      setTouchMode(false);
+      setSelection({ startIndex: 0, endIndex: 0, text: "", points: 0 });
+      setPhaseSynced("idle");
+      onDeselect?.();
+    };
     // Modern browsers
-    if (typeof mql.addEventListener === 'function') {
-      mql.addEventListener('change', handler)
-      return () => mql.removeEventListener('change', handler)
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", handler);
+      return () => mql.removeEventListener("change", handler);
     }
     // Safari fallback
-    const legacy = mql as unknown as { addListener: (cb: () => void) => void; removeListener: (cb: () => void) => void }
+    const legacy = mql as unknown as {
+      addListener: (cb: () => void) => void;
+      removeListener: (cb: () => void) => void;
+    };
     if (legacy.addListener) {
-      legacy.addListener(handler)
-      return () => legacy.removeListener(handler)
+      legacy.addListener(handler);
+      return () => legacy.removeListener(handler);
     }
-    return undefined
-  }, [clearSuppress, onDeselect, setPhaseSynced])
+    return undefined;
+  }, [clearSuppress, onDeselect, setPhaseSynced]);
 
   useEffect(() => {
     return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current)
-      if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current)
-    }
-  }, [])
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current);
+    };
+  }, []);
 
   const tryParseSelection = useCallback(
     (sel: Selection): { parsed: SelectedText; rect: DOMRect } | null => {
-      const text = sel.toString()
-      if (!text) return null
-      if (sel.rangeCount === 0) return null
-      const range = sel.getRangeAt(0)
-      if (range.collapsed) return null
-      const root = contentRef.current
-      if (!root) return null
-      if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) return null
-      let rect: DOMRect
+      const text = sel.toString();
+      if (!text) return null;
+      if (sel.rangeCount === 0) return null;
+      const range = sel.getRangeAt(0);
+      if (range.collapsed) return null;
+      const root = contentRef.current;
+      if (!root) return null;
+      if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) return null;
+      let rect: DOMRect;
       try {
-        rect = range.getBoundingClientRect()
+        rect = range.getBoundingClientRect();
       } catch {
-        return null
+        return null;
       }
-      if (rect.width <= 0 || rect.height <= 0) return null
+      if (rect.width <= 0 || rect.height <= 0) return null;
 
-      // DOM-aware parser for correct repeated-text handling; fallback to legacy parser for collapsed newline edge
+      // DOM-aware parser only (P2 #2): no legacy indexOf fallback —
+      // rejecting the selection is safer than binding the wrong passage.
       const domParsed = parseDomSelection({
         content,
         selectedText: text,
         range,
         contentRoot: root,
-      })
-      let parsed: SelectedText | null = null
-      if (domParsed && typeof domParsed.startIndex === 'number' && typeof domParsed.endIndex === 'number') {
-        // Validate slice matches normalized selection
-        const slice = content.slice(domParsed.startIndex as number, domParsed.endIndex as number)
-        const normSlice = slice.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
-        const normText = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
-        if (normSlice === normText || slice === text) {
-          parsed = {
-            startIndex: domParsed.startIndex as number,
-            endIndex: domParsed.endIndex as number,
-            text: slice,
-            points: (domParsed.endIndex as number) - (domParsed.startIndex as number),
-          }
-        }
+      });
+      if (
+        !domParsed ||
+        typeof domParsed.startIndex !== "number" ||
+        typeof domParsed.endIndex !== "number"
+      ) {
+        return null;
       }
-      if (!parsed) {
-        // Don't use legacy indexOf as authoritative — reject if DOM parser couldn't defensibly match
-        // But keep legacy as desktop fallback when DOM enumeration failed due to ephemeral rect
-        const legacy = parser(content, text)
-        if (!legacy || typeof legacy.startIndex !== 'number' || legacy.startIndex === -1) return null
-        // Only accept legacy if it passes slice verification
-        const legacySlice = content.slice(legacy.startIndex as number, legacy.endIndex as number)
-        if (legacySlice !== text) return null
-        parsed = {
-          startIndex: legacy.startIndex as number,
-          endIndex: legacy.endIndex as number,
-          text,
-          points: legacy.endIndex as number - (legacy.startIndex as number),
-        }
+      const startIndex = domParsed.startIndex;
+      const endIndex = domParsed.endIndex;
+      if (startIndex < 0 || endIndex > content.length || endIndex <= startIndex) {
+        return null;
       }
-      if (parsed.startIndex < 0 || parsed.endIndex > content.length || parsed.endIndex <= parsed.startIndex) {
-        return null
-      }
-      return { parsed, rect }
+      // Final verification: normalized slice must match normalized selection
+      const slice = content.slice(startIndex, endIndex);
+      const normSlice = slice.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+      const normText = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+      if (normSlice !== normText) return null;
+      return {
+        parsed: {
+          startIndex,
+          endIndex,
+          text: slice,
+          points: endIndex - startIndex,
+        },
+        rect,
+      };
     },
     [content]
-  )
+  );
 
   const handleSelectionChange = useCallback(() => {
-    const sel = window.getSelection()
-    if (!sel || sel.rangeCount === 0) {
+    const sel = window.getSelection();
+    const collapsedOrEmpty = !sel || sel.rangeCount === 0 || sel.getRangeAt(0).collapsed;
+    if (collapsedOrEmpty) {
       // Refinement 2: collapsed with no cached passage → idle; with cached passage → ignore
-      if (phaseRef.current === 'native' && cachedSelectionRef.current) return
-      if (phaseRef.current === 'native' && !cachedSelectionRef.current) {
-        resetToIdle()
+      if (phaseRef.current === "native") {
+        if (!cachedSelectionRef.current) resetToIdle();
+        return;
       }
-      return
+      // Desktop toolbar: selection cleared (click elsewhere) → dismiss.
+      // Retained (touch) toolbar clears the native selection deliberately
+      // during the transition, so it must NOT reset here.
+      if (phaseRef.current === "toolbar" && !touchModeRef.current) {
+        resetToIdle();
+      }
+      return;
     }
-    const range = sel.getRangeAt(0)
-    if (range.collapsed) {
-      if (phaseRef.current === 'native' && cachedSelectionRef.current) return
-      if (phaseRef.current === 'native' && !cachedSelectionRef.current) resetToIdle()
-      return
-    }
-    const result = tryParseSelection(sel)
+    const result = tryParseSelection(sel!);
     if (!result) {
-      if (phaseRef.current === 'native' && cachedSelectionRef.current) return
-      return
+      if (phaseRef.current === "native" && cachedSelectionRef.current) return;
+      return;
     }
-    const { parsed, rect } = result
-    cachedSelectionRef.current = parsed
-    cachedRectRef.current = rect
-    setSelection(parsed)
+    const { parsed, rect } = result;
+    cachedSelectionRef.current = parsed;
+    cachedRectRef.current = rect;
+    setSelection(parsed);
 
-    const delayed = isCoarseTouchEnvironment()
+    // Capture input mode at the moment the selection becomes valid (P1 #1)
+    const delayed = isCoarseTouchEnvironment();
+    touchModeRef.current = delayed;
+    setTouchMode(delayed);
     if (delayed) {
       // Touch-first: store but keep toolbar hidden (native menu active)
-      setPhaseSynced('native')
+      setPhaseSynced("native");
       // Don't call onSelect yet; toolbar not shown
     } else {
-      // Desktop: open immediately
-      setPhaseSynced('toolbar')
-      onSelect?.(parsed)
+      // Desktop: open immediately, live selection drives rendering/positioning
+      setPhaseSynced("toolbar");
+      onSelect?.(parsed);
     }
-  }, [tryParseSelection, resetToIdle, setPhaseSynced, onSelect])
+  }, [tryParseSelection, resetToIdle, setPhaseSynced, onSelect]);
 
   // Selection ownership scoped to local selectable-content ref + polling fallback
   useEffect(() => {
-    const target = selectableRef.current
-    if (!target) return
+    const target = selectableRef.current;
+    if (!target) return;
 
     const onSelectStart = () => {
-      if (intervalRef.current) clearInterval(intervalRef.current)
+      if (intervalRef.current) clearInterval(intervalRef.current);
       intervalRef.current = setInterval(() => {
         // Polling fallback for mobile handle drag; also observe selectionchange in native
-        handleSelectionChange()
-      }, 100)
-    }
+        handleSelectionChange();
+      }, 100);
+    };
     const onPointerUp = () => {
       if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-        intervalRef.current = null
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
       // Let selection settle then refresh
-      window.setTimeout(handleSelectionChange, 0)
-    }
+      window.setTimeout(handleSelectionChange, 0);
+    };
 
-    target.addEventListener('selectstart', onSelectStart)
-    target.addEventListener('pointerup', onPointerUp)
-    // While in native, selectionchange from handle drag should refresh
+    target.addEventListener("selectstart", onSelectStart);
+    target.addEventListener("pointerup", onPointerUp);
+    // While in native, selectionchange from handle drag should refresh;
+    // desktop selectionchange drives both open (idle→toolbar) and dismissal
+    // (toolbar→idle when the selection collapses). Retained toolbar ignores
+    // it because the native selection was deliberately cleared.
     const onDocSelectionChange = () => {
-      if (phaseRef.current === 'native') handleSelectionChange()
-      else if (phaseRef.current === 'idle' && !isCoarseTouchEnvironment()) handleSelectionChange()
-    }
-    document.addEventListener('selectionchange', onDocSelectionChange)
+      if (phaseRef.current === "native") handleSelectionChange();
+      else if (phaseRef.current === "idle" && !isCoarseTouchEnvironment()) handleSelectionChange();
+      else if (phaseRef.current === "toolbar" && !touchModeRef.current) handleSelectionChange();
+    };
+    document.addEventListener("selectionchange", onDocSelectionChange);
 
     return () => {
-      target.removeEventListener('selectstart', onSelectStart)
-      target.removeEventListener('pointerup', onPointerUp)
-      document.removeEventListener('selectionchange', onDocSelectionChange)
+      target.removeEventListener("selectstart", onSelectStart);
+      target.removeEventListener("pointerup", onPointerUp);
+      document.removeEventListener("selectionchange", onDocSelectionChange);
       if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-        intervalRef.current = null
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
-    }
-  }, [handleSelectionChange])
+    };
+  }, [handleSelectionChange]);
 
-  // Outside-tap handlers: only while native or toolbar active
+  /**
+   * Perform the native → toolbar transition (first tap).
+   * Ordering (refinement 1): cache rect → phase → flushSync mark → clear
+   * native → position. flushSync runs only from this pointer-event path.
+   */
+  const performNativeToToolbarTransition = useCallback(
+    (pointerId: number | null) => {
+      // Refresh cached selection if still valid
+      const sel = window.getSelection();
+      if (sel && sel.rangeCount > 0) {
+        const refreshed = tryParseSelection(sel);
+        if (refreshed) {
+          cachedSelectionRef.current = refreshed.parsed;
+          cachedRectRef.current = refreshed.rect;
+          setSelection(refreshed.parsed);
+        }
+      }
+      if (!cachedSelectionRef.current || !cachedRectRef.current) {
+        resetToIdle();
+        return;
+      }
+      const rectToCache = cachedRectRef.current;
+      const parsedToCommit = cachedSelectionRef.current;
+      flushSync(() => {
+        phaseRef.current = "toolbar";
+        setPhase("toolbar");
+        setSelection(parsedToCommit);
+      });
+      // Now retained <mark> exists; clear native
+      clearNativeSelection();
+      // Prime popover positioning from cached rect; popover recomputes from mark
+      cachedRectRef.current = rectToCache;
+      onSelect?.(parsedToCommit);
+      armSuppress(pointerId);
+    },
+    [tryParseSelection, resetToIdle, clearNativeSelection, onSelect, armSuppress]
+  );
+
+  // Outside-tap handlers: only for the touch workflow (native phase, or the
+  // retained toolbar). Desktop toolbar installs NO document-level capture
+  // handlers — dismissal is selection-driven, so normal desktop clicks are
+  // never consumed (P1 #1).
   useEffect(() => {
-    if (phase !== 'native' && phase !== 'toolbar') return
+    const active = phase === "native" || (phase === "toolbar" && touchMode);
+    if (!active) return;
 
     const onPointerDownCapture = (e: PointerEvent) => {
-      const target = e.target as HTMLElement | null
+      const target = e.target;
       // Protect guest auth dialog
       if (isDialogTarget(target)) {
         // Clear stale toolbar but don't swallow dialog interaction
-        if (phaseRef.current === 'toolbar' || phaseRef.current === 'native') {
-          cachedRectRef.current = null
-          cachedSelectionRef.current = null
-          setSelection({ startIndex: 0, endIndex: 0, text: '', points: 0 })
-          setPhaseSynced('idle')
-          onDeselect?.()
+        if (phaseRef.current === "toolbar" || phaseRef.current === "native") {
+          resetToIdle();
         }
-        return
+        return;
       }
       // Inside popover — preserve
-      if (popoverRef.current?.contains(target as Node)) return
-
-      // Inside selectable content while native — refresh, don't transition
-      if (phaseRef.current === 'native' && selectableRef.current?.contains(target as Node)) {
-        // Allow native handles to move; will be handled by selectionchange
-        return
+      if (popoverRef.current && target instanceof Node && popoverRef.current.contains(target)) {
+        return;
       }
+      const insideSelectable =
+        selectableRef.current && target instanceof Node && selectableRef.current.contains(target);
 
-      if (phaseRef.current === 'native') {
+      if (phaseRef.current === "native") {
+        if (insideSelectable) {
+          // Tap-vs-drag (P1 #2): a stationary tap inside the quote should
+          // transition; dragging the selection handles should not. Track the
+          // gesture and decide on pointerup.
+          pendingTapRef.current = { pointerId: e.pointerId, x: e.clientX, y: e.clientY };
+          tapDraggedRef.current = false;
+          return;
+        }
         // First outside tap: native → toolbar
-        // Refresh cached selection if still valid
-        const sel = window.getSelection()
-        if (sel && sel.rangeCount > 0) {
-          const refreshed = tryParseSelection(sel)
-          if (refreshed) {
-            cachedSelectionRef.current = refreshed.parsed
-            cachedRectRef.current = refreshed.rect
-            setSelection(refreshed.parsed)
-          }
-        }
-        if (!cachedSelectionRef.current || !cachedRectRef.current) {
-          resetToIdle()
-          return
-        }
-        const rectToCache = cachedRectRef.current
-        const parsedToCommit = cachedSelectionRef.current
-        // Refinement 1 ordering: cache rect → phaseRef → flushSync render → clear native → position
-        // Must run flushSync only from this pointerdown handler, not an effect
-        flushSync(() => {
-          phaseRef.current = 'toolbar'
-          setPhase('toolbar')
-          setSelection(parsedToCommit)
-        })
-        // Now retained <mark> exists; clear native
-        clearNativeSelection()
-        // Prime popover positioning from cached rect; recompute from retained mark on next frames handled by popover
-        cachedRectRef.current = rectToCache
-        onSelect?.(parsedToCommit)
-        armSuppress(e.pointerId ?? null)
-        e.preventDefault()
-        e.stopPropagation()
-        // Also suppress the compatibility click
-        return
+        performNativeToToolbarTransition(e.pointerId ?? null);
+        e.preventDefault();
+        e.stopPropagation();
+        return;
       }
 
-      if (phaseRef.current === 'toolbar') {
+      if (phaseRef.current === "toolbar") {
         // Second outside tap: toolbar → idle
-        // If tap inside content but not toolbar, dismiss
-        armSuppress(e.pointerId ?? null)
-        e.preventDefault()
-        e.stopPropagation()
+        armSuppress(e.pointerId ?? null);
+        e.preventDefault();
+        e.stopPropagation();
         // Clear after suppress armed so click suppression can fire
-        window.setTimeout(() => resetToIdle(), 0)
+        window.setTimeout(() => resetToIdle(), 0);
       }
-    }
+    };
+
+    const onPointerMoveCapture = (e: PointerEvent) => {
+      if (!pendingTapRef.current) return;
+      const tap = pendingTapRef.current;
+      // Mark as drag once the pointer moves beyond a small slop threshold
+      if (
+        e.pointerId === tap.pointerId &&
+        (Math.abs(e.clientX - tap.x) > 8 || Math.abs(e.clientY - tap.y) > 8)
+      ) {
+        tapDraggedRef.current = true;
+      }
+    };
+
+    const onPointerUpCapture = (e: PointerEvent) => {
+      const tap = pendingTapRef.current;
+      if (!tap) return;
+      pendingTapRef.current = null;
+      if (e.pointerId !== tap.pointerId) return;
+      if (tapDraggedRef.current) return;
+      // Stationary tap inside the quote: perform the first transition
+      if (phaseRef.current === "native" && cachedSelectionRef.current) {
+        performNativeToToolbarTransition(e.pointerId ?? null);
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
 
     const onClickCapture = (e: MouseEvent) => {
-      if (!suppressNextClickRef.current) return
+      if (!suppressNextClickRef.current) return;
       if (Date.now() > suppressDeadlineRef.current) {
-        clearSuppress()
-        return
+        clearSuppress();
+        return;
       }
-      const target = e.target as HTMLElement | null
+      const target = e.target;
+      // Dialogs are higher-priority UI (guest auth): let the click through
       if (isDialogTarget(target)) {
-        clearSuppress()
-        return
+        clearSuppress();
+        return;
       }
-      // Only suppress if this click corresponds to the suppressed pointer
-      // For mouse compatibility clicks pointerId is not available; suppress any outside click within deadline
-      e.preventDefault()
-      e.stopPropagation()
-      if (typeof (e as unknown as { stopImmediatePropagation?: () => void }).stopImmediatePropagation === 'function') {
-        ;(e as unknown as { stopImmediatePropagation: () => void }).stopImmediatePropagation!()
+      // Popover interactions are never suppressed (P1 #3): a quick
+      // Agree/Comment/Quote tap after the transition must work.
+      if (popoverRef.current && target instanceof Node && popoverRef.current.contains(target)) {
+        clearSuppress();
+        return;
       }
-      clearSuppress()
-    }
+      // Suppress only the click matching the consumed pointer (P1 #3).
+      // MouseEvent has no pointerId; for touch, PointerEvent-driven clicks
+      // carry a matching pointerId when available.
+      const clickPointerId = (e as unknown as { pointerId?: number }).pointerId;
+      if (
+        suppressPointerIdRef.current !== null &&
+        clickPointerId !== undefined &&
+        clickPointerId !== suppressPointerIdRef.current
+      ) {
+        // Different pointer than the consumed gesture — let it through
+        clearSuppress();
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      if (
+        typeof (e as unknown as { stopImmediatePropagation?: () => void })
+          .stopImmediatePropagation === "function"
+      ) {
+        (e as unknown as { stopImmediatePropagation: () => void }).stopImmediatePropagation!();
+      }
+      clearSuppress();
+    };
 
-    document.addEventListener('pointerdown', onPointerDownCapture, true)
-    document.addEventListener('click', onClickCapture, true)
+    document.addEventListener("pointerdown", onPointerDownCapture, true);
+    document.addEventListener("pointermove", onPointerMoveCapture, true);
+    document.addEventListener("pointerup", onPointerUpCapture, true);
+    document.addEventListener("click", onClickCapture, true);
     return () => {
-      document.removeEventListener('pointerdown', onPointerDownCapture, true)
-      document.removeEventListener('click', onClickCapture, true)
-    }
-  }, [phase, tryParseSelection, clearNativeSelection, resetToIdle, setPhaseSynced, onSelect, onDeselect, armSuppress, clearSuppress])
+      document.removeEventListener("pointerdown", onPointerDownCapture, true);
+      document.removeEventListener("pointermove", onPointerMoveCapture, true);
+      document.removeEventListener("pointerup", onPointerUpCapture, true);
+      document.removeEventListener("click", onClickCapture, true);
+    };
+  }, [
+    phase,
+    touchMode,
+    performNativeToToolbarTransition,
+    resetToIdle,
+    onSelect,
+    onDeselect,
+    armSuppress,
+    clearSuppress,
+  ]);
 
   const findChunksAtBeginningOfWords = useCallback(
     () => [{ start: startWordIndex > 0 ? startWordIndex : 0, end: endWordIndex }],
     [startWordIndex, endWordIndex]
-  )
+  );
 
   const findRetainedChunks = useCallback(() => {
-    const s = cachedSelectionRef.current
-    if (!s) return []
-    return [{ start: s.startIndex, end: s.endIndex }]
-  }, [])
+    const s = cachedSelectionRef.current;
+    if (!s) return [];
+    return [{ start: s.startIndex, end: s.endIndex }];
+  }, []);
 
   const disableContextMenu = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
+    e.preventDefault();
     if (e.nativeEvent.stopImmediatePropagation) {
-      e.nativeEvent.stopImmediatePropagation()
+      e.nativeEvent.stopImmediatePropagation();
     }
-  }, [])
+  }, []);
 
   const handlePassageClick = useCallback(
     (e: React.MouseEvent) => {
-      const target = e.target as HTMLElement
+      const target = e.target as HTMLElement;
       if (target.closest('[data-linked-passage="true"]')) {
-        e.preventDefault()
-        onHighlightClick?.()
+        e.preventDefault();
+        onHighlightClick?.();
       }
     },
-    [onHighlightClick],
-  )
+    [onHighlightClick]
+  );
 
   const resolveAnchorRect = useCallback((): DOMRect | null => {
-    // Mobile toolbar: prefer retained mark rect, fall back to cached native rect during transition frame
-    if (phaseRef.current === 'toolbar') {
-      const mark = document.querySelector('[data-testid="retained-selection-highlight"]') as HTMLElement | null
+    // Retained (touch) toolbar: prefer retained mark rect, fall back to cached
+    // native rect during the transition frame.
+    if (phaseRef.current === "toolbar" && touchModeRef.current) {
+      const mark = document.querySelector(
+        '[data-testid="retained-selection-highlight"]'
+      ) as HTMLElement | null;
       if (mark) {
-        const r = mark.getBoundingClientRect()
-        if (r.width > 0 && r.height > 0) return r
+        const r = mark.getBoundingClientRect();
+        if (r.width > 0 && r.height > 0) return r;
       }
-      if (cachedRectRef.current) return cachedRectRef.current
-      return null
+      if (cachedRectRef.current) return cachedRectRef.current;
+      return null;
     }
     // Desktop toolbar (immediate) or native measurement: live range
-    const sel = window.getSelection()
+    const sel = window.getSelection();
     if (sel && sel.rangeCount > 0) {
       try {
-        const r = sel.getRangeAt(0).getBoundingClientRect()
-        if (r.width > 0 && r.height > 0) return r
+        const r = sel.getRangeAt(0).getBoundingClientRect();
+        if (r.width > 0 && r.height > 0) return r;
       } catch {
         // ignore
       }
     }
-    if (cachedRectRef.current) return cachedRectRef.current
-    return null
-  }, [])
+    if (cachedRectRef.current) return cachedRectRef.current;
+    return null;
+  }, []);
 
-  const showPopover = phase === 'toolbar' && hasValidRetainedSelection
+  // Popover visibility: retained (touch) or desktop-immediate toolbar
+  const showRetainedPopover = phase === "toolbar" && hasValidRetainedSelection;
+  const showDesktopPopover = phase === "toolbar" && !touchMode && selection.text.length > 0;
+  const effectiveShowPopover = showRetainedPopover || showDesktopPopover;
 
-  // Desktop immediate mode also uses toolbar phase; hasValidRetainedSelection may be false for desktop
-  // because isCoarseTouchEnvironment() returns false → we set phase toolbar but hasValidRetainedSelection needs cache.
-  // Unify: desktop should show popover whenever phase toolbar and selection has text.
-  const isDesktopToolbar = phase === 'toolbar' && !isCoarseTouchEnvironment() && selection.text.length > 0
-  const effectiveShowPopover = showPopover || isDesktopToolbar
+  const renderRetained = () => (
+    <Highlighter
+      style={{ whiteSpace: "pre-line" }}
+      highlightClassName={RETAINED_PASSAGE_CLASS}
+      highlightTag={RetainedPassageMark}
+      textToHighlight={content}
+      searchWords={[]}
+      findChunks={findRetainedChunks}
+      autoEscape
+      onContextMenu={disableContextMenu}
+    />
+  );
 
   const renderHighlights = () => {
-    if (effectiveShowPopover || (phase === 'toolbar' && hasValidRetainedSelection)) {
-      // Refinement 4: explicit priority branch — retained takes precedence, no mutation of hasLinkedRange
-      if (phase === 'toolbar' && hasValidRetainedSelection) {
-        return (
-          <Highlighter
-            style={{ whiteSpace: 'pre-line' }}
-            highlightClassName={RETAINED_PASSAGE_CLASS}
-            highlightTag={RetainedPassageMark}
-            textToHighlight={content}
-            searchWords={[]}
-            findChunks={findRetainedChunks}
-            autoEscape
-            onContextMenu={disableContextMenu}
-          />
-        )
-      }
+    // Explicit priority branch (refinement 4): retained takes precedence,
+    // hasLinkedRange is not mutated so the linked highlight returns after
+    // dismissal.
+    if (phase === "toolbar" && hasValidRetainedSelection) {
+      return renderRetained();
     }
 
     if (highlights) {
-      if (hasLinkedRange && !(phase === 'toolbar' && hasValidRetainedSelection)) {
+      if (hasLinkedRange) {
         return (
           <Highlighter
-            style={{ whiteSpace: 'pre-line' }}
+            style={{ whiteSpace: "pre-line" }}
             highlightClassName={LINKED_PASSAGE_CLASS}
             highlightTag={LinkedPassageMark}
             textToHighlight={content}
@@ -561,28 +684,12 @@ export default function VotingBoard({
             autoEscape
             onContextMenu={disableContextMenu}
           />
-        )
-      }
-
-      // When not linked but highlights on, we still want retained to show if in toolbar; handled above
-      if (phase === 'toolbar' && hasValidRetainedSelection) {
-        return (
-          <Highlighter
-            style={{ whiteSpace: 'pre-line' }}
-            highlightClassName={RETAINED_PASSAGE_CLASS}
-            highlightTag={RetainedPassageMark}
-            textToHighlight={content}
-            searchWords={[]}
-            findChunks={findRetainedChunks}
-            autoEscape
-            onContextMenu={disableContextMenu}
-          />
-        )
+        );
       }
 
       return (
         <Highlighter
-          style={{ whiteSpace: 'pre-line' }}
+          style={{ whiteSpace: "pre-line" }}
           highlightClassName={LINKED_PASSAGE_CLASS}
           searchWords={[highlightedText]}
           textToHighlight={content}
@@ -590,23 +697,7 @@ export default function VotingBoard({
           caseSensitive
           onContextMenu={disableContextMenu}
         />
-      )
-    }
-
-    // Non-highlight mode but toolbar active: still show retained mark
-    if (phase === 'toolbar' && hasValidRetainedSelection) {
-      return (
-        <Highlighter
-          style={{ whiteSpace: 'pre-line' }}
-          highlightClassName={RETAINED_PASSAGE_CLASS}
-          highlightTag={RetainedPassageMark}
-          textToHighlight={content}
-          searchWords={[]}
-          findChunks={findRetainedChunks}
-          autoEscape
-          onContextMenu={disableContextMenu}
-        />
-      )
+      );
     }
 
     return content.split(/\n/g).map((line, contentIndex) => (
@@ -616,8 +707,8 @@ export default function VotingBoard({
         ))}
         <br />
       </Fragment>
-    ))
-  }
+    ));
+  };
 
   return (
     <div className="relative h-full flex flex-col" style={style}>
@@ -640,5 +731,5 @@ export default function VotingBoard({
         {children && children(selection)}
       </SelectionPopover>
     </div>
-  )
+  );
 }

--- a/quotevote-frontend/src/lib/utils/parser.ts
+++ b/quotevote-frontend/src/lib/utils/parser.ts
@@ -1,4 +1,4 @@
-import { ParsedSelection } from "@/types/store";
+import type { ParsedSelection } from "@/types/store";
 export const CONTENT_REGEX = /(\w|\.)+/g;
 
 export function parser(

--- a/quotevote-frontend/src/lib/utils/parser.ts
+++ b/quotevote-frontend/src/lib/utils/parser.ts
@@ -1,32 +1,40 @@
-import { ParsedSelection } from "@/types/store"
-export const CONTENT_REGEX = /(\w|\.)+/g
+import { ParsedSelection } from "@/types/store";
+export const CONTENT_REGEX = /(\w|\.)+/g;
 
 // Backward-compatible overloads: accept positional args or object args
 // Note: repeated-text cases should use parserDom.ts (DOM-aware) instead.
 // This legacy parser is retained for desktop fallback and existing callers.
-export function parser(doc: string, selected: string, _ranges?: unknown): ParsedSelection | undefined
-export function parser(args: { doc: string; selected: string }): ParsedSelection | undefined
-export function parser(arg1: string | { doc: string; selected: string }, arg2?: string, _ranges?: unknown): ParsedSelection | undefined {
-  let doc: string
-  let selected: string
+export function parser(
+  doc: string,
+  selected: string,
+  _ranges?: unknown
+): ParsedSelection | undefined;
+export function parser(args: { doc: string; selected: string }): ParsedSelection | undefined;
+export function parser(
+  arg1: string | { doc: string; selected: string },
+  arg2?: string,
+  _ranges?: unknown
+): ParsedSelection | undefined {
+  let doc: string;
+  let selected: string;
 
-  if (typeof arg1 === 'string') {
-    doc = arg1
-    selected = arg2 ?? ''
+  if (typeof arg1 === "string") {
+    doc = arg1;
+    selected = arg2 ?? "";
   } else {
-    doc = arg1.doc
-    selected = arg1.selected
+    doc = arg1.doc;
+    selected = arg1.selected;
   }
 
-  if (!selected) return
-  const charStartIndex = doc.indexOf(selected)
-  const charEndIndex = charStartIndex !== -1 ? charStartIndex + selected.length : -1
+  if (!selected) return;
+  const charStartIndex = doc.indexOf(selected);
+  const charEndIndex = charStartIndex !== -1 ? charStartIndex + selected.length : -1;
   return {
     startIndex: charStartIndex,
     endIndex: charEndIndex,
     text: selected,
     points: charEndIndex !== -1 ? charEndIndex - charStartIndex : 0,
-  }
+  };
 }
 
-export { parseDomSelection, isValidRangeForRoot, domApproximateStartOffset } from "./parserDom"
+export { parseDomSelection, isValidRangeForRoot, domApproximateStartOffset } from "./parserDom";

--- a/quotevote-frontend/src/lib/utils/parser.ts
+++ b/quotevote-frontend/src/lib/utils/parser.ts
@@ -1,9 +1,6 @@
 import { ParsedSelection } from "@/types/store";
 export const CONTENT_REGEX = /(\w|\.)+/g;
 
-// Backward-compatible overloads: accept positional args or object args
-// Note: repeated-text cases should use parserDom.ts (DOM-aware) instead.
-// This legacy parser is retained for desktop fallback and existing callers.
 export function parser(
   doc: string,
   selected: string,

--- a/quotevote-frontend/src/lib/utils/parser.ts
+++ b/quotevote-frontend/src/lib/utils/parser.ts
@@ -2,6 +2,8 @@ import { ParsedSelection } from "@/types/store"
 export const CONTENT_REGEX = /(\w|\.)+/g
 
 // Backward-compatible overloads: accept positional args or object args
+// Note: repeated-text cases should use parserDom.ts (DOM-aware) instead.
+// This legacy parser is retained for desktop fallback and existing callers.
 export function parser(doc: string, selected: string, _ranges?: unknown): ParsedSelection | undefined
 export function parser(args: { doc: string; selected: string }): ParsedSelection | undefined
 export function parser(arg1: string | { doc: string; selected: string }, arg2?: string, _ranges?: unknown): ParsedSelection | undefined {
@@ -26,3 +28,5 @@ export function parser(arg1: string | { doc: string; selected: string }, arg2?: 
     points: charEndIndex !== -1 ? charEndIndex - charStartIndex : 0,
   }
 }
+
+export { parseDomSelection, isValidRangeForRoot, domApproximateStartOffset } from "./parserDom"

--- a/quotevote-frontend/src/lib/utils/parserDom.ts
+++ b/quotevote-frontend/src/lib/utils/parserDom.ts
@@ -1,0 +1,206 @@
+import type { ParsedSelection } from "@/types/store"
+
+/**
+ * DOM-aware parser for VotingBoard (issue #484).
+ *
+ * Legacy parser.ts used `doc.indexOf(selected)` which always returns the first
+ * occurrence — wrong for repeated passages.
+ *
+ * This module derives the *approximate* offset from a live Range → prefix text
+ * length, then enumerates every exact occurrence and picks the nearest to the
+ * DOM offset. Safer to return undefined (no toolbar) than to bind a vote to
+ * the wrong passage.
+ */
+
+export interface DomParserArgs {
+  content: string
+  selectedText: string
+  range: Range
+  contentRoot: HTMLElement
+}
+
+function buildNormalizedIndexMap(content: string): { normalized: string; map: number[] } {
+  const map: number[] = []
+  let normalized = ""
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i]
+    if (ch === "\r") {
+      // CRLF → single LF, lone CR → LF
+      if (i + 1 < content.length && content[i + 1] === "\n") {
+        normalized += "\n"
+        map.push(i)
+        i++ // skip the '\n' part of CRLF, but map normalized char to start of CRLF
+      } else {
+        normalized += "\n"
+        map.push(i)
+      }
+    } else {
+      normalized += ch
+      map.push(i)
+    }
+  }
+  return { normalized, map }
+}
+
+function enumerateOccurrences(haystack: string, needle: string): number[] {
+  const out: number[] = []
+  if (!needle) return out
+  let from = 0
+  while (true) {
+    const idx = haystack.indexOf(needle, from)
+    if (idx === -1) break
+    out.push(idx)
+    from = idx + 1
+  }
+  return out
+}
+
+/**
+ * Validate range belongs to contentRoot and is non-collapsed with geometry.
+ */
+export function isValidRangeForRoot(range: Range, contentRoot: HTMLElement): boolean {
+  if (!range || range.collapsed) return false
+  if (!contentRoot.contains(range.startContainer) || !contentRoot.contains(range.endContainer)) {
+    return false
+  }
+  // Reverse range (end before start) collapses or produces negative geometry elsewhere;
+  // DOM Range is always normalized, but guard against zero-area selections.
+  try {
+    const rect = range.getBoundingClientRect()
+    if (rect.width <= 0 || rect.height <= 0) return false
+  } catch {
+    return false
+  }
+  return true
+}
+
+/**
+ * Derive approximate start offset from DOM: length of text from contentRoot start to range.start.
+ */
+export function domApproximateStartOffset(range: Range, contentRoot: HTMLElement): number | null {
+  try {
+    const prefix = document.createRange()
+    prefix.selectNodeContents(contentRoot)
+    prefix.setEnd(range.startContainer, range.startOffset)
+    const text = prefix.toString()
+    prefix.detach?.()
+    return text.length
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Main entry: resolve a Selection Range to character offsets within `content`.
+ * Returns undefined if no defensible match exists.
+ */
+export function parseDomSelection(args: DomParserArgs): ParsedSelection | undefined {
+  const { content, selectedText, range, contentRoot } = args
+  if (!selectedText) return undefined
+  if (!isValidRangeForRoot(range, contentRoot)) return undefined
+
+  const approx = domApproximateStartOffset(range, contentRoot)
+  const normalizedSelected = selectedText.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+
+  // Fast path: direct validation at approx
+  if (approx != null) {
+    // Try raw content first (common case: DOM text equals content slice)
+    if (approx >= 0 && approx + normalizedSelected.length <= content.length) {
+      const rawSlice = content.slice(approx, approx + normalizedSelected.length)
+      const normSlice = rawSlice.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+      if (normSlice === normalizedSelected) {
+        return {
+          startIndex: approx,
+          endIndex: approx + selectedText.length,
+          text: selectedText,
+          points: selectedText.length,
+        }
+      }
+    }
+  }
+
+  // Normalize content for CRLF differences, keep map to original offsets
+  const { normalized: normContent, map } = buildNormalizedIndexMap(content)
+
+  // Enumerate every occurrence in normalized space
+  const occurrences = enumerateOccurrences(normContent, normalizedSelected)
+  if (occurrences.length === 0) return undefined
+
+  // If single occurrence, map back via index map
+  if (occurrences.length === 1) {
+    const normStart = occurrences[0]
+    const origStart = map[normStart]
+    // Map normalized length back to original length (CRLF counts as 2)
+    // For normalized length L, original length is determined by scanning.
+    let origEnd: number
+    if (normStart + normalizedSelected.length < map.length) {
+      // Next normalized char maps to that original index
+      // Original end is start of next char after the selection
+      const nextOrig = map[normStart + normalizedSelected.length]
+      // Handle case where selection ends with CRLF-expanded char: we need to include full CRLF
+      // Heuristic: if normContent slice maps back via prefix length counting CRLFs, compute via scanning.
+      // Simpler: find original end by advancing over original content counting normalized chars.
+      let n = 0
+      let o = origStart
+      while (n < normalizedSelected.length && o < content.length) {
+        if (content[o] === "\r" && o + 1 < content.length && content[o + 1] === "\n") {
+          o += 2
+        } else {
+          o += 1
+        }
+        n += 1
+      }
+      origEnd = o
+      // If we computed via map next, prefer that when it covers CRLFs correctly; fallback to scan
+      if (nextOrig !== undefined && nextOrig <= origEnd) {
+        // Keep scanned origEnd as ground truth
+      }
+    } else {
+      // Selection reaches end of content
+      origEnd = content.length
+    }
+    return {
+      startIndex: origStart,
+      endIndex: origEnd,
+      text: content.slice(origStart, origEnd),
+      points: origEnd - origStart,
+    }
+  }
+
+  // Multiple occurrences: pick nearest to approx
+  const target = approx ?? 0
+  // Convert approx (DOM prefix length, which is normalized) to normalized-content offset
+  // approx already equals normalized prefix length, so compare directly in normalized space
+  let best = occurrences[0]
+  let bestDist = Math.abs(best - target)
+  for (let i = 1; i < occurrences.length; i++) {
+    const dist = Math.abs(occurrences[i] - target)
+    if (dist < bestDist) {
+      bestDist = dist
+      best = occurrences[i]
+    }
+  }
+  const origStart = map[best]
+  // Compute original end via scan (handles CRLF)
+  let n = 0
+  let o = origStart
+  while (n < normalizedSelected.length && o < content.length) {
+    if (content[o] === "\r" && o + 1 < content.length && content[o + 1] === "\n") {
+      o += 2
+    } else {
+      o += 1
+    }
+    n += 1
+  }
+  const origEnd = o
+  // Final verification in normalized space already passed; also verify raw slice normalizes correctly
+  const rawSlice = content.slice(origStart, origEnd)
+  const normSlice = rawSlice.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+  if (normSlice !== normalizedSelected) return undefined
+  return {
+    startIndex: origStart,
+    endIndex: origEnd,
+    text: content.slice(origStart, origEnd),
+    points: origEnd - origStart,
+  }
+}

--- a/quotevote-frontend/src/lib/utils/parserDom.ts
+++ b/quotevote-frontend/src/lib/utils/parserDom.ts
@@ -121,7 +121,7 @@ export function domApproximateStartOffset(range: Range, contentRoot: HTMLElement
     prefix.setEnd(range.startContainer, range.startOffset);
     const text = prefix.toString();
     prefix.detach?.();
-    return text.length;
+    return normalizeText(text).length;
   } catch {
     return null;
   }
@@ -164,8 +164,29 @@ export function parseDomSelection(args: DomParserArgs): ParsedSelection | undefi
   const occurrences = enumerateOccurrences(normContent, normalizedSelected);
   if (occurrences.length === 0) return undefined;
 
+  // Reject uncertain matches: with no anchor and multiple candidates we cannot
+  // defensibly choose. Single occurrence is unambiguous even without approx.
+  if (approx == null) {
+    if (occurrences.length > 1) return undefined;
+    const original = normalizedRangeToOriginal(
+      content,
+      map,
+      occurrences[0],
+      normalizedSelected.length
+    );
+    if (!original) return undefined;
+    const rawSlice = content.slice(original.start, original.end);
+    if (normalizeText(rawSlice) !== normalizedSelected) return undefined;
+    return {
+      startIndex: original.start,
+      endIndex: original.end,
+      text: rawSlice,
+      points: original.end - original.start,
+    };
+  }
+
   // Pick the occurrence nearest the DOM-derived approximate offset
-  const target = approx ?? 0;
+  const target = approx;
   let best = occurrences[0];
   let bestDist = Math.abs(best - target);
   for (let i = 1; i < occurrences.length; i++) {

--- a/quotevote-frontend/src/lib/utils/parserDom.ts
+++ b/quotevote-frontend/src/lib/utils/parserDom.ts
@@ -1,17 +1,5 @@
 import type { ParsedSelection } from "@/types/store";
 
-/**
- * DOM-aware parser for VotingBoard (issue #484).
- *
- * Legacy parser.ts used `doc.indexOf(selected)` which always returns the first
- * occurrence — wrong for repeated passages.
- *
- * This module derives the *approximate* offset from a live Range → prefix text
- * length, then enumerates every exact occurrence and picks the nearest to the
- * DOM offset. Safer to return undefined (no toolbar) than to bind a vote to
- * the wrong passage.
- */
-
 export interface DomParserArgs {
   content: string;
   selectedText: string;
@@ -21,7 +9,6 @@ export interface DomParserArgs {
 
 interface NormalizedContent {
   normalized: string;
-  /** map[normalizedIndex] = originalIndex for every normalized char */
   map: number[];
 }
 
@@ -31,11 +18,10 @@ function buildNormalizedIndexMap(content: string): NormalizedContent {
   for (let i = 0; i < content.length; i++) {
     const ch = content[i];
     if (ch === "\r") {
-      // CRLF → single LF, lone CR → LF
       if (i + 1 < content.length && content[i + 1] === "\n") {
         normalized += "\n";
         map.push(i);
-        i++; // skip the '\n' half of the CRLF pair
+        i++;
       } else {
         normalized += "\n";
         map.push(i);
@@ -65,12 +51,6 @@ function enumerateOccurrences(haystack: string, needle: string): number[] {
   return out;
 }
 
-/**
- * Convert a normalized-space [start, end) range back to original-content
- * offsets, advancing over CRLF pairs as a single normalized char.
- * This is the only end-point derivation — no length arithmetic in original
- * space, so a selection can never end midway through a CRLF (P2 #2).
- */
 function normalizedRangeToOriginal(
   content: string,
   map: number[],
@@ -89,13 +69,10 @@ function normalizedRangeToOriginal(
     }
     n += 1;
   }
-  if (n < normLength) return null; // ran off the end of content
+  if (n < normLength) return null;
   return { start, end: o };
 }
 
-/**
- * Validate range belongs to contentRoot and is non-collapsed with geometry.
- */
 export function isValidRangeForRoot(range: Range, contentRoot: HTMLElement): boolean {
   if (!range || range.collapsed) return false;
   if (!contentRoot.contains(range.startContainer) || !contentRoot.contains(range.endContainer)) {
@@ -110,10 +87,6 @@ export function isValidRangeForRoot(range: Range, contentRoot: HTMLElement): boo
   return true;
 }
 
-/**
- * Derive approximate start offset from DOM: length of text from contentRoot
- * start to range.start. This is a *normalized* offset (DOM text has no CRLF).
- */
 export function domApproximateStartOffset(range: Range, contentRoot: HTMLElement): number | null {
   try {
     const prefix = document.createRange();
@@ -127,10 +100,6 @@ export function domApproximateStartOffset(range: Range, contentRoot: HTMLElement
   }
 }
 
-/**
- * Main entry: resolve a Selection Range to character offsets within `content`.
- * Returns undefined if no defensible match exists.
- */
 export function parseDomSelection(args: DomParserArgs): ParsedSelection | undefined {
   const { content, selectedText, range, contentRoot } = args;
   if (!selectedText) return undefined;
@@ -140,11 +109,8 @@ export function parseDomSelection(args: DomParserArgs): ParsedSelection | undefi
   const normalizedSelected = normalizeText(selectedText);
   if (!normalizedSelected) return undefined;
 
-  // Normalize content once; all matching happens in normalized space and both
-  // endpoints map back through the index map (P2 #2 — fast path included).
   const { normalized: normContent, map } = buildNormalizedIndexMap(content);
 
-  // Fast path: validate directly at the DOM-derived offset in normalized space
   if (approx != null && approx >= 0 && approx + normalizedSelected.length <= normContent.length) {
     const normSlice = normContent.slice(approx, approx + normalizedSelected.length);
     if (normSlice === normalizedSelected) {
@@ -160,12 +126,9 @@ export function parseDomSelection(args: DomParserArgs): ParsedSelection | undefi
     }
   }
 
-  // Enumerate every exact occurrence in normalized space
   const occurrences = enumerateOccurrences(normContent, normalizedSelected);
   if (occurrences.length === 0) return undefined;
 
-  // Reject uncertain matches: with no anchor and multiple candidates we cannot
-  // defensibly choose. Single occurrence is unambiguous even without approx.
   if (approx == null) {
     if (occurrences.length > 1) return undefined;
     const original = normalizedRangeToOriginal(
@@ -185,7 +148,6 @@ export function parseDomSelection(args: DomParserArgs): ParsedSelection | undefi
     };
   }
 
-  // Pick the occurrence nearest the DOM-derived approximate offset
   const target = approx;
   let best = occurrences[0];
   let bestDist = Math.abs(best - target);
@@ -200,7 +162,6 @@ export function parseDomSelection(args: DomParserArgs): ParsedSelection | undefi
   const original = normalizedRangeToOriginal(content, map, best, normalizedSelected.length);
   if (!original) return undefined;
 
-  // Final verification: raw slice must normalize back to the selection
   const rawSlice = content.slice(original.start, original.end);
   if (normalizeText(rawSlice) !== normalizedSelected) return undefined;
   return {

--- a/quotevote-frontend/src/lib/utils/parserDom.ts
+++ b/quotevote-frontend/src/lib/utils/parserDom.ts
@@ -34,15 +34,19 @@ function buildNormalizedIndexMap(content: string): NormalizedContent {
   return { normalized, map };
 }
 
-let normalizedContentCache: { content: string; value: NormalizedContent } | null = null;
+const normalizedContentCache = new WeakMap<
+  HTMLElement,
+  { content: string; value: NormalizedContent }
+>();
 
-function getNormalizedContent(content: string): NormalizedContent {
-  if (normalizedContentCache?.content === content) {
-    return normalizedContentCache.value;
+function getNormalizedContent(contentRoot: HTMLElement, content: string): NormalizedContent {
+  const cached = normalizedContentCache.get(contentRoot);
+  if (cached?.content === content) {
+    return cached.value;
   }
 
   const value = buildNormalizedIndexMap(content);
-  normalizedContentCache = { content, value };
+  normalizedContentCache.set(contentRoot, { content, value });
   return value;
 }
 
@@ -121,7 +125,7 @@ export function parseDomSelection(args: DomParserArgs): ParsedSelection | undefi
   const normalizedSelected = normalizeText(selectedText);
   if (!normalizedSelected) return undefined;
 
-  const { normalized: normContent, map } = getNormalizedContent(content);
+  const { normalized: normContent, map } = getNormalizedContent(contentRoot, content);
 
   if (approx != null && approx >= 0 && approx + normalizedSelected.length <= normContent.length) {
     const normSlice = normContent.slice(approx, approx + normalizedSelected.length);

--- a/quotevote-frontend/src/lib/utils/parserDom.ts
+++ b/quotevote-frontend/src/lib/utils/parserDom.ts
@@ -34,6 +34,18 @@ function buildNormalizedIndexMap(content: string): NormalizedContent {
   return { normalized, map };
 }
 
+let normalizedContentCache: { content: string; value: NormalizedContent } | null = null;
+
+function getNormalizedContent(content: string): NormalizedContent {
+  if (normalizedContentCache?.content === content) {
+    return normalizedContentCache.value;
+  }
+
+  const value = buildNormalizedIndexMap(content);
+  normalizedContentCache = { content, value };
+  return value;
+}
+
 function normalizeText(text: string): string {
   return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
@@ -109,7 +121,7 @@ export function parseDomSelection(args: DomParserArgs): ParsedSelection | undefi
   const normalizedSelected = normalizeText(selectedText);
   if (!normalizedSelected) return undefined;
 
-  const { normalized: normContent, map } = buildNormalizedIndexMap(content);
+  const { normalized: normContent, map } = getNormalizedContent(content);
 
   if (approx != null && approx >= 0 && approx + normalizedSelected.length <= normContent.length) {
     const normSlice = normContent.slice(approx, approx + normalizedSelected.length);

--- a/quotevote-frontend/src/lib/utils/parserDom.ts
+++ b/quotevote-frontend/src/lib/utils/parserDom.ts
@@ -1,4 +1,4 @@
-import type { ParsedSelection } from "@/types/store"
+import type { ParsedSelection } from "@/types/store";
 
 /**
  * DOM-aware parser for VotingBoard (issue #484).
@@ -13,80 +13,117 @@ import type { ParsedSelection } from "@/types/store"
  */
 
 export interface DomParserArgs {
-  content: string
-  selectedText: string
-  range: Range
-  contentRoot: HTMLElement
+  content: string;
+  selectedText: string;
+  range: Range;
+  contentRoot: HTMLElement;
 }
 
-function buildNormalizedIndexMap(content: string): { normalized: string; map: number[] } {
-  const map: number[] = []
-  let normalized = ""
+interface NormalizedContent {
+  normalized: string;
+  /** map[normalizedIndex] = originalIndex for every normalized char */
+  map: number[];
+}
+
+function buildNormalizedIndexMap(content: string): NormalizedContent {
+  const map: number[] = [];
+  let normalized = "";
   for (let i = 0; i < content.length; i++) {
-    const ch = content[i]
+    const ch = content[i];
     if (ch === "\r") {
       // CRLF → single LF, lone CR → LF
       if (i + 1 < content.length && content[i + 1] === "\n") {
-        normalized += "\n"
-        map.push(i)
-        i++ // skip the '\n' part of CRLF, but map normalized char to start of CRLF
+        normalized += "\n";
+        map.push(i);
+        i++; // skip the '\n' half of the CRLF pair
       } else {
-        normalized += "\n"
-        map.push(i)
+        normalized += "\n";
+        map.push(i);
       }
     } else {
-      normalized += ch
-      map.push(i)
+      normalized += ch;
+      map.push(i);
     }
   }
-  return { normalized, map }
+  return { normalized, map };
+}
+
+function normalizeText(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
 function enumerateOccurrences(haystack: string, needle: string): number[] {
-  const out: number[] = []
-  if (!needle) return out
-  let from = 0
+  const out: number[] = [];
+  if (!needle) return out;
+  let from = 0;
   while (true) {
-    const idx = haystack.indexOf(needle, from)
-    if (idx === -1) break
-    out.push(idx)
-    from = idx + 1
+    const idx = haystack.indexOf(needle, from);
+    if (idx === -1) break;
+    out.push(idx);
+    from = idx + 1;
   }
-  return out
+  return out;
+}
+
+/**
+ * Convert a normalized-space [start, end) range back to original-content
+ * offsets, advancing over CRLF pairs as a single normalized char.
+ * This is the only end-point derivation — no length arithmetic in original
+ * space, so a selection can never end midway through a CRLF (P2 #2).
+ */
+function normalizedRangeToOriginal(
+  content: string,
+  map: number[],
+  normStart: number,
+  normLength: number
+): { start: number; end: number } | null {
+  if (normStart < 0 || normStart >= map.length) return null;
+  const start = map[normStart];
+  let n = 0;
+  let o = start;
+  while (n < normLength && o < content.length) {
+    if (content[o] === "\r" && o + 1 < content.length && content[o + 1] === "\n") {
+      o += 2;
+    } else {
+      o += 1;
+    }
+    n += 1;
+  }
+  if (n < normLength) return null; // ran off the end of content
+  return { start, end: o };
 }
 
 /**
  * Validate range belongs to contentRoot and is non-collapsed with geometry.
  */
 export function isValidRangeForRoot(range: Range, contentRoot: HTMLElement): boolean {
-  if (!range || range.collapsed) return false
+  if (!range || range.collapsed) return false;
   if (!contentRoot.contains(range.startContainer) || !contentRoot.contains(range.endContainer)) {
-    return false
+    return false;
   }
-  // Reverse range (end before start) collapses or produces negative geometry elsewhere;
-  // DOM Range is always normalized, but guard against zero-area selections.
   try {
-    const rect = range.getBoundingClientRect()
-    if (rect.width <= 0 || rect.height <= 0) return false
+    const rect = range.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return false;
   } catch {
-    return false
+    return false;
   }
-  return true
+  return true;
 }
 
 /**
- * Derive approximate start offset from DOM: length of text from contentRoot start to range.start.
+ * Derive approximate start offset from DOM: length of text from contentRoot
+ * start to range.start. This is a *normalized* offset (DOM text has no CRLF).
  */
 export function domApproximateStartOffset(range: Range, contentRoot: HTMLElement): number | null {
   try {
-    const prefix = document.createRange()
-    prefix.selectNodeContents(contentRoot)
-    prefix.setEnd(range.startContainer, range.startOffset)
-    const text = prefix.toString()
-    prefix.detach?.()
-    return text.length
+    const prefix = document.createRange();
+    prefix.selectNodeContents(contentRoot);
+    prefix.setEnd(range.startContainer, range.startOffset);
+    const text = prefix.toString();
+    prefix.detach?.();
+    return text.length;
   } catch {
-    return null
+    return null;
   }
 }
 
@@ -95,112 +132,60 @@ export function domApproximateStartOffset(range: Range, contentRoot: HTMLElement
  * Returns undefined if no defensible match exists.
  */
 export function parseDomSelection(args: DomParserArgs): ParsedSelection | undefined {
-  const { content, selectedText, range, contentRoot } = args
-  if (!selectedText) return undefined
-  if (!isValidRangeForRoot(range, contentRoot)) return undefined
+  const { content, selectedText, range, contentRoot } = args;
+  if (!selectedText) return undefined;
+  if (!isValidRangeForRoot(range, contentRoot)) return undefined;
 
-  const approx = domApproximateStartOffset(range, contentRoot)
-  const normalizedSelected = selectedText.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+  const approx = domApproximateStartOffset(range, contentRoot);
+  const normalizedSelected = normalizeText(selectedText);
+  if (!normalizedSelected) return undefined;
 
-  // Fast path: direct validation at approx
-  if (approx != null) {
-    // Try raw content first (common case: DOM text equals content slice)
-    if (approx >= 0 && approx + normalizedSelected.length <= content.length) {
-      const rawSlice = content.slice(approx, approx + normalizedSelected.length)
-      const normSlice = rawSlice.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
-      if (normSlice === normalizedSelected) {
+  // Normalize content once; all matching happens in normalized space and both
+  // endpoints map back through the index map (P2 #2 — fast path included).
+  const { normalized: normContent, map } = buildNormalizedIndexMap(content);
+
+  // Fast path: validate directly at the DOM-derived offset in normalized space
+  if (approx != null && approx >= 0 && approx + normalizedSelected.length <= normContent.length) {
+    const normSlice = normContent.slice(approx, approx + normalizedSelected.length);
+    if (normSlice === normalizedSelected) {
+      const original = normalizedRangeToOriginal(content, map, approx, normalizedSelected.length);
+      if (original) {
         return {
-          startIndex: approx,
-          endIndex: approx + selectedText.length,
-          text: selectedText,
-          points: selectedText.length,
-        }
+          startIndex: original.start,
+          endIndex: original.end,
+          text: content.slice(original.start, original.end),
+          points: original.end - original.start,
+        };
       }
     }
   }
 
-  // Normalize content for CRLF differences, keep map to original offsets
-  const { normalized: normContent, map } = buildNormalizedIndexMap(content)
+  // Enumerate every exact occurrence in normalized space
+  const occurrences = enumerateOccurrences(normContent, normalizedSelected);
+  if (occurrences.length === 0) return undefined;
 
-  // Enumerate every occurrence in normalized space
-  const occurrences = enumerateOccurrences(normContent, normalizedSelected)
-  if (occurrences.length === 0) return undefined
-
-  // If single occurrence, map back via index map
-  if (occurrences.length === 1) {
-    const normStart = occurrences[0]
-    const origStart = map[normStart]
-    // Map normalized length back to original length (CRLF counts as 2)
-    // For normalized length L, original length is determined by scanning.
-    let origEnd: number
-    if (normStart + normalizedSelected.length < map.length) {
-      // Next normalized char maps to that original index
-      // Original end is start of next char after the selection
-      const nextOrig = map[normStart + normalizedSelected.length]
-      // Handle case where selection ends with CRLF-expanded char: we need to include full CRLF
-      // Heuristic: if normContent slice maps back via prefix length counting CRLFs, compute via scanning.
-      // Simpler: find original end by advancing over original content counting normalized chars.
-      let n = 0
-      let o = origStart
-      while (n < normalizedSelected.length && o < content.length) {
-        if (content[o] === "\r" && o + 1 < content.length && content[o + 1] === "\n") {
-          o += 2
-        } else {
-          o += 1
-        }
-        n += 1
-      }
-      origEnd = o
-      // If we computed via map next, prefer that when it covers CRLFs correctly; fallback to scan
-      if (nextOrig !== undefined && nextOrig <= origEnd) {
-        // Keep scanned origEnd as ground truth
-      }
-    } else {
-      // Selection reaches end of content
-      origEnd = content.length
-    }
-    return {
-      startIndex: origStart,
-      endIndex: origEnd,
-      text: content.slice(origStart, origEnd),
-      points: origEnd - origStart,
-    }
-  }
-
-  // Multiple occurrences: pick nearest to approx
-  const target = approx ?? 0
-  // Convert approx (DOM prefix length, which is normalized) to normalized-content offset
-  // approx already equals normalized prefix length, so compare directly in normalized space
-  let best = occurrences[0]
-  let bestDist = Math.abs(best - target)
+  // Pick the occurrence nearest the DOM-derived approximate offset
+  const target = approx ?? 0;
+  let best = occurrences[0];
+  let bestDist = Math.abs(best - target);
   for (let i = 1; i < occurrences.length; i++) {
-    const dist = Math.abs(occurrences[i] - target)
+    const dist = Math.abs(occurrences[i] - target);
     if (dist < bestDist) {
-      bestDist = dist
-      best = occurrences[i]
+      bestDist = dist;
+      best = occurrences[i];
     }
   }
-  const origStart = map[best]
-  // Compute original end via scan (handles CRLF)
-  let n = 0
-  let o = origStart
-  while (n < normalizedSelected.length && o < content.length) {
-    if (content[o] === "\r" && o + 1 < content.length && content[o + 1] === "\n") {
-      o += 2
-    } else {
-      o += 1
-    }
-    n += 1
-  }
-  const origEnd = o
-  // Final verification in normalized space already passed; also verify raw slice normalizes correctly
-  const rawSlice = content.slice(origStart, origEnd)
-  const normSlice = rawSlice.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
-  if (normSlice !== normalizedSelected) return undefined
+
+  const original = normalizedRangeToOriginal(content, map, best, normalizedSelected.length);
+  if (!original) return undefined;
+
+  // Final verification: raw slice must normalize back to the selection
+  const rawSlice = content.slice(original.start, original.end);
+  if (normalizeText(rawSlice) !== normalizedSelected) return undefined;
   return {
-    startIndex: origStart,
-    endIndex: origEnd,
-    text: content.slice(origStart, origEnd),
-    points: origEnd - origStart,
-  }
+    startIndex: original.start,
+    endIndex: original.end,
+    text: rawSlice,
+    points: original.end - original.start,
+  };
 }

--- a/quotevote-frontend/src/types/voting.ts
+++ b/quotevote-frontend/src/types/voting.ts
@@ -95,6 +95,11 @@ export interface VotingPopupProps {
 }
 
 /**
+ * Explicit delayed-mobile selection state machine (issue #484).
+ */
+export type SelectionPhase = "idle" | "native" | "toolbar"
+
+/**
  * VotingBoard component props
  */
 export interface VotingBoardProps {
@@ -106,6 +111,11 @@ export interface VotingBoardProps {
    * Handler function called when text is selected
    */
   onSelect?: SelectionHandler
+  /**
+   * Handler called when selection is dismissed (background tap, reset, mode change).
+   * Parent should clear its selectedText to empty indices/text.
+   */
+  onDeselect?: () => void
   /**
    * Whether to show highlights for votes/comments
    */
@@ -141,7 +151,8 @@ export interface VotingBoardProps {
 }
 
 /**
- * SelectionPopover component props
+ * SelectionPopover component props — pure portal/positioning (issue #484).
+ * No selection polling, no onSelect/onDeselect. Owner (VotingBoard) resolves the anchor.
  */
 export interface SelectionPopoverProps {
   /**
@@ -153,13 +164,14 @@ export interface SelectionPopoverProps {
    */
   topOffset?: number
   /**
-   * Handler function called when text is selected
+   * Resolve the current anchor rectangle for positioning.
+   * Desktop: live browser range rect; Mobile toolbar: retained mark rect or cached native rect.
    */
-  onSelect: (selection: Selection) => void
+  resolveAnchorRect: () => DOMRect | null
   /**
-   * Handler function called when selection is cleared
+   * Ref to the popover element (owned by VotingBoard)
    */
-  onDeselect: () => void
+  popoverRef: React.RefObject<HTMLDivElement | null>
   /**
    * Additional style props
    */

--- a/quotevote-frontend/src/types/voting.ts
+++ b/quotevote-frontend/src/types/voting.ts
@@ -3,58 +3,58 @@
  * Types for voting components and vote-related data structures
  */
 
-import type { PostVote } from './post'
-import type { ParsedSelection } from './store'
+import type { PostVote } from "./post";
+import type { ParsedSelection } from "./store";
 
 /**
  * Vote type (upvote or downvote)
  */
-export type VoteType = 'up' | 'down'
+export type VoteType = "up" | "down";
 
 /**
  * Vote option tags
  */
-export type VoteOption = '#true' | '#agree' | '#like' | '#false' | '#disagree' | '#dislike'
+export type VoteOption = "#true" | "#agree" | "#like" | "#false" | "#disagree" | "#dislike";
 
 /**
  * Voted by entry structure
  */
 export interface VotedByEntry {
-  userId: string
-  type: VoteType
-  _id?: string
-  [key: string]: unknown
+  userId: string;
+  type: VoteType;
+  _id?: string;
+  [key: string]: unknown;
 }
 
 /**
  * Selected text structure from parser
  */
 export interface SelectedText extends ParsedSelection {
-  startIndex: number
-  endIndex: number
-  text: string
-  points?: number
+  startIndex: number;
+  endIndex: number;
+  text: string;
+  points?: number;
 }
 
 /**
  * Vote handler function type
  */
-export type VoteHandler = (vote: { type: VoteType; tags: VoteOption }) => void
+export type VoteHandler = (vote: { type: VoteType; tags: VoteOption }) => void;
 
 /**
  * Comment handler function type
  */
-export type CommentHandler = (comment: string, withQuote: boolean) => void | Promise<void>
+export type CommentHandler = (comment: string, withQuote: boolean) => void | Promise<void>;
 
 /**
  * Quote handler function type
  */
-export type QuoteHandler = () => void
+export type QuoteHandler = () => void;
 
 /**
  * Selection handler function type
  */
-export type SelectionHandler = (selection: SelectedText) => void
+export type SelectionHandler = (selection: SelectedText) => void;
 
 /**
  * VotingPopup component props
@@ -63,41 +63,41 @@ export interface VotingPopupProps {
   /**
    * Array of users who have voted
    */
-  votedBy: VotedByEntry[]
+  votedBy: VotedByEntry[];
   /**
    * Handler function called when a vote is submitted
    */
-  onVote: VoteHandler
+  onVote: VoteHandler;
   /**
    * Handler function called when a comment is added
    */
-  onAddComment: CommentHandler
+  onAddComment: CommentHandler;
   /**
    * Handler function called when a quote is added
    */
-  onAddQuote: QuoteHandler
+  onAddQuote: QuoteHandler;
   /**
    * Currently selected text
    */
-  selectedText: SelectedText
+  selectedText: SelectedText;
   /**
    * Whether the current user has already voted
    */
-  hasVoted: boolean
+  hasVoted: boolean;
   /**
    * Type of vote the current user has cast (if any)
    */
-  userVoteType?: VoteType | null
+  userVoteType?: VoteType | null;
   /**
    * Handler function called when a vote is retracted/deleted
    */
-  onDeleteVote?: () => void
+  onDeleteVote?: () => void;
 }
 
 /**
  * Explicit delayed-mobile selection state machine (issue #484).
  */
-export type SelectionPhase = "idle" | "native" | "toolbar"
+export type SelectionPhase = "idle" | "native" | "toolbar";
 
 /**
  * VotingBoard component props
@@ -106,48 +106,48 @@ export interface VotingBoardProps {
   /**
    * Top offset for positioning the popover
    */
-  topOffset?: number
+  topOffset?: number;
   /**
    * Handler function called when text is selected
    */
-  onSelect?: SelectionHandler
+  onSelect?: SelectionHandler;
   /**
    * Handler called when selection is dismissed (background tap, reset, mode change).
    * Parent should clear its selectedText to empty indices/text.
    */
-  onDeselect?: () => void
+  onDeselect?: () => void;
   /**
    * Whether to show highlights for votes/comments
    */
-  highlights?: boolean
+  highlights?: boolean;
   /**
    * The content text to display and make selectable
    */
-  content: string
+  content: string;
   /**
    * Render prop function that receives selection data
    */
-  children?: (selection: SelectedText) => React.ReactNode
+  children?: (selection: SelectedText) => React.ReactNode;
   /**
    * Array of votes to highlight
    */
-  votes?: PostVote[]
+  votes?: PostVote[];
   /**
    * Additional style props
    */
-  style?: React.CSSProperties
+  style?: React.CSSProperties;
   /**
    * Focused comment data (optional, for highlighting specific comment ranges)
    */
   focusedComment?: {
-    startWordIndex: number
-    endWordIndex: number
-    actionId?: string
-  } | null
+    startWordIndex: number;
+    endWordIndex: number;
+    actionId?: string;
+  } | null;
   /**
    * Called when the highlighted (linked) passage is tapped.
    */
-  onHighlightClick?: () => void
+  onHighlightClick?: () => void;
 }
 
 /**
@@ -158,27 +158,26 @@ export interface SelectionPopoverProps {
   /**
    * Whether to show the popover
    */
-  showPopover: boolean
+  showPopover: boolean;
   /**
    * Top offset for positioning
    */
-  topOffset?: number
+  topOffset?: number;
   /**
    * Resolve the current anchor rectangle for positioning.
    * Desktop: live browser range rect; Mobile toolbar: retained mark rect or cached native rect.
    */
-  resolveAnchorRect: () => DOMRect | null
+  resolveAnchorRect: () => DOMRect | null;
   /**
    * Ref to the popover element (owned by VotingBoard)
    */
-  popoverRef: React.RefObject<HTMLDivElement | null>
+  popoverRef: React.RefObject<HTMLDivElement | null>;
   /**
    * Additional style props
    */
-  style?: React.CSSProperties
+  style?: React.CSSProperties;
   /**
    * Child components to render inside the popover
    */
-  children: React.ReactNode
+  children: React.ReactNode;
 }
-


### PR DESCRIPTION
## Summary

- delay the Quote.Vote voting toolbar on coarse touch devices while native selection controls are active
- retain the exact selected passage as a visual highlight before clearing the native selection
- consume transition and dismissal gestures without activating UI underneath
- preserve immediate desktop selection behavior
- resolve repeated passages and newline-normalized DOM ranges safely
- add state-machine, parser, positioning, and mobile workflow regression coverage

## Validation

- [x] 55 focused Jest tests
- [x] TypeScript type-check
- [x] ESLint on modified files
- [x] Prettier on modified files
- [x] Playwright specifications collect successfully
- [ ] Physical iOS Safari verification
- [x] Physical Android Chrome verification

Closes #484